### PR TITLE
feat: introduce customizable winhighlight for autocomplete and documentation windows

### DIFF
--- a/lua/blink/cmp/config.lua
+++ b/lua/blink/cmp/config.lua
@@ -82,6 +82,7 @@
 --- @field order "top_down" | "bottom_up"
 --- @field direction_priority ("n" | "s")[]
 --- @field preselect boolean
+--- @field winhighlight string | nil
 
 --- @class blink.cmp.DocumentationDirectionPriorityConfig
 --- @field autocomplete_north ("n" | "s" | "e" | "w")[]
@@ -98,6 +99,7 @@
 --- @field auto_show boolean
 --- @field auto_show_delay_ms number Delay before showing the documentation window
 --- @field update_delay_ms number Delay before updating the documentation window
+--- @field winhighlight string | nil
 
 --- @class blink.cmp.SignatureHelpConfig
 --- @field min_width number

--- a/lua/blink/cmp/windows/autocomplete.lua
+++ b/lua/blink/cmp/windows/autocomplete.lua
@@ -1,5 +1,6 @@
 -- todo: track cursor position
 local config = require('blink.cmp.config')
+local autocmp_config = config.windows.autocomplete
 local autocomplete = {
   items = {},
   context = nil,
@@ -12,12 +13,12 @@ local autocomplete = {
 
 function autocomplete.setup()
   autocomplete.win = require('blink.cmp.windows.lib').new({
-    min_width = config.min_width,
-    max_width = config.max_width,
-    max_height = config.max_height,
-    border = config.border,
+    min_width = autocmp_config.min_width,
+    max_width = autocmp_config.max_width,
+    max_height = autocmp_config.max_height,
+    border = autocmp_config.border,
     cursorline = true,
-    winhighlight = 'Normal:Pmenu,FloatBorder:Pmenu,CursorLine:PmenuSel,Search:None',
+    winhighlight = autocmp_config.winhighlight or 'Normal:Pmenu,FloatBorder:Pmenu,CursorLine:PmenuSel,Search:None',
     scrolloff = 2,
   })
 

--- a/lua/blink/cmp/windows/documentation.lua
+++ b/lua/blink/cmp/windows/documentation.lua
@@ -10,6 +10,7 @@ function docs.setup()
     max_width = config.max_width,
     max_height = config.max_height,
     border = config.border,
+    winhighlight = config.winhighlight or 'Normal:Normal,FloatBorder:FloatBorder,CursorLine:Visual,Search:None',
     wrap = true,
     filetype = 'markdown',
   })


### PR DESCRIPTION
- Added `winhighlight` support to enable user-defined highlight customization for both autocomplete and documentation windows.
- Enhances user control over window appearance for a more personalized interface.