### PR TITLE
fix(config): make blink lua config fields optional

### DIFF
--- a/lua/blink/cmp/config.lua
+++ b/lua/blink/cmp/config.lua
@@ -1,137 +1,137 @@
 --- @class blink.cmp.KeymapConfig
---- @field show string | string[]
---- @field accept string | string[]
---- @field select_prev string | string[]
---- @field select_next string | string[]
---- @field show_documentation string | string[]
---- @field hide_documentation string | string[]
---- @field scroll_documentation_up string | string[]
---- @field scroll_documentation_down string | string[]
---- @field snippet_forward string | string[]
---- @field snippet_backward string | string[]
+--- @field show? string | string[]
+--- @field accept? string | string[]
+--- @field select_prev? string | string[]
+--- @field select_next? string | string[]
+--- @field show_documentation? string | string[]
+--- @field hide_documentation? string | string[]
+--- @field scroll_documentation_up? string | string[]
+--- @field scroll_documentation_down? string | string[]
+--- @field snippet_forward? string | string[]
+--- @field snippet_backward? string | string[]
 
 --- @class blink.cmp.AcceptConfig
---- @field create_undo_point boolean Create an undo point when accepting a completion item
---- @field auto_brackets blink.cmp.AutoBracketsConfig
+--- @field create_undo_point? boolean Create an undo point when accepting a completion item
+--- @field auto_brackets? blink.cmp.AutoBracketsConfig
 
 --- @class blink.cmp.AutoBracketsConfig
---- @field enabled boolean
---- @field default_brackets string[]
---- @field override_brackets_for_filetypes table<string, string[] | function(item: blink.cmp.CompletionItem): string[]>
---- @field force_allow_filetypes string[] Overrides the default blocked filetypes
---- @field blocked_filetypes string[]
---- @field kind_resolution blink.cmp.AutoBracketResolutionConfig Synchronously use the kind of the item to determine if brackets should be added
---- @field semantic_token_resolution blink.cmp.AutoBracketSemanticTokenResolutionConfig Asynchronously use semantic token to determine if brackets should be added
+--- @field enabled? boolean
+--- @field default_brackets? string[]
+--- @field override_brackets_for_filetypes? table<string, string[] | function(item: blink.cmp.CompletionItem): string[]>
+--- @field force_allow_filetypes? string[] Overrides the default blocked filetypes
+--- @field blocked_filetypes? string[]
+--- @field kind_resolution? blink.cmp.AutoBracketResolutionConfig Synchronously use the kind of the item to determine if brackets should be added
+--- @field semantic_token_resolution? blink.cmp.AutoBracketSemanticTokenResolutionConfig Asynchronously use semantic token to determine if brackets should be added
 
 --- @class blink.cmp.AutoBracketResolutionConfig
---- @field enabled boolean
---- @field blocked_filetypes string[]
+--- @field enabled? boolean
+--- @field blocked_filetypes? string[]
 ---
 --- @class blink.cmp.AutoBracketSemanticTokenResolutionConfig : blink.cmp.AutoBracketResolutionConfig
---- @field timeout_ms number How long to wait for semantic tokens to return before assuming no brackets should be added
+--- @field timeout_ms? number How long to wait for semantic tokens to return before assuming no brackets should be added
 
 --- @class blink.cmp.CompletionTriggerConfig
---- @field keyword_regex string
---- @field blocked_trigger_characters string[]
---- @field show_on_insert_on_trigger_character boolean When true, will show the completion window when the cursor comes after a trigger character when entering insert mode
---- @field show_on_insert_blocked_trigger_characters string[] List of additional trigger characters that won't trigger the completion window when the cursor comes after a trigger character when entering insert mode
+--- @field keyword_regex? string
+--- @field blocked_trigger_characters? string[]
+--- @field show_on_insert_on_trigger_character? boolean When true, will show the completion window when the cursor comes after a trigger character when entering insert mode
+--- @field show_on_insert_blocked_trigger_characters? string[] List of additional trigger characters that won't trigger the completion window when the cursor comes after a trigger character when entering insert mode
 ---
 --- @class blink.cmp.SignatureHelpTriggerConfig
---- @field enabled boolean
---- @field blocked_trigger_characters string[]
---- @field blocked_retrigger_characters string[]
---- @field show_on_insert_on_trigger_character boolean When true, will show the signature help window when the cursor comes after a trigger character when entering insert mode
+--- @field enabled? boolean
+--- @field blocked_trigger_characters? string[]
+--- @field blocked_retrigger_characters? string[]
+--- @field show_on_insert_on_trigger_character? boolean When true, will show the signature help window when the cursor comes after a trigger character when entering insert mode
 ---
 --- @class blink.cmp.TriggerConfig
---- @field completion blink.cmp.CompletionTriggerConfig
---- @field signature_help blink.cmp.SignatureHelpTriggerConfig
+--- @field completion? blink.cmp.CompletionTriggerConfig
+--- @field signature_help? blink.cmp.SignatureHelpTriggerConfig
 
 --- @class blink.cmp.SourceConfig
---- @field providers blink.cmp.SourceProviderConfig[][]
+--- @field providers? blink.cmp.SourceProviderConfig[][]
 ---
 --- @class blink.cmp.SourceProviderConfig
---- @field [1] string
---- @field keyword_length number | nil
---- @field score_offset number | nil
---- @field deduplicate blink.cmp.DeduplicateConfig | nil
---- @field trigger_characters string[] | nil
---- @field opts table | nil
+--- @field [1]? string
+--- @field keyword_length? number | nil
+--- @field score_offset? number | nil
+--- @field deduplicate? blink.cmp.DeduplicateConfig | nil
+--- @field trigger_characters? string[] | nil
+--- @field opts? table | nil
 ---
 --- @class blink.cmp.DeduplicateConfig
---- @field enabled boolean
---- @field priority number
+--- @field enabled? boolean
+--- @field priority? number
 
 --- @class blink.cmp.PrebuiltBinariesConfig
---- @field download boolean
---- @field forceVersion string | nil
+--- @field download? boolean
+--- @field forceVersion? string | nil
 
 --- @class blink.cmp.FuzzyConfig
---- @field use_frecency boolean
---- @field use_proximity boolean
---- @field max_items number
---- @field sorts ("label" | "kind" | "score")[]
---- @field prebuiltBinaries blink.cmp.PrebuiltBinariesConfig
+--- @field use_frecency? boolean
+--- @field use_proximity? boolean
+--- @field max_items? number
+--- @field sorts? ("label" | "kind" | "score")[]
+--- @field prebuiltBinaries? blink.cmp.PrebuiltBinariesConfig
 
 --- @class blink.cmp.WindowConfig
---- @field autocomplete blink.cmp.AutocompleteConfig
---- @field documentation blink.cmp.DocumentationConfig
---- @field signature_help blink.cmp.SignatureHelpConfig
+--- @field autocomplete? blink.cmp.AutocompleteConfig
+--- @field documentation? blink.cmp.DocumentationConfig
+--- @field signature_help? blink.cmp.SignatureHelpConfig
 
 --- @class blink.cmp.HighlightConfig
---- @field ns number
---- @field use_nvim_cmp_as_default boolean
+--- @field ns? number
+--- @field use_nvim_cmp_as_default? boolean
 
 --- @class blink.cmp.AutocompleteConfig
---- @field min_width number
---- @field max_width number
---- @field max_height number
---- @field border blink.cmp.WindowBorder
---- @field order "top_down" | "bottom_up"
---- @field direction_priority ("n" | "s")[]
---- @field preselect boolean
---- @field winhighlight string
---- @field scrolloff number
---- @field draw 'simple' | 'reversed' | function(blink.cmp.CompletionRenderContext): blink.cmp.Component[]
---- @field cycle blink.cmp.AutocompleteConfig.CycleConfig
+--- @field min_width? number
+--- @field max_width? number
+--- @field max_height? number
+--- @field border? blink.cmp.WindowBorder
+--- @field order? "top_down" | "bottom_up"
+--- @field direction_priority? ("n" | "s")[]
+--- @field preselect? boolean
+--- @field winhighlight? string
+--- @field scrolloff? number
+--- @field draw? 'simple' | 'reversed' | function(blink.cmp.CompletionRenderContext): blink.cmp.Component[]
+--- @field cycle? blink.cmp.AutocompleteConfig.CycleConfig
 
 --- @class blink.cmp.AutocompleteConfig.CycleConfig
---- @field from_bottom boolean When `true`, calling `select_next` at the *bottom* of the completion list will select the *first* completion item.
---- @field from_top boolean When `true`, calling `select_prev` at the *top* of the completion list will select the *last* completion item.
+--- @field from_bottom? boolean When `true`, calling `select_next` at the *bottom* of the completion list will select the *first* completion item.
+--- @field from_top? boolean When `true`, calling `select_prev` at the *top* of the completion list will select the *last* completion item.
 
 --- @class blink.cmp.DocumentationDirectionPriorityConfig
---- @field autocomplete_north ("n" | "s" | "e" | "w")[]
---- @field autocomplete_south ("n" | "s" | "e" | "w")[]
+--- @field autocomplete_north? ("n" | "s" | "e" | "w")[]
+--- @field autocomplete_south? ("n" | "s" | "e" | "w")[]
 ---
 --- @alias blink.cmp.WindowBorder 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'padded' | 'none' | string[]
 ---
 --- @class blink.cmp.DocumentationConfig
---- @field min_width number
---- @field max_width number
---- @field max_height number
---- @field border blink.cmp.WindowBorder
---- @field direction_priority blink.cmp.DocumentationDirectionPriorityConfig
---- @field auto_show boolean
---- @field auto_show_delay_ms number Delay before showing the documentation window
---- @field update_delay_ms number Delay before updating the documentation window
---- @field winhighlight string
+--- @field min_width? number
+--- @field max_width? number
+--- @field max_height? number
+--- @field border? blink.cmp.WindowBorder
+--- @field direction_priority? blink.cmp.DocumentationDirectionPriorityConfig
+--- @field auto_show? boolean
+--- @field auto_show_delay_ms? number Delay before showing the documentation window
+--- @field update_delay_ms? number Delay before updating the documentation window
+--- @field winhighlight? string
 
 --- @class blink.cmp.SignatureHelpConfig
---- @field min_width number
---- @field max_width number
---- @field max_height number
---- @field border blink.cmp.WindowBorder
---- @field winhighlight string
+--- @field min_width? number
+--- @field max_width? number
+--- @field max_height? number
+--- @field border? blink.cmp.WindowBorder
+--- @field winhighlight? string
 
 --- @class blink.cmp.Config
---- @field keymap blink.cmp.KeymapConfig
---- @field accept blink.cmp.AcceptConfig
---- @field trigger blink.cmp.TriggerConfig
---- @field fuzzy blink.cmp.FuzzyConfig
---- @field sources blink.cmp.SourceConfig
---- @field windows blink.cmp.WindowConfig
---- @field highlight blink.cmp.HighlightConfig
---- @field nerd_font_variant 'mono' | 'normal'
---- @field kind_icons table<string, string>
+--- @field keymap? blink.cmp.KeymapConfig
+--- @field accept? blink.cmp.AcceptConfig
+--- @field trigger? blink.cmp.TriggerConfig
+--- @field fuzzy? blink.cmp.FuzzyConfig
+--- @field sources? blink.cmp.SourceConfig
+--- @field windows? blink.cmp.WindowConfig
+--- @field highlight? blink.cmp.HighlightConfig
+--- @field nerd_font_variant? 'mono' | 'normal'
+--- @field kind_icons? table<string, string>
 
 --- @type blink.cmp.Config
 local config = {


### PR DESCRIPTION
Hello @Saghen 

First of all, congrats on the plugin! My initial impression has been great. 

This patch fixes a somewhat selfish issue of mine. I prefer to use the `config` function to run configure plugins over `opts` just for a bit more flexibility and the added benefit of completions for option names. 

However, in the current `blink.cmp.Config` class, all fields are required. This results in a bit of an unsightly warning:

![image](https://github.com/user-attachments/assets/3d7e762b-1c9b-4378-b0fa-c01989da876e)

With this fix, the options aren't required anymore (which reflects reality) and the warning is no longer present when configuring via the `config` option in lazy.

Let me know if you have any questions!