### PR TITLE
fix: use correct prev/next keymap for k and j

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ For LazyVim/distro users, you can disable nvim-cmp via:
     show = '<C-space>',
     hide = '<C-e>',
     accept = '<Tab>',
-    select_prev = { '<Up>', '<C-j>' },
-    select_next = { '<Down>', '<C-k>' },
+    select_prev = { '<Up>', '<C-k>' },
+    select_next = { '<Down>', '<C-j>' },
 
     show_documentation = {},
     hide_documentation = {},

--- a/lua/blink/cmp/config.lua
+++ b/lua/blink/cmp/config.lua
@@ -131,8 +131,8 @@ local config = {
     show = '<C-space>',
     hide = '<C-e>',
     accept = '<Tab>',
-    select_prev = { '<Up>', '<C-j>' },
-    select_next = { '<Down>', '<C-k>' },
+    select_prev = { '<Up>', '<C-k>' },
+    select_next = { '<Down>', '<C-j>' },
 
     show_documentation = {},
     hide_documentation = {},


### PR DESCRIPTION
This PR fixes the incorrect default keymap for `select_next` and `select_prev`.