### PR TITLE
Add rust-toolchain.toml to require nightly.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
This allows a `cargo build --release` and `rust-analyzer` to work without extra flags.