### PR TITLE
Add basic event trigger API

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@
     -- set to 'mono' for 'Nerd Font Mono' or 'normal' for 'Nerd Font'
     -- adjusts spacing to ensure icons are aligned
     nerd_font_variant = 'normal',
-
+    
     -- experimental auto-brackets support
-    -- accept = { auto_brackets = { enabled = true } },
-
+    -- accept = { auto_brackets = { enabled = true } }
+    
     -- experimental signature help support
-    -- trigger = { signature_help = { enabled = true } },
+    -- trigger = { signature_help = { enabled = true } }
   }
 }
 ```
@@ -197,7 +197,7 @@ For LazyVim/distro users, you can disable nvim-cmp via:
     },
     -- FOR REF: full example
     providers = {
-      {
+      { 
         -- all of these properties work on every source
         {
             'blink.cmp.sources.lsp',
@@ -205,10 +205,10 @@ For LazyVim/distro users, you can disable nvim-cmp via:
             score_offset = 0,
             trigger_characters = { 'f', 'o', 'o' },
             opts = {},
-        },
+        }, 
         -- the follow two sources have additional options
-        {
-          'blink.cmp.sources.path',
+        { 
+          'blink.cmp.sources.path', 
           opts = {
             trailing_slash = false,
             label_trailing_slash = true,

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@
     -- set to 'mono' for 'Nerd Font Mono' or 'normal' for 'Nerd Font'
     -- adjusts spacing to ensure icons are aligned
     nerd_font_variant = 'normal',
-    
+
     -- experimental auto-brackets support
-    -- accept = { auto_brackets = { enabled = true } }
-    
+    -- accept = { auto_brackets = { enabled = true } },
+
     -- experimental signature help support
-    -- trigger = { signature_help = { enabled = true } }
+    -- trigger = { signature_help = { enabled = true } },
   }
 }
 ```
@@ -197,7 +197,7 @@ For LazyVim/distro users, you can disable nvim-cmp via:
     },
     -- FOR REF: full example
     providers = {
-      { 
+      {
         -- all of these properties work on every source
         {
             'blink.cmp.sources.lsp',
@@ -205,10 +205,10 @@ For LazyVim/distro users, you can disable nvim-cmp via:
             score_offset = 0,
             trigger_characters = { 'f', 'o', 'o' },
             opts = {},
-        }, 
+        },
         -- the follow two sources have additional options
-        { 
-          'blink.cmp.sources.path', 
+        {
+          'blink.cmp.sources.path',
           opts = {
             trailing_slash = false,
             label_trailing_slash = true,
@@ -348,9 +348,9 @@ The plugin use a 4 stage pipeline: trigger -> sources -> fuzzy -> render
 
 &nbsp;&nbsp;&nbsp;&nbsp;**Filtering:** The fuzzy matching uses smith-waterman, same as FZF, but implemented in SIMD for ~6x the performance of FZF (todo: add benchmarks). Due to the SIMD's performance, the prefiltering phase on FZF was dropped to allow for typos. Similar to fzy/fzf, additional points are given to prefix matches, characters with capitals (to promote camelCase/PascalCase first char matching) and matches after delimiters (to promote snake_case first char matching)
 
-&nbsp;&nbsp;&nbsp;&nbsp;**Sorting:** Combines fuzzy matching score with frecency and proximity bonus. Each completion item may also include a `score_offset` which will be added to this score to demote certain sources. The `snippets` source takes advantage of this to avoid taking presedence over the LSP source. The paramaters here still need to be tuned, so please let me know if you find some magical parameters!
+&nbsp;&nbsp;&nbsp;&nbsp;**Sorting:** Combines fuzzy matching score with frecency and proximity bonus. Each completion item may also include a `score_offset` which will be added to this score to demote certain sources. The `snippets` source takes advantage of this to avoid taking precedence over the LSP source. The parameters here still need to be tuned, so please let me know if you find some magical parameters!
 
-**Windows:** Responsible for placing the autocomplete, documentation and function parameters windows. All of the rendering can be overriden following a syntax similar to incline.nvim. It uses the neovim window decoration provider to provide next to no overhead from highlighting.
+**Windows:** Responsible for placing the autocomplete, documentation and function parameters windows. All of the rendering can be overridden following a syntax similar to incline.nvim. It uses the neovim window decoration provider to provide next to no overhead from highlighting.
 
 ## Compared to nvim-cmp
 

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -129,6 +129,12 @@ cmp.hide = function()
   return true
 end
 
+--- @param callback fun(context: blink.cmp.Context)
+cmp.on_show = function(callback) cmp.trigger.listen_on_show(callback) end
+
+--- @param callback fun()
+cmp.on_hide = function(callback) cmp.trigger.listen_on_hide(callback) end
+
 cmp.accept = function()
   local item = cmp.windows.autocomplete.get_selected_item()
   if item == nil then return end

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -130,10 +130,10 @@ cmp.hide = function()
 end
 
 --- @param callback fun(context: blink.cmp.Context)
-cmp.on_show = function(callback) cmp.trigger.listen_on_show(callback) end
+cmp.on_open = function(callback) cmp.windows.autocomplete.listen_on_open(callback) end
 
 --- @param callback fun()
-cmp.on_hide = function(callback) cmp.trigger.listen_on_hide(callback) end
+cmp.on_close = function(callback) cmp.windows.autocomplete.listen_on_close(callback) end
 
 cmp.accept = function()
   local item = cmp.windows.autocomplete.get_selected_item()

--- a/lua/blink/cmp/sources/buffer.lua
+++ b/lua/blink/cmp/sources/buffer.lua
@@ -4,6 +4,7 @@
 
 local uv = vim.uv
 
+---@return string
 local function get_buf_text()
   local bufnr = vim.api.nvim_get_current_buf()
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
@@ -45,6 +46,8 @@ local function words_to_items(words)
   return items
 end
 
+--- @param buf_text string
+--- @param callback fun(items: blink.cmp.CompletionItem[])
 local function run_sync(buf_text, callback) callback(words_to_items(require('blink.cmp.fuzzy').get_words(buf_text))) end
 
 local function run_async(buf_text, callback)

--- a/lua/blink/cmp/trigger/completion.lua
+++ b/lua/blink/cmp/trigger/completion.lua
@@ -11,10 +11,10 @@ local trigger = {
   --- @type blink.cmp.Context | nil
   context = nil,
   event_targets = {
-    --- @type fun(context: blink.cmp.Context)
-    on_show = function() end,
-    --- @type fun()
-    on_hide = function() end,
+    --- @type table<fun(context: blink.cmp.Context)>
+    on_show = {},
+    --- @type table<fun()>
+    on_hide = {},
   },
 }
 
@@ -144,21 +144,22 @@ function trigger.show(opts)
     },
   }
 
-  trigger.event_targets.on_show(trigger.context)
+  vim.iter(trigger.event_targets.on_show):each(function(callback) callback(trigger.context) end)
 end
 
 --- @param callback fun(context: blink.cmp.Context)
-function trigger.listen_on_show(callback) trigger.event_targets.on_show = callback end
+function trigger.listen_on_show(callback) table.insert(trigger.event_targets.on_show, callback) end
 
 function trigger.hide()
   if not trigger.context then return end
 
   trigger.context = nil
-  trigger.event_targets.on_hide()
+
+  vim.iter(trigger.event_targets.on_hide):each(function(callback) callback() end)
 end
 
 --- @param callback fun()
-function trigger.listen_on_hide(callback) trigger.event_targets.on_hide = callback end
+function trigger.listen_on_hide(callback) table.insert(trigger.event_targets.on_hide, callback) end
 
 --- @param cursor number[]
 --- @return boolean

--- a/lua/blink/cmp/trigger/completion.lua
+++ b/lua/blink/cmp/trigger/completion.lua
@@ -11,10 +11,10 @@ local trigger = {
   --- @type blink.cmp.Context | nil
   context = nil,
   event_targets = {
-    --- @type table<fun(context: blink.cmp.Context)>
-    on_show = {},
-    --- @type table<fun()>
-    on_hide = {},
+    --- @type fun(context: blink.cmp.Context)
+    on_show = function() end,
+    --- @type fun()
+    on_hide = function() end,
   },
 }
 
@@ -144,22 +144,22 @@ function trigger.show(opts)
     },
   }
 
-  vim.iter(trigger.event_targets.on_show):each(function(callback) callback(trigger.context) end)
+  trigger.event_targets.on_show(trigger.context)
 end
 
 --- @param callback fun(context: blink.cmp.Context)
-function trigger.listen_on_show(callback) table.insert(trigger.event_targets.on_show, callback) end
+function trigger.listen_on_show(callback) trigger.event_targets.on_show = callback end
 
 function trigger.hide()
   if not trigger.context then return end
 
   trigger.context = nil
 
-  vim.iter(trigger.event_targets.on_hide):each(function(callback) callback() end)
+  trigger.event_targets.on_hide()
 end
 
 --- @param callback fun()
-function trigger.listen_on_hide(callback) table.insert(trigger.event_targets.on_hide, callback) end
+function trigger.listen_on_hide(callback) trigger.event_targets.on_hide = callback end
 
 --- @param cursor number[]
 --- @return boolean

--- a/lua/blink/cmp/trigger/signature.lua
+++ b/lua/blink/cmp/trigger/signature.lua
@@ -14,10 +14,10 @@ local trigger = {
   --- @type blink.cmp.SignatureHelpContext | nil
   context = nil,
   event_targets = {
-    --- @type table<fun(context: blink.cmp.SignatureHelpContext)>
-    on_show = {},
-    --- @type table<fun()>
-    on_hide = {},
+    --- @type fun(context: blink.cmp.SignatureHelpContext)
+    on_show = function() end,
+    --- @type fun()
+    on_hide = function() end,
   },
 }
 
@@ -112,7 +112,7 @@ function trigger.show(opts)
     active_signature_help = trigger.context and trigger.context.active_signature_help or nil,
   }
 
-  vim.iter(trigger.event_targets.on_show):each(function(callback) callback(trigger.context) end)
+  trigger.event_targets.on_show(trigger.context)
 end
 
 function trigger.listen_on_show(callback) trigger.event_targets.on_show = callback end
@@ -121,10 +121,10 @@ function trigger.hide()
   if not trigger.context then return end
 
   trigger.context = nil
-  vim.iter(trigger.event_targets.on_hide):each(function(callback) callback() end)
+  trigger.event_targets.on_hide()
 end
 
-function trigger.listen_on_hide(callback) table.insert(trigger.event_targets.on_hide, callback) end
+function trigger.listen_on_hide(callback) trigger.event_targets.on_hide = callback end
 
 function trigger.set_active_signature_help(signature_help)
   if not trigger.context then return end

--- a/lua/blink/cmp/trigger/signature.lua
+++ b/lua/blink/cmp/trigger/signature.lua
@@ -14,10 +14,10 @@ local trigger = {
   --- @type blink.cmp.SignatureHelpContext | nil
   context = nil,
   event_targets = {
-    --- @type fun(context: blink.cmp.SignatureHelpContext)
-    on_show = function() end,
-    --- @type fun()
-    on_hide = function() end,
+    --- @type table<fun(context: blink.cmp.SignatureHelpContext)>
+    on_show = {},
+    --- @type table<fun()>
+    on_hide = {},
   },
 }
 
@@ -112,7 +112,7 @@ function trigger.show(opts)
     active_signature_help = trigger.context and trigger.context.active_signature_help or nil,
   }
 
-  trigger.event_targets.on_show(trigger.context)
+  vim.iter(trigger.event_targets.on_show):each(function(callback) callback(trigger.context) end)
 end
 
 function trigger.listen_on_show(callback) trigger.event_targets.on_show = callback end
@@ -121,10 +121,10 @@ function trigger.hide()
   if not trigger.context then return end
 
   trigger.context = nil
-  trigger.event_targets.on_hide()
+  vim.iter(trigger.event_targets.on_hide):each(function(callback) callback() end)
 end
 
-function trigger.listen_on_hide(callback) trigger.event_targets.on_hide = callback end
+function trigger.listen_on_hide(callback) table.insert(trigger.event_targets.on_hide, callback) end
 
 function trigger.set_active_signature_help(signature_help)
   if not trigger.context then return end


### PR DESCRIPTION
This allows for `copilot.lua` (and others I'm sure) ghost text to be hidden when the completion menu is shown:

```lua
            -- Remove Copilot ghost text when the cmp menu is opened.
            ev.on_load("blink.cmp", function()
                vim.schedule(function()
                    local cmp = require("blink.cmp")

                    cmp.on_show(function()
                        require("copilot.suggestion").dismiss()
                        vim.api.nvim_buf_set_var(0, "copilot_suggestion_hidden", true)
                    end)

                    cmp.on_hide(function()
                        vim.api.nvim_buf_set_var(0, "copilot_suggestion_hidden", false)
                    end)
                end)
            end)
```

I'm not sure of the best place to document this at the moment.

Fix some typos and syntax issue in the README as well.