### PR TITLE
feat(opt): option to use mini.icons instead of default ones

### DIFF
--- a/lua/blink/cmp/config.lua
+++ b/lua/blink/cmp/config.lua
@@ -9,6 +9,7 @@
 --- @field scroll_documentation_down string | string[]
 --- @field snippet_forward string | string[]
 --- @field snippet_backward string | string[]
+--- @field use_mini_icons boolean Tries to use mini.icons instead of default
 
 --- @class blink.cmp.AcceptConfig
 --- @field create_undo_point boolean Create an undo point when accepting a completion item
@@ -132,6 +133,7 @@
 local config = {
   -- for keymap, all values may be string | string[]
   -- use an empty table to disable a keymap
+  use_mini_icons = false,
   keymap = {
     show = '<C-space>',
     hide = '<C-e>',

--- a/lua/blink/cmp/windows/autocomplete.lua
+++ b/lua/blink/cmp/windows/autocomplete.lua
@@ -185,7 +185,16 @@ function autocomplete.draw()
   local arr_of_components = {}
   for _, item in ipairs(autocomplete.items) do
     local kind = vim.lsp.protocol.CompletionItemKind[item.kind] or 'Unknown'
-    local kind_icon = config.kind_icons[kind] or config.kind_icons.Field
+    local kind_icon
+
+    -- Use mini.icons if configured
+    if config.use_mini_icons then
+      local icon_info = require("mini.icons").get("lsp", kind:lower())
+      kind_icon = icon_info or ''
+    else
+      -- Fallback to predefined kind icons
+      kind_icon = config.kind_icons[kind] or config.kind_icons.Field
+    end
 
     table.insert(
       arr_of_components,


### PR DESCRIPTION
Hi @Saghen,

This PR adds support for using mini icons in the autocomplete menu. 

Now, if one uses mini.icons, just enable them inside the config,

`use_mini_icons = false` by default. 

I also added fallback to predefined icons if mini icons are not available.

## Testing

Verified mini icons display correctly when enabled.
Confirmed fallback icons work as expected.

<img width="1360" alt="Screenshot 2024-10-08 at 2 03 29 PM" src="https://github.com/user-attachments/assets/3571c257-2c5a-4a47-8fac-4b7992546139">
