### PR TITLE
fix!: autocompletion window components alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,6 @@ For LazyVim/distro users, you can disable nvim-cmp via:
 
   windows = {
     autocomplete = {
-      min_width = 30,
-      max_width = 60,
       max_height = 10,
       border = 'none',
       winhighlight = 'Normal:BlinkCmpMenu,FloatBorder:BlinkCmpMenuBorder,CursorLine:BlinkCmpMenuSelection,Search:None',

--- a/lua/blink/cmp/config.lua
+++ b/lua/blink/cmp/config.lua
@@ -82,8 +82,6 @@
 --- @field use_nvim_cmp_as_default? boolean
 
 --- @class blink.cmp.AutocompleteConfig
---- @field min_width? number
---- @field max_width? number
 --- @field max_height? number
 --- @field border? blink.cmp.WindowBorder
 --- @field order? "top_down" | "bottom_up"
@@ -234,8 +232,6 @@ local config = {
 
   windows = {
     autocomplete = {
-      min_width = 30,
-      max_width = 60,
       max_height = 10,
       border = 'none',
       winhighlight = 'Normal:BlinkCmpMenu,FloatBorder:BlinkCmpMenuBorder,CursorLine:BlinkCmpMenuSelection,Search:None',

--- a/lua/blink/cmp/windows/autocomplete.lua
+++ b/lua/blink/cmp/windows/autocomplete.lua
@@ -21,8 +21,6 @@ local autocomplete = {
 
 function autocomplete.setup()
   autocomplete.win = require('blink.cmp.windows.lib').new({
-    min_width = autocmp_config.min_width,
-    max_width = autocmp_config.max_width,
     max_height = autocmp_config.max_height,
     border = autocmp_config.border,
     winhighlight = autocmp_config.winhighlight,
@@ -192,13 +190,13 @@ end
 function autocomplete.draw()
   local draw_fn = autocomplete.get_draw_fn()
   local icon_gap = config.nerd_font_variant == 'mono' and ' ' or '  '
-  local arr_of_components = {}
+  local components_list = {}
   for _, item in ipairs(autocomplete.items) do
     local kind = require('blink.cmp.types').CompletionItemKind[item.kind] or 'Unknown'
     local kind_icon = config.kind_icons[kind] or config.kind_icons.Field
 
     table.insert(
-      arr_of_components,
+      components_list,
       draw_fn({
         item = item,
         kind = kind,
@@ -209,11 +207,10 @@ function autocomplete.draw()
     )
   end
 
-  local max_line_length =
-    math.min(autocmp_config.max_width, math.max(autocmp_config.min_width, renderer.get_max_length(arr_of_components)))
+  local max_lengths = renderer.get_max_lengths(components_list)
   autocomplete.rendered_items = vim.tbl_map(
-    function(component) return renderer.render(component, max_line_length) end,
-    arr_of_components
+    function(component) return renderer.render(component, max_lengths) end,
+    components_list
   )
 
   local lines = vim.tbl_map(function(rendered) return rendered.text end, autocomplete.rendered_items)
@@ -237,8 +234,10 @@ end
 --- @return blink.cmp.Component[]
 function autocomplete.render_item_simple(ctx)
   return {
-    { ' ', ctx.kind_icon, ctx.icon_gap, hl_group = 'BlinkCmpKind' .. ctx.kind },
+    ' ',
+    { ctx.kind_icon, ctx.icon_gap, hl_group = 'BlinkCmpKind' .. ctx.kind },
     { ctx.item.label, fill = true, hl_group = ctx.deprecated and 'BlinkCmpLabelDeprecated' or 'BlinkCmpLabel' },
+    ' ',
   }
 end
 
@@ -246,12 +245,15 @@ end
 --- @return blink.cmp.Component[]
 function autocomplete.render_item_reversed(ctx)
   return {
+    ' ',
     {
-      ' ' .. ctx.item.label,
+      ctx.item.label,
       fill = true,
       hl_group = ctx.deprecated and 'BlinkCmpLabelDeprecated' or 'BlinkCmpLabel',
     },
-    { ' ', ctx.kind_icon, ctx.icon_gap, ctx.kind .. ' ', hl_group = 'BlinkCmpKind' .. ctx.kind },
+    ' ',
+    { ctx.kind_icon, ctx.icon_gap, ctx.kind, hl_group = 'BlinkCmpKind' .. ctx.kind },
+    ' ',
   }
 end
 

--- a/lua/blink/cmp/windows/lib/init.lua
+++ b/lua/blink/cmp/windows/lib/init.lua
@@ -1,8 +1,8 @@
 local win = {}
 
 --- @class blink.cmp.WindowOptions
---- @field min_width number
---- @field max_width number
+--- @field min_width? number
+--- @field max_width? number
 --- @field max_height number
 --- @field cursorline boolean
 --- @field border blink.cmp.WindowBorder
@@ -12,7 +12,7 @@ local win = {}
 --- @field scrolloff number
 
 --- @class blink.cmp.Window
---- @field id number | nil
+--- @field id? number
 --- @field config blink.cmp.WindowOptions
 ---
 --- @param config blink.cmp.WindowOptions
@@ -21,8 +21,8 @@ function win.new(config)
 
   self.id = nil
   self.config = {
-    min_width = config.min_width or 30,
-    max_width = config.max_width or 60,
+    min_width = config.min_width,
+    max_width = config.max_width,
     max_height = config.max_height or 10,
     cursorline = config.cursorline or false,
     border = config.border or 'none',
@@ -63,7 +63,7 @@ function win:open()
   self.id = vim.api.nvim_open_win(self:get_buf(), false, {
     relative = 'cursor',
     style = 'minimal',
-    width = self.config.min_width,
+    width = self.config.min_width or 1,
     height = self.config.max_height,
     row = 1,
     col = 1,
@@ -81,9 +81,7 @@ function win:open()
   vim.api.nvim_set_option_value('scrolloff', self.config.scrolloff, { win = self.id })
 end
 
-function win:set_option_values(option, value)
-  vim.api.nvim_set_option_value(option, value, { win = self.id })
-end
+function win:set_option_values(option, value) vim.api.nvim_set_option_value(option, value, { win = self.id }) end
 
 function win:close()
   if self.id ~= nil then
@@ -100,7 +98,9 @@ function win:update_size()
   -- todo: never go above the screen width and height
 
   -- set width to current content width, bounded by min and max
-  local width = math.max(math.min(self:get_content_width(), config.max_width), config.min_width)
+  local width = self:get_content_width()
+  if config.max_width then width = math.min(width, config.max_width) end
+  if config.min_width then width = math.max(width, config.min_width) end
   vim.api.nvim_win_set_width(winnr, width)
 
   -- set height to current line count, bounded by max

--- a/lua/blink/cmp/windows/lib/render.lua
+++ b/lua/blink/cmp/windows/lib/render.lua
@@ -1,14 +1,30 @@
 --- @class blink.cmp.Component
 --- @field [number] blink.cmp.Component | string
---- @field fill boolean | nil
---- @field hl_group string | nil
---- @field hl_params table | nil
+--- @field fill? boolean
+--- @field max_width? number
+--- @field hl_group? string
+--- @field hl_params? table
 
 --- @class blink.cmp.RenderedComponentTree
 --- @field text string
---- @field highlights { start: number, stop: number, group: string | nil, params: table | nil }[]
+--- @field highlights { start: number, stop: number, group?: string, params?: table }[]
+
+--- @class blink.cmp.StringsBuild
+--- @field text string
+--- @field length number
 
 local renderer = {}
+
+---@param text string
+---@param max_width number
+---@return string
+function renderer.truncate_text(text, max_width)
+  if vim.api.nvim_strwidth(text) > max_width then
+    return vim.fn.strcharpart(text, 0, max_width) .. '…'
+  else
+    return text
+  end
+end
 
 --- Draws the highlights for the rendered component tree
 --- as ephemeral extmarks
@@ -25,101 +41,77 @@ function renderer.draw_highlights(rendered, bufnr, ns, line_number)
   end
 end
 
---- @param components blink.cmp.Component[]
---- @param length number
---- @return blink.cmp.RenderedComponentTree
-function renderer.render(components, length)
-  local left_of_fill = {}
-  local right_of_fill = {}
-  local fill = nil
-  for _, component in ipairs(components) do
-    if component.fill then
-      fill = component
-    else
-      table.insert(fill and right_of_fill or left_of_fill, component)
-    end
+---@param strings string[]
+---@param max_width? number
+---@return blink.cmp.StringsBuild
+function renderer.build_strings(strings, max_width)
+  local text = ''
+  for _, component in ipairs(strings) do
+    text = text .. component
   end
 
-  local left_rendered = renderer.render_components(left_of_fill)
-  local fill_rendered = renderer.render_components({ fill })
-  local right_rendered = renderer.render_components(right_of_fill)
-
-  -- expanad/truncate the fill component to the width
-  fill_rendered.text = fill_rendered.text
-    .. string.rep(' ', length - vim.api.nvim_strwidth(left_rendered.text .. fill_rendered.text .. right_rendered.text))
-  fill_rendered.text = fill_rendered.text:sub(
-    1,
-    length - vim.api.nvim_strwidth(left_rendered.text) - vim.api.nvim_strwidth(right_rendered.text)
-  )
-
-  renderer.add_offset_to_rendered_component(fill_rendered, left_rendered.text:len())
-  renderer.add_offset_to_rendered_component(right_rendered, left_rendered.text:len() + fill_rendered.text:len())
-
-  local highlights = {}
-  vim.list_extend(highlights, left_rendered.highlights)
-  vim.list_extend(highlights, fill_rendered.highlights)
-  vim.list_extend(highlights, right_rendered.highlights)
-
-  return {
-    text = left_rendered.text .. fill_rendered.text .. right_rendered.text,
-    highlights = highlights,
-  }
+  if max_width then text = renderer.truncate_text(text, max_width) end
+  return { text = text, length = vim.api.nvim_strwidth(text) }
 end
 
 --- @param components (blink.cmp.Component | string)[]
+--- @param lengths number[]
 --- @return blink.cmp.RenderedComponentTree
-function renderer.render_components(components)
+function renderer.render(components, lengths)
   local text = ''
   local offset = 0
   local highlights = {}
 
-  for _, component in ipairs(components) do
+  for i, component in ipairs(components) do
     if type(component) == 'string' then
       text = text .. component
       offset = offset + #component
     else
-      local rendered = renderer.render_components(component)
+      local build = renderer.build_strings(component, component.max_width)
 
-      renderer.add_offset_to_rendered_component(rendered, offset)
       table.insert(highlights, {
         start = offset + 1,
-        stop = offset + #rendered.text + 1,
+        stop = offset + #build.text + 1,
         group = component.hl_group,
         params = component.hl_params,
       })
-      vim.list_extend(highlights, rendered.highlights)
 
-      text = text .. rendered.text
-      offset = offset + #rendered.text
+      text = text .. build.text
+      offset = offset + #build.text
+
+      if component.fill then
+        local spaces = lengths[i] - build.length
+        text = text .. string.rep(' ', spaces)
+        offset = offset + spaces
+      end
     end
   end
 
   return { text = text, highlights = highlights }
 end
 
---- @param components blink.cmp.Component[]
+--- @param component blink.cmp.Component | string
 --- @return number
-function renderer.get_length(components)
-  local length = 0
-  for _, component in ipairs(components) do
-    if type(component) == 'string' then
-      length = length + #component
-    else
-      length = length + renderer.get_length(component)
-    end
+function renderer.get_length(component)
+  if type(component) == 'string' then
+    return vim.api.nvim_strwidth(component)
+  else
+    local build = renderer.build_strings(component, component.max_width)
+    return build.length
   end
-  return length
 end
 
---- @param arr_of_components blink.cmp.Component[][]
---- @return number
-function renderer.get_max_length(arr_of_components)
-  local max_length = 0
-  for _, components in ipairs(arr_of_components) do
-    local length = renderer.get_length(components)
-    if length > max_length then max_length = length end
+--- @param components_list (blink.cmp.Component | string)[][]
+--- @return number[]
+function renderer.get_max_lengths(components_list)
+  local lengths = {}
+  for _, components in ipairs(components_list) do
+    for i, component in ipairs(components) do
+      local length = renderer.get_length(component)
+      if not lengths[i] or lengths[i] < length then lengths[i] = length end
+    end
   end
-  return max_length
+  return lengths
 end
 
 --- @param component blink.cmp.RenderedComponentTree


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/371c2cba-5575-4ca5-9d8f-0ced74a7c7c7)
After
![image](https://github.com/user-attachments/assets/d2962f64-370f-45b2-afb6-2c43605b2e73)

I have a custom `windows.autocomplete.draw` function:
```lua
draw = function(ctx)
  return {
    {
      ctx.item.label,
      ctx.kind == "Snippet" and "~" or nil,
      fill = true,
      hl_group = ctx.deprecated and "BlinkCmpLabelDeprecated" or "BlinkCmpLabel",
    },
    " ",
    { ctx.kind, hl_group = "BlinkCmpKind" .. ctx.kind },
  }
end
```
## Notes
* I've removed `windows.autocomplete.min_width` and `windows.autocomplete.max_width` since it's way easier to maintain the alignment without those, but in compensation, `max_width` component option was added:
```lua
draw = function(ctx)
  return {
    {
      ctx.item.label,
      ctx.kind == "Snippet" and "~" or nil,
      fill = true,
      max_width = 5,
      hl_group = ctx.deprecated and "BlinkCmpLabelDeprecated" or "BlinkCmpLabel",
    },
    " ",
    { ctx.kind, hl_group = "BlinkCmpKind" .. ctx.kind },
  }
end
```
![image](https://github.com/user-attachments/assets/34defd00-7ba6-41ed-9963-62907fd7b1c6)
Also it feels weird to have unnecessary blank spacing with the `windows.autocomplete.min_width` option

* This PR allows for multiple `fill` components
* Added padding for both left and right sides of the display item