### PR TITLE
fix: use correct prev/next keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ For LazyVim/distro users, you can disable nvim-cmp via:
     show = '<C-space>',
     hide = '<C-e>',
     accept = '<Tab>',
-    select_prev = { '<Up>', '<C-k>' },
-    select_next = { '<Down>', '<C-j>' },
+    select_prev = { '<Up>', '<C-p>' },
+    select_next = { '<Down>', '<C-n>' },
 
     show_documentation = {},
     hide_documentation = {},

--- a/lua/blink/cmp/config.lua
+++ b/lua/blink/cmp/config.lua
@@ -141,8 +141,8 @@ local config = {
     show = '<C-space>',
     hide = '<C-e>',
     accept = '<Tab>',
-    select_prev = { '<Up>', '<C-k>' },
-    select_next = { '<Down>', '<C-j>' },
+    select_prev = { '<Up>', '<C-p>' },
+    select_next = { '<Down>', '<C-n>' },
 
     show_documentation = {},
     hide_documentation = {},


### PR DESCRIPTION
https://github.com/Saghen/blink.cmp/pull/23#issuecomment-2399876619 nvim-cmp uses `ctrl-n` and `ctrl-p` by default for choosing items in a completion windows. So does vanilla Neovim and Emacs and pretty much every terminal application I know of. `ctrl-j` and `ctrl-k` are unidiomatic.