### PR TITLE
doc: add musl libc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@
   version = 'v0.*',
   -- OR build from source, requires nightly: https://rust-lang.github.io/rustup/concepts/channels.html#working-with-nightly-rust
   -- build = 'cargo build --release',
+  -- On musl libc based systems you need to add this flag
+  -- build = 'RUSTFLAGS="-C target-feature=-crt-static" cargo build --release',
 
   opts = {
     highlight = {


### PR DESCRIPTION
Musl libc doesnt support dynamic linking unless a specific RUSTFLAG is provided, i added this flag in the README:
> -- OR build from source, requires nightly: https://rust-lang.github.io/rustup/concepts/channels.html#working-with-nightly-rust
-- build = 'cargo build --release',
-- On musl libc based systems you need to add this flag
-- build = 'RUSTFLAGS="-C target-feature=-crt-static" cargo build --release',
