### PR TITLE
fix: close completion window on ctrl+c in insert mode

### DIFF
--- a/lua/blink/cmp/trigger/completion.lua
+++ b/lua/blink/cmp/trigger/completion.lua
@@ -84,6 +84,17 @@ function trigger.activate_autocmds()
   -- definitely leaving the context
   vim.api.nvim_create_autocmd({ 'InsertLeave', 'BufLeave' }, { callback = trigger.hide })
 
+  -- trigger InsertLeave autocommand when exiting insert mode with ctrl+c
+  local ctrl_c = vim.api.nvim_replace_termcodes('<C-c>', true, true, true)
+  vim.on_key(function(key)
+    if key == ctrl_c then
+      vim.schedule(function()
+        local mode = vim.api.nvim_get_mode().mode
+        if mode ~= 'i' then trigger.hide() end
+      end)
+    end
+  end)
+
   return trigger
 end
 


### PR DESCRIPTION
As a nvim-cmp user, I was used to close the completion window with ctrl+c (it's kind of muscle memory at this point).
So I wanted to add the ability to blink.cmp too. Before this PR, the completion would not be closed as C-c does not trigger the InsertLeave autocommand in Vim/Nvim.

Currently, it looks like this:
![image](https://github.com/user-attachments/assets/39ae8268-8dad-4fc6-864f-07059a25859d)
Notice that my cursor is on line 13, outside of the completion window after I pressed ctrl+c.


For reference, nvim-cmp does something similar here:

https://github.com/hrsh7th/nvim-cmp/blob/ae644feb7b67bf1ce4260c231d1d4300b19c6f30/plugin/cmp.lua#L43-L54