### PR TITLE
fix: snippets generation rendering invalid markdown

### DIFF
--- a/lua/blink/cmp/sources/snippets/init.lua
+++ b/lua/blink/cmp/sources/snippets/init.lua
@@ -48,7 +48,7 @@ function snippets:resolve(item, callback)
   local snippet = parsed_snippet and tostring(parsed_snippet) or item.insertText
 
   -- TODO: ideally context is passed with the filetype
-  local documentation = '```' .. vim.bo.filetype .. '\n' .. snippet .. '```' .. '\n---\n' .. item.description
+  local documentation = '```' .. vim.bo.filetype .. '\n' .. snippet .. '\n```' .. '\n---\n' .. item.description
 
   local resolved_item = vim.deepcopy(item)
   resolved_item.documentation = {


### PR DESCRIPTION
When rendering markdown in for the documentation window I realized that the snippet generation was outputting invalid markdown

### Before

example with `vim.lsp.util.stylize_markdown` 
![image](https://github.com/user-attachments/assets/eab1001a-a233-4406-a08d-7121de496144)

example with `render-markdown`
![image](https://github.com/user-attachments/assets/34360158-1d01-4dfe-886e-1d74e2401986)

### After the fix

with `vim.lsp.util.stylize_markdown` 
![image](https://github.com/user-attachments/assets/5866cab2-6511-47ff-ac14-ab19aa76469c)

with `render-markdown`
![image](https://github.com/user-attachments/assets/5a0aaa47-5fcb-4e6b-9cc5-4564911fdc6c)

At the moment the plugin itself does not render markdown but it could be acheived with a filetype plugin or the render-markdown plugin

