### PR TITLE
fix: correctly handle non-blink keymaps with string rhs

### DIFF
--- a/lua/blink/cmp/keymap.lua
+++ b/lua/blink/cmp/keymap.lua
@@ -110,11 +110,13 @@ function keymap.run_non_blink_keymap(mode, key)
   -- https://github.com/hrsh7th/nvim-cmp/blob/ae644feb7b67bf1ce4260c231d1d4300b19c6f30/lua/cmp/utils/keymap.lua
   if type(mapping.callback) == 'function' then
     local expr = mapping.callback()
-    if mapping.replace_keycodes then expr = vim.api.nvim_replace_termcodes(expr, true, true, true) end
-    if mapping.expr then return expr end
+    if mapping.replace_keycodes == 1 then expr = vim.api.nvim_replace_termcodes(expr, true, true, true) end
+    if mapping.expr == 1 then return expr end
     return
   elseif mapping.rhs then
-    return vim.api.nvim_eval(vim.api.nvim_replace_termcodes(mapping.rhs, true, true, true))
+    local rhs = vim.api.nvim_replace_termcodes(mapping.rhs, true, true, true)
+    if mapping.expr == 1 then rhs = vim.api.nvim_eval(rhs) end
+    return rhs
   end
 
   -- pass the key along as usual


### PR DESCRIPTION
Given the following config:

```lua
require("blink.cmp").setup({
    keymap = {
        select_prev = { "<S-Tab>" },
    },
})

vim.keymap.set("i", "<S-Tab>", "<C-o>A")
```

Pressing `<S-Tab>` in insert mode when the Blink window is not visible creates an error:

```
E5108: Error executing lua: Vim:E15: Invalid expression: "^OA"
```

The issue is that `nvim_eval` is unconditionally called on `mapping.rhs`, so this PR fixes the logic to only evaluate the result of `<expr>` mappings. 

I also fixed a bug in the `if mapping` conditions, which are a little different in nvim-cmp because [these fields are converted into boolean values](https://github.com/hrsh7th/nvim-cmp/blob/ae644feb7b67bf1ce4260c231d1d4300b19c6f30/lua/cmp/utils/keymap.lua#L209).

As you noted in a comment, handling fallback keymaps correctly in all cases is tricky, but for the moment, this should at least unblock a common case.
