### PR TITLE
fix: documentation of snippet cannot be shown when description is list

### DIFF
--- a/lua/blink/cmp/sources/snippets/utils.lua
+++ b/lua/blink/cmp/sources/snippets/utils.lua
@@ -22,6 +22,11 @@ function utils.read_snippet(snippet, fallback)
   local prefix = snippet.prefix or fallback
   local description = snippet.description or fallback
   local body = snippet.body
+
+  if type(description) == "table" then
+    description = vim.fn.join(description)
+  end
+
   if type(prefix) == 'table' then
     for _, p in ipairs(prefix) do
       snippets[p] = {


### PR DESCRIPTION
When formating documentation of snippets, we treat the description field of a snippet item as string by default but it could a list of string sometimes(see [snippets for shell in friendly-snippets](https://github.com/rafamadriz/friendly-snippets/blob/de8fce94985873666bd9712ea3e49ee17aadb1ed/snippets/shell/shell.json#L62) ) which might cause a concatenation failure.

So here is a tiny fix by joining the description list if it is a list when loading snippets, so now it could be shown and looks like this:
![image](https://github.com/user-attachments/assets/9aa41e78-378d-453f-80df-944da3d3e754)

Closes https://github.com/Saghen/blink.cmp/issues/91