### PR TITLE
implement new behavior for autocompletion menu, toggle option to require keypress for showing suggestions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ MiniDeps.add({
       -- which directions to show the window,
       -- falling back to the next direction when there's not enough space
       direction_priority = { 's', 'n' },
+      -- Controls whether the completion window will automatically show when typing
+      auto_show = true,
       -- Controls how the completion items are selected
       -- 'preselect' will automatically select the first item in the completion list
       -- 'manual' will not select any item by default
@@ -318,6 +320,7 @@ MiniDeps.add({
         autocomplete_north = { 'e', 'w', 'n', 's' },
         autocomplete_south = { 'e', 'w', 's', 'n' },
       },
+      -- Controls whether the documentation window will automatically show when selecting a completion item
       auto_show = false,
       auto_show_delay_ms = 500,
       update_delay_ms = 50,

--- a/lua/blink/cmp/config.lua
+++ b/lua/blink/cmp/config.lua
@@ -84,12 +84,12 @@
 --- @field use_nvim_cmp_as_default? boolean
 
 --- @class blink.cmp.AutocompleteConfig
---- @field auto_show? boolean
 --- @field min_width? number
 --- @field max_height? number
 --- @field border? blink.cmp.WindowBorder
 --- @field order? "top_down" | "bottom_up"
 --- @field direction_priority? ("n" | "s")[]
+--- @field auto_show? boolean
 --- @field selection? "preselect" | "manual" | "auto_insert"
 --- @field winhighlight? string
 --- @field scrolloff? number
@@ -240,7 +240,6 @@ local config = {
 
   windows = {
     autocomplete = {
-      auto_show = true,
       min_width = 15,
       max_height = 10,
       border = 'none',
@@ -252,6 +251,8 @@ local config = {
       -- which directions to show the window,
       -- falling back to the next direction when there's not enough space
       direction_priority = { 's', 'n' },
+      -- Controls whether the completion window will automatically show when typing
+      auto_show = true,
       -- Controls how the completion items are selected
       -- 'preselect' will automatically select the first item in the completion list
       -- 'manual' will not select any item by default
@@ -283,6 +284,7 @@ local config = {
         autocomplete_north = { 'e', 'w', 'n', 's' },
         autocomplete_south = { 'e', 'w', 's', 'n' },
       },
+      -- Controls whether the documentation window will automatically show when selecting a completion item
       auto_show = false,
       auto_show_delay_ms = 500,
       update_delay_ms = 50,

--- a/lua/blink/cmp/config.lua
+++ b/lua/blink/cmp/config.lua
@@ -84,6 +84,7 @@
 --- @field use_nvim_cmp_as_default? boolean
 
 --- @class blink.cmp.AutocompleteConfig
+--- @field auto_show? boolean
 --- @field min_width? number
 --- @field max_height? number
 --- @field border? blink.cmp.WindowBorder
@@ -239,6 +240,7 @@ local config = {
 
   windows = {
     autocomplete = {
+      auto_show = true,
       min_width = 15,
       max_height = 10,
       border = 'none',

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -149,13 +149,21 @@ cmp.accept = function()
 end
 
 cmp.select_prev = function()
-  if not cmp.windows.autocomplete.win:is_open() then return end
+  if not cmp.trigger.auto_show then cmp.trigger.set_auto_show(true) end
+  if not cmp.windows.autocomplete.win:is_open() then
+    cmp.show()
+    return true
+  end
   vim.schedule(cmp.windows.autocomplete.select_prev)
   return true
 end
 
 cmp.select_next = function()
-  if not cmp.windows.autocomplete.win:is_open() then return end
+  if not cmp.trigger.auto_show then cmp.trigger.set_auto_show(true) end
+  if not cmp.windows.autocomplete.win:is_open() then
+    cmp.show()
+    return true
+  end
   vim.schedule(cmp.windows.autocomplete.select_next)
   return true
 end

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -119,7 +119,10 @@ end
 
 cmp.show = function()
   if cmp.windows.autocomplete.win:is_open() then return end
-  vim.schedule(cmp.trigger.show)
+  vim.schedule(function()
+    cmp.windows.autocomplete.auto_show = true
+    cmp.trigger.show({ force = true })
+  end)
   return true
 end
 
@@ -149,7 +152,6 @@ cmp.accept = function()
 end
 
 cmp.select_prev = function()
-  if not cmp.trigger.auto_show then cmp.trigger.set_auto_show(true) end
   if not cmp.windows.autocomplete.win:is_open() then
     cmp.show()
     return true
@@ -159,7 +161,6 @@ cmp.select_prev = function()
 end
 
 cmp.select_next = function()
-  if not cmp.trigger.auto_show then cmp.trigger.set_auto_show(true) end
   if not cmp.windows.autocomplete.win:is_open() then
     cmp.show()
     return true

--- a/lua/blink/cmp/trigger/completion.lua
+++ b/lua/blink/cmp/trigger/completion.lua
@@ -3,7 +3,6 @@
 -- This can be used downstream to determine if we should make new requests to the sources or not.
 
 local config = require('blink.cmp.config').trigger.completion
-local autocomplete = require('blink.cmp.config').windows.autocomplete
 local sources = require('blink.cmp.sources.lib')
 local utils = require('blink.cmp.utils')
 
@@ -11,7 +10,6 @@ local trigger = {
   current_context_id = -1,
   --- @type blink.cmp.Context | nil
   context = nil,
-  auto_show = autocomplete.auto_show,
   event_targets = {
     --- @type fun(context: blink.cmp.Context)
     on_show = function() end,
@@ -19,39 +17,6 @@ local trigger = {
     on_hide = function() end,
   },
 }
-
-function trigger.set_auto_show(value)
-  trigger.auto_show = value
-  trigger.on_input(vim.v.char)
-end
-
---- @param last_char string
-function trigger.on_input(last_char)
-  if not trigger.auto_show then return end
-  -- no characters added so let cursormoved handle it
-  if last_char == '' then return end
-
-  -- ignore if in a special buffer
-  if utils.is_special_buffer() then
-    trigger.hide()
-    -- character forces a trigger according to the sources, create a fresh context
-  elseif vim.tbl_contains(sources.get_trigger_characters(), last_char) then
-    trigger.context = nil
-    trigger.show({ trigger_character = last_char })
-    -- character is part of the current context OR in an existing context
-  elseif last_char:match(config.keyword_regex) ~= nil then
-    trigger.show()
-    -- nothing matches so hide
-  else
-    trigger.hide()
-  end
-
-  last_char = ''
-end
-
--- vim.api.nvim_create_autocmd('TextChangedI', {
---   callback = function() trigger.on_input(last_char) end,
--- })
 
 function trigger.activate_autocmds()
   local last_char = ''
@@ -177,13 +142,18 @@ function trigger.suppress_events_for_callback(cb)
     and is_insert_mode
 end
 
---- @param opts { trigger_character?: string, send_upstream?: boolean } | nil
+--- @param opts { trigger_character?: string, send_upstream?: boolean, force?: boolean } | nil
 function trigger.show(opts)
   opts = opts or {}
 
   local cursor = vim.api.nvim_win_get_cursor(0)
   -- already triggered at this position, ignore
-  if trigger.context ~= nil and cursor[1] == trigger.context.cursor[1] and cursor[2] == trigger.context.cursor[2] then
+  if
+    not opts.force
+    and trigger.context ~= nil
+    and cursor[1] == trigger.context.cursor[1]
+    and cursor[2] == trigger.context.cursor[2]
+  then
     return
   end
 
@@ -210,7 +180,6 @@ function trigger.listen_on_show(callback) trigger.event_targets.on_show = callba
 
 function trigger.hide()
   if not trigger.context then return end
-  trigger.set_auto_show(autocomplete.auto_show)
   trigger.context = nil
   trigger.event_targets.on_hide()
 end

--- a/lua/blink/cmp/windows/autocomplete.lua
+++ b/lua/blink/cmp/windows/autocomplete.lua
@@ -13,6 +13,8 @@ local autocomplete = {
   ---@type blink.cmp.CompletionItem[]
   items = {},
   has_selected = nil,
+  -- hack: ideally this doesn't get mutated by the public API
+  auto_show = autocmp_config.auto_show,
   ---@type blink.cmp.Context?
   context = nil,
   event_targets = {
@@ -71,9 +73,9 @@ function autocomplete.open_with_items(context, items)
 
   vim.iter(autocomplete.event_targets.on_open):each(function(callback) callback() end)
 
+  if not autocomplete.auto_show then return end
   autocomplete.win:open()
 
-  autocomplete.context = context
   autocomplete.update_position(context)
   autocomplete.set_has_selected(autocmp_config.selection == 'preselect')
 
@@ -91,6 +93,7 @@ end
 
 function autocomplete.close()
   if not autocomplete.win:is_open() then return end
+  autocomplete.auto_show = autocmp_config.auto_show
   autocomplete.win:close()
   autocomplete.set_has_selected(autocmp_config.selection == 'preselect')
 


### PR DESCRIPTION
This introduces a new `auto_show` config for the autocompletion menu. It's set to `true` by default, so nothing has changed. If we set it to `false,` then we need to press default or user-set keymaps to show the menu.