### PR TITLE
feat(ci): support windows pre-built binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,11 @@ jobs:
             target: aarch64-apple-darwin
             artifact_name: target/aarch64-apple-darwin/release/libblink_cmp_fuzzy.dylib
 
+          # Windows builds
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact_name: target/x86_64-pc-windows-msvc/release/blink_cmp_fuzzy.dll
+
     steps:
       - uses: actions/checkout@v4
 

--- a/lua/blink/cmp/fuzzy/download.lua
+++ b/lua/blink/cmp/fuzzy/download.lua
@@ -134,6 +134,9 @@ function download.get_system_triple()
     if jit.arch:lower():match('arm') then return 'aarch64-apple-darwin' end
     if jit.arch:lower():match('x64') then return 'x86_64-apple-darwin' end
   end
+  if jit.os:lower() == 'windows' then
+    if jit.arch:lower():match('x64') then return 'x86_64-pc-windows-msvc' end
+  end
   if jit.os:lower() ~= 'windows' then
     if jit.arch:lower():match('arm') then return 'aarch64-unknown-linux-gnu' end
     if jit.arch:lower():match('x64') then return 'x86_64-unknown-linux-gnu' end


### PR DESCRIPTION
This PR adds support for pre-built binaries for Windows. Now that #74 is merged, the logical next step is to get this up and running. 

I've set up a separate branch on my fork where actions are enabled and I've tested with a few tags, all looking good on my Windows machine. The binary is downloaded and detected by the plugin just like it is on other OSs:

https://github.com/scottmckendry/blink.cmp/releases/tag/v1.0.3

For obvious reasons, the branch above is different from the one used for this PR 😉 

Resolves #7 