### PR TITLE
feat: add health.lua and basic healthchecks

### DIFF
--- a/lua/blink/cmp/fuzzy/download.lua
+++ b/lua/blink/cmp/fuzzy/download.lua
@@ -10,7 +10,7 @@ function download.get_lib_extension()
 end
 
 local root_dir = debug.getinfo(1).source:match('@?(.*/)')
-local lib_path = root_dir .. '../../../../target/release/libblink_cmp_fuzzy' .. download.get_lib_extension()
+download.lib_path = root_dir .. '../../../../target/release/libblink_cmp_fuzzy' .. download.get_lib_extension()
 local version_path = root_dir .. '../../../../target/release/version.txt'
 
 --- @param callback fun(err: string | nil)
@@ -58,12 +58,15 @@ end
 
 --- @param cb fun(downloaded: boolean)
 function download.is_downloaded(cb)
-  vim.uv.fs_stat(lib_path, function(err)
+  vim.uv.fs_stat(download.lib_path, function(err)
     if not err then
       cb(true)
     else
       -- If not found, check without 'lib' prefix
-      vim.uv.fs_stat(string.gsub(lib_path, 'libblink_cmp_fuzzy', 'blink_cmp_fuzzy'), function(error) cb(not error) end)
+      vim.uv.fs_stat(
+        string.gsub(download.lib_path, 'libblink_cmp_fuzzy', 'blink_cmp_fuzzy'),
+        function(error) cb(not error) end
+      )
     end
   end)
 end
@@ -97,7 +100,7 @@ function download.from_github(tag, cb)
     .. system_triple
     .. download.get_lib_extension()
 
-  vim.system({ 'curl', '--create-dirs', '-Lo', lib_path, url }, {}, function(out)
+  vim.system({ 'curl', '--create-dirs', '-Lo', download.lib_path, url }, {}, function(out)
     if out.code ~= 0 then cb('Failed to download pre-build binaries: ' .. out.stderr) end
     cb()
   end)

--- a/lua/blink/cmp/health.lua
+++ b/lua/blink/cmp/health.lua
@@ -1,0 +1,35 @@
+local M = {}
+local download = require('blink.cmp.fuzzy.download')
+
+M.check = function()
+  vim.health.start('blink.cmp healthcheck')
+
+  local required_executables = { 'curl', 'git' }
+  for _, executable in ipairs(required_executables) do
+    if vim.fn.executable(executable) == 0 then
+      vim.health.error(executable .. ' is not installed')
+    else
+      vim.health.ok(executable .. ' is installed')
+    end
+  end
+
+  -- check if os is supported
+  local system_triple = download.get_system_triple()
+  if system_triple then
+    vim.health.ok('Your system is supported by pre-built binaries (' .. system_triple .. ')')
+  else
+    vim.health.warn(
+      'Your system is not supported by pre-built binaries. You must run cargo build --release via your package manager with rust nightly. See the README for more info.'
+    )
+  end
+
+  if
+    vim.uv.fs_stat(download.lib_path)
+    or vim.uv.fs_stat(string.gsub(download.lib_path, 'libblink_cmp_fuzzy', 'blink_cmp_fuzzy'))
+  then
+    vim.health.ok('blink_cmp_fuzzy lib is downloaded/built')
+  else
+    vim.health.warn('blink_cmp_fuzzy lib is not downloaded/built')
+  end
+end
+return M


### PR DESCRIPTION
Adds some basic healthchecks that can be run with `:checkhealth`. 

Here is an example of the output of `:checkhealth blink.cmp`:
![image](https://github.com/user-attachments/assets/ec9fe403-9c40-4cd5-9e4e-2d376467b5eb)
