### PR TITLE
docs: add missing source name in default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ MiniDeps.add({
     providers = {
       { 'blink.cmp.sources.lsp', name = 'LSP' },
       { 'blink.cmp.sources.path', name = 'Path', score_offset = 3 },
-      { 'blink.cmp.sources.snippets', score_offset = -3 },
+      { 'blink.cmp.sources.snippets', name = 'Snippets', score_offset = -3 },
       { 'blink.cmp.sources.buffer', name = 'Buffer', fallback_for = { 'LSP' } },
     },
     -- FOR REF: full example


### PR DESCRIPTION
Name for the snippets source missing in the default configuration in the readme