### PR TITLE
feat(config): add ignored filetypes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,9 @@ MiniDeps.add({
   -- adjusts spacing to ensure icons are aligned
   nerd_font_variant = 'normal',
 
+  -- don't show completions or signature help for these filetypes. Keymaps are also disabled.
+  blocked_filetypes = {},
+
   kind_icons = {
     Text = '󰉿',
     Method = '󰊕',

--- a/lua/blink/cmp/config.lua
+++ b/lua/blink/cmp/config.lua
@@ -133,6 +133,7 @@
 --- @field highlight? blink.cmp.HighlightConfig
 --- @field nerd_font_variant? 'mono' | 'normal'
 --- @field kind_icons? table<string, string>
+--- @field blocked_filetypes? string[]
 
 --- @type blink.cmp.Config
 local config = {
@@ -305,6 +306,9 @@ local config = {
   -- set to 'mono' for 'Nerd Font Mono' or 'normal' for 'Nerd Font'
   -- adjusts spacing to ensure icons are aligned
   nerd_font_variant = 'normal',
+
+  -- don't show completions or signature help for these filetypes. Keymaps are also disabled.
+  blocked_filetypes = {},
 
   kind_icons = {
     Text = '󰉿',

--- a/lua/blink/cmp/keymap.lua
+++ b/lua/blink/cmp/keymap.lua
@@ -44,7 +44,7 @@ function keymap.setup(opts)
   -- applied on other autocmds, such as LspAttach used by nvim-lspconfig and most configs
   vim.api.nvim_create_autocmd('InsertEnter', {
     callback = function()
-      if utils.is_special_buffer() then return end
+      if utils.is_ignored_buffer() then return end
       keymap.apply_keymap_to_current_buffer(insert_keys_to_commands, snippet_keys_to_commands)
     end,
   })

--- a/lua/blink/cmp/trigger/completion.lua
+++ b/lua/blink/cmp/trigger/completion.lua
@@ -38,7 +38,7 @@ function trigger.activate_autocmds()
         return
 
       -- ignore if in a special buffer
-      elseif utils.is_special_buffer() then
+      elseif utils.is_ignored_buffer() then
         trigger.hide()
 
       -- character forces a trigger according to the sources, create a fresh context
@@ -61,7 +61,7 @@ function trigger.activate_autocmds()
 
   vim.api.nvim_create_autocmd({ 'CursorMovedI', 'InsertEnter' }, {
     callback = function(ev)
-      if utils.is_special_buffer() then return end
+      if utils.is_ignored_buffer() then return end
 
       -- we were told to ignore the cursor moved event, so we update the context
       -- but don't send an on_show event upstream

--- a/lua/blink/cmp/trigger/signature.lua
+++ b/lua/blink/cmp/trigger/signature.lua
@@ -39,7 +39,7 @@ function trigger.activate_autocmds()
 
       for _, last_char in ipairs(last_chars) do
         -- ignore if in a special buffer
-        if utils.is_special_buffer() then
+        if utils.is_ignored_buffer() then
           trigger.hide()
           break
         -- character forces a trigger according to the sources, refresh the existing context if it exists
@@ -60,7 +60,7 @@ function trigger.activate_autocmds()
   -- check if we've moved outside of the context by diffing against the query boundary
   vim.api.nvim_create_autocmd({ 'CursorMovedI', 'InsertEnter' }, {
     callback = function(ev)
-      if utils.is_special_buffer() then return end
+      if utils.is_ignored_buffer() then return end
 
       -- characters added so let textchanged handle it
       if #last_chars ~= 0 then return end

--- a/lua/blink/cmp/utils.lua
+++ b/lua/blink/cmp/utils.lua
@@ -28,11 +28,15 @@ function utils.union_keys(t1, t2)
   return vim.tbl_keys(t3)
 end
 
---- Determines whether the current buffer is a "special" buffer
+--- Determines whether the current buffer is a "special" buffer or if the filetype is in the list of ignored filetypes
 --- @return boolean
-function utils.is_special_buffer()
+function utils.is_ignored_buffer()
   local bufnr = vim.api.nvim_get_current_buf()
   local buftype = vim.api.nvim_get_option_value('buftype', { buf = bufnr })
+  local blocked_filetypes = require('blink.cmp.config').blocked_filetypes or {}
+  local buf_filetype = vim.api.nvim_get_option_value('filetype', { buf = bufnr })
+
+  if vim.tbl_contains(blocked_filetypes, buf_filetype) then return true end
   return buftype ~= ''
 end
 


### PR DESCRIPTION
Adds a new config option `ignored_filetypes` that can be used to turn off completions and keymaps for specific filetypes.
It extends the existing `is_special_buffer()` function(now renamed to `is_ignored_buffer` for clarity) to check whether the current buffer's filetype is in the table.

I'm not attached to the implementation. So I'm open to feedback on alternative approaches 🙂 

Resolves #52 