### PR TITLE
Fix signature error

### DIFF
--- a/lua/blink/cmp/windows/signature.lua
+++ b/lua/blink/cmp/windows/signature.lua
@@ -25,7 +25,9 @@ end
 --- @param signature_help lsp.SignatureHelp | nil
 function signature.open_with_signature_help(context, signature_help)
   signature.context = context
-  if signature_help == nil then
+  -- check if there are any signatures in signature_help, since
+  -- convert_signature_help_to_markdown_lines errors with no signatures
+  if signature_help == nil or #signature_help.signatures == 0 then
     signature.win:close()
     return
   end


### PR DESCRIPTION
I kept getting the following error on main, and this one line change seems to fix it. (Note: I haven't investigated more, so maybe the proper fix is actually to figure out why `signature_help.signatures` can be empty.)

```
Error executing vim.schedule lua callback: /usr/local/share/nvim/runtime/lua/vim/lsp/util.lua:822: attempt to index local 'signature' (a nil value)
-- stack traceback:
--         /usr/local/share/nvim/runtime/lua/vim/lsp/util.lua:822: in function 'convert_signature_help_to_markdown_lines'
--         .../nvim/lazy/blink.cmp/lua/blink/cmp/windows/signature.lua:39: in function 'open_with_signature_help'
--         .../.local/share/nvim/lazy/blink.cmp/lua/blink/cmp/init.lua:80: in function 'callback'
--         ...e/nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/init.lua:126: in function 'fn'
--         .../nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/async.lua:86: in function 'cb'
--         .../nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/async.lua:44: in function 'resolve'
--         .../nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/async.lua:163: in function 'resolve_if_completed'
--         .../nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/async.lua:169: in function 'cb'
--         .../nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/async.lua:44: in function 'resolve'
--         ...im/lazy/blink.cmp/lua/blink/cmp/sources/lib/provider.lua:112: in function <...im/lazy/blink.cmp/lua/blink/cmp/sources/lib/provider.lua:112>
```

Also: While looking at this file I noted that 
```lua
  local cursor_row = vim.api.nvim_win_get_cursor(0)[1]
  local is_space_below = screen_height - cursor_row - screen_scroll_range.start_line > height
  local is_space_above = cursor_row - screen_scroll_range.start_line > height
```
at the bottom is never used for anything, but I didn't change it for now, since I assume it is meant to be used? (`context` is also not used in that function.)
