### PR TITLE
fix: Typo in signature.win

### DIFF
--- a/lua/blink/cmp/windows/signature.lua
+++ b/lua/blink/cmp/windows/signature.lua
@@ -104,7 +104,7 @@ function signature.update_position(context)
   local direction = autocomplete_win_is_up and 's' or 'n'
 
   local height = signature.win:get_height()
-  local cursor_screen_position = win.get_cursor_screen_position()
+  local cursor_screen_position = signature.win.get_cursor_screen_position()
 
   -- detect if there's space above/below the cursor
   local cursor_row = vim.api.nvim_win_get_cursor(0)[1]


### PR DESCRIPTION
https://github.com/Saghen/blink.cmp/commit/819b978328b244fc124cfcd74661b2a7f4259f4f#diff-a640c01fb7bc8cf6505b8eb364637612227b1330d4205c09c9fa0d66b5a14072R107

references a `win` that isn't defined, which leads to the following error:

```
Error executing vim.schedule lua callback: .../nvim/lazy/blink.cmp/lua/blink/cmp/windows/signature.lua:107: attempt to index global 'win' (a nil value)
stack traceback:
        .../nvim/lazy/blink.cmp/lua/blink/cmp/windows/signature.lua:107: in function 'update_position'
        .../nvim/lazy/blink.cmp/lua/blink/cmp/windows/signature.lua:66: in function 'open_with_signature_help'
        .../.local/share/nvim/lazy/blink.cmp/lua/blink/cmp/init.lua:80: in function 'callback'
        ...e/nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/init.lua:126: in function 'fn'
        .../nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/async.lua:86: in function 'cb'
        .../nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/async.lua:44: in function 'resolve'
        .../nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/async.lua:163: in function 'resolve_if_completed'
        .../nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/async.lua:169: in function 'cb'
        .../nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/async.lua:44: in function 'resolve'
        ...im/lazy/blink.cmp/lua/blink/cmp/sources/lib/provider.lua:112: in function <...im/lazy/blink.cmp/lua/blink/cmp/sources/lib/provider.lua:112>
```