### PR TITLE
fix: signature window no longer overlaps cursor

### DIFF
--- a/lua/blink/cmp/windows/signature.lua
+++ b/lua/blink/cmp/windows/signature.lua
@@ -111,6 +111,9 @@ function signature.update_position(context)
   local is_space_below = cursor_screen_position.distance_from_bottom > height
   local is_space_above = cursor_screen_position.distance_from_top > height
 
+  -- fixes issue where the signature window would cover the cursor
+  if is_space_above then direction = 'n' else direction = 's' end
+
   -- default to the user's preference but attempt to use the other options
   local row = direction == 's' and 1 or -height
   vim.api.nvim_win_set_config(winnr, { relative = 'cursor', row = row, col = -1 })


### PR DESCRIPTION
I had an issue where the signature help window was covering the cursor if there was not enough space above or below the cursor. 
Not sure if this is the correct way to go about fixing it, I think in the future it should have the direction priority like what autocomplete has. I don't know lua though, so best I can do is a temporary solution.

Closes #45 