### PR TITLE
Fix broken completion documentation

### DIFF
--- a/lua/blink/cmp/windows/documentation.lua
+++ b/lua/blink/cmp/windows/documentation.lua
@@ -12,6 +12,7 @@ function docs.setup()
     border = config.border,
     winhighlight = config.winhighlight,
     wrap = true,
+    filetype = 'markdown'
   })
 
   autocomplete.listen_on_position_update(function()


### PR DESCRIPTION
## Problem

`cmp_menu` is not a known treesitter parser. Treesitter users get errors when showing the completion docs.

## Solution

Add "markdown" filetype to `windows.documentation.setup`

## Before

![before-fix](https://github.com/user-attachments/assets/dee7c5fa-8f32-4d56-9e2e-f32567e20c1f)

## After

![after-fix](https://github.com/user-attachments/assets/c5f7fe8e-3740-4082-841a-49f4cf2dac7f)

