### PR TITLE
feat(windows): add support for individual border character highlights

### DIFF
--- a/lua/blink/cmp/config.lua
+++ b/lua/blink/cmp/config.lua
@@ -108,7 +108,8 @@
 --- @field autocomplete_north? ("n" | "s" | "e" | "w")[]
 --- @field autocomplete_south? ("n" | "s" | "e" | "w")[]
 ---
---- @alias blink.cmp.WindowBorder 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'padded' | 'none' | string[]
+--- @alias blink.cmp.WindowBorderChar string | table
+--- @alias blink.cmp.WindowBorder 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'padded' | 'none' | blink.cmp.WindowBorderChar
 ---
 --- @class blink.cmp.DocumentationConfig
 --- @field min_width? number


### PR DESCRIPTION
Hide type warnings when using a table with character highlights:

![image](https://github.com/user-attachments/assets/5485fe4b-ac84-45a2-bd2e-f604e934d77d)

This is supported by the neovim API, so no other code changes were required 🙂 