### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug Report
+description: File a bug report
+title: "Bug: "
+labels: ["bug"]
+body:
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Make sure you have done the following
+      options:
+        - label: I have updated to the latest version of `blink.cmp`.
+          required: true
+        - label: I have read the README.
+          required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+    validations: { required: true }
+  - type: textarea
+    id: user-config
+    attributes:
+      label: Relevant configuration
+      description: Copypaste the part of the config relevant to the bug.
+      render: lua
+      placeholder: |
+        sources = {
+          completion = {
+            enabled_providers = { "lsp", "path", "snippets", "buffer" },
+          },
+        },
+    validations: { required: false }
+  - type: input
+    id: version-info
+    attributes:
+      label: neovim version
+      placeholder: "for example: 0.10.0 or nightly"
+    validations: { required: true }
+  - type: input
+    id: branch-or-tag
+    attributes:
+      label: "`blink.cmp` version: branch, tag, or commit"
+      placeholder: "for example: main or v0.4.0"
+    validations: { required: true }

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: File a bug report
-title: "Bug: "
 labels: ["bug"]
 body:
   - type: checkboxes
@@ -8,9 +7,9 @@ body:
     attributes:
       label: Make sure you have done the following
       options:
-        - label: I have updated to the latest version of `blink.cmp`.
+        - label: I have updated to the latest version of `blink.cmp`
           required: true
-        - label: I have read the README.
+        - label: I have read the README
           required: true
   - type: textarea
     id: bug-description
@@ -21,7 +20,7 @@ body:
     id: user-config
     attributes:
       label: Relevant configuration
-      description: Copypaste the part of the config relevant to the bug.
+      description: Copypaste the part of the config relevant to the bug. Do NOT paste the entire default config.
       render: lua
       placeholder: |
         sources = {
@@ -34,7 +33,7 @@ body:
     id: version-info
     attributes:
       label: neovim version
-      placeholder: "for example: 0.10.0 or nightly"
+      placeholder: "output for `nvim --version`"
     validations: { required: true }
   - type: input
     id: branch-or-tag

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest an idea
+title: "FR: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: feature-requested
+    attributes:
+      label: Feature Requested
+      description: A clear and concise description of the feature.
+    validations: { required: true }
+  - type: textarea
+    id: problem-solved
+    attributes:
+      label: Problem solved
+      description: What problem would the feature solve?
+    validations: { required: true }
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: What alternatives are there to the feature?
+    validations: { required: false }

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,23 +1,10 @@
 name: Feature request
 description: Suggest an idea
-title: "FR: "
 labels: ["enhancement"]
 body:
   - type: textarea
     id: feature-requested
     attributes:
       label: Feature Requested
-      description: A clear and concise description of the feature.
+      description: A clear and concise description of the feature
     validations: { required: true }
-  - type: textarea
-    id: problem-solved
-    attributes:
-      label: Problem solved
-      description: What problem would the feature solve?
-    validations: { required: true }
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives
-      description: What alternatives are there to the feature?
-    validations: { required: false }


### PR DESCRIPTION
The repo is large enough that it regularly gets new issues, warranting the use of GitHub issue templates. These can save time for all involved (maintainers & issue creators), since some basic back-and-forth questions, [such as asking whether the user is on a branch or a tag](https://github.com/Saghen/blink.cmp/issues/185#issuecomment-2436210225), could be skipped.

I only added some sensible basics, these can of course be improved later on.