### PR TITLE
fix(keymaps): expr can't nvim_buf_set_text

### DIFF
--- a/lua/blink/cmp/keymap.lua
+++ b/lua/blink/cmp/keymap.lua
@@ -117,10 +117,16 @@ function keymap.run_non_blink_keymap(mode, key)
   -- and is quite complex. we should look to see if we can simplify their logic
   -- https://github.com/hrsh7th/nvim-cmp/blob/ae644feb7b67bf1ce4260c231d1d4300b19c6f30/lua/cmp/utils/keymap.lua
   if type(mapping.callback) == 'function' then
+    -- with expr = true, which we use, we can't modify the buffer without scheduling
+    -- so if the keymap does not use expr, we must schedule it
+    if mapping.expr ~= 1 then
+      vim.schedule(mapping.callback)
+      return
+    end
+
     local expr = mapping.callback()
     if mapping.replace_keycodes == 1 then expr = vim.api.nvim_replace_termcodes(expr, true, true, true) end
-    if mapping.expr == 1 then return expr end
-    return
+    return expr
   elseif mapping.rhs then
     local rhs = vim.api.nvim_replace_termcodes(mapping.rhs, true, true, true)
     if mapping.expr == 1 then rhs = vim.api.nvim_eval(rhs) end
@@ -136,7 +142,7 @@ end
 --- @param callback fun(): string | nil
 function keymap.set(mode, key, callback)
   vim.api.nvim_buf_set_keymap(0, mode, key, '', {
-    callback = vim.schedule_wrap(callback),
+    callback = callback,
     expr = true,
     silent = true,
     noremap = true,

--- a/lua/blink/cmp/keymap.lua
+++ b/lua/blink/cmp/keymap.lua
@@ -136,7 +136,7 @@ end
 --- @param callback fun(): string | nil
 function keymap.set(mode, key, callback)
   vim.api.nvim_buf_set_keymap(0, mode, key, '', {
-    callback = callback,
+    callback = vim.schedule_wrap(callback),
     expr = true,
     silent = true,
     noremap = true,


### PR DESCRIPTION
Bumped into conflicts when trying to use completions from [supermaven](https://github.com/supermaven-inc/supermaven-nvim) (with the `TAB` keymap). Changing blink's keymaps to not be triggered as expressions saved the day — let me know if this is not the intended fix.

_error:_
![image](https://github.com/user-attachments/assets/5a1c7bf2-4ed7-425f-850f-310bc889c0a8)
