### PR TITLE
feat: highlight matched characters

### DIFF
--- a/lua/blink/cmp/windows/autocomplete.lua
+++ b/lua/blink/cmp/windows/autocomplete.lua
@@ -61,16 +61,17 @@ function autocomplete.setup()
           inputMatchIndex = string.find(current_buf_content, input:lower():gsub('%s+', ''))
         end
 
-        local inputNonWord = string.match(input, '%.(.*)')
-
         -- Making sure that symbols like dot, comma and space doesn't break it
+        local inputNonWord = string.match(input, '%.(.*)')
         if inputNonWord == nil then inputNonWord = string.match(input, '%:(.*)') end
         if inputNonWord == nil then inputNonWord = string.match(input, '[^%s+]+(.*)') end
+
+        -- Break out if we got nothing to match at all
         if inputMatchIndex == nil then
           if inputNonWord == nil or inputNonWord == '' then return false end
         end
 
-        -- skip to next section of the label e.g. if input is "net.buddy", it will match "buddy" instead
+        -- Skip to next section of the label e.g. if input is "net.buddy", it will match "buddy" instead
         if inputMatchIndex == nil and inputNonWord ~= nil then
           if string.match(inputNonWord, '.') then
             input = inputNonWord
@@ -78,11 +79,11 @@ function autocomplete.setup()
           end
         end
 
-        -- only highlight if we have a match
+        -- Only highlight if we have a match
         if inputMatchIndex then
           vim.api.nvim_buf_set_extmark(buf, config.highlight.ns, i, inputMatchIndex - 1, {
             end_row = i,
-            end_col = string.len(string.sub(input, autocomplete.context.bounds.start_col)) + inputMatchIndex - 1,
+            end_col = string.len(string.sub(input, input_start_col)) + inputMatchIndex - 1,
             hl_group = 'BlinkCmpLabelMatch',
             hl_mode = 'combine',
             ephemeral = true,

--- a/lua/blink/cmp/windows/lib/render.lua
+++ b/lua/blink/cmp/windows/lib/render.lua
@@ -31,6 +31,7 @@ end
 --- @param rendered blink.cmp.RenderedComponentTree
 function renderer.draw_highlights(rendered, bufnr, ns, line_number)
   for _, highlight in ipairs(rendered.highlights) do
+    if highlight.group == "BlinkCmpLabel" then return end
     vim.api.nvim_buf_set_extmark(bufnr, ns, line_number, highlight.start - 1, {
       end_col = highlight.stop - 1,
       hl_group = highlight.group,


### PR DESCRIPTION
Fixes https://github.com/Saghen/blink.cmp/issues/174 and https://github.com/scottmckendry/cyberdream.nvim/issues/144 

This includes case-insensitive search on the label, and if a match is found, it will add the highlight group.

How?
- Loop through the autocompletion items
- Match current typed character with current cmp item
- Handle edge cases (dots, spaces, colon)
- Check if we have any match and highlight if we do otherwise don't do anything

Tested mostly with java and react(tsx) files so I can't be sure it works well in other languages.

FYI i'm no neovim/lua expert, so you're warned against ugly code :) 

Examples
<img width="1056" alt="Screenshot 2024-10-31 at 12 00 42" src="https://github.com/user-attachments/assets/b92bb280-66da-45f4-a8d6-6e3bd979899b">
<img width="1048" alt="Screenshot 2024-10-31 at 12 00 48" src="https://github.com/user-attachments/assets/dbeef94b-7509-4088-a070-a3da0f8d0f99">
<img width="1041" alt="Screenshot 2024-10-31 at 12 00 59" src="https://github.com/user-attachments/assets/e7f9615c-276c-458f-8012-e41daccbeedf">
<img width="959" alt="Screenshot 2024-10-31 at 12 01 06" src="https://github.com/user-attachments/assets/6fd7d6cb-5d30-4e8a-835a-1e4d70fd7e8c">
<img width="1051" alt="Screenshot 2024-10-31 at 12 01 42" src="https://github.com/user-attachments/assets/a528c144-8912-48ad-9ab3-1b3667bc5207">
