### PR TITLE
feat: allow merging of keymap preset with custom keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,10 +239,6 @@ MiniDeps.add({
   --
   --   ['<C-b>'] = { 'scroll_documentation_up', 'fallback' },
   --   ['<C-f>'] = { 'scroll_documentation_down', 'fallback' },
-  --
-  -- available commands:
-  --   show, hide, accept, select_and_accept, select_prev, select_next, show_documentation, hide_documentation,
-  --   scroll_documentation_up, scroll_documentation_down, snippet_forward, snippet_backward, fallback
   keymap = 'default',
 
   accept = {

--- a/README.md
+++ b/README.md
@@ -160,10 +160,27 @@ MiniDeps.add({
 
 ```lua
 {
-  -- the keymap may be a preset ('default' | 'super-tab') OR a table of keys => command[]
-  -- when defining your own, no keybinds will be assigned automatically.
-  -- you may pass a function in the command array where returning true 
-  -- will prevent the next command from running
+  -- The keymap can be:
+  --   - A preset ('default' | 'super-tab')
+  --   - A table of keys => command[]
+  --   - A table that includes a 'preset' key and custom key mappings
+  --
+  -- When specifying 'preset' in the keymap table, the custom key mappings are merged with the preset,
+  -- and any conflicting keys will overwrite the preset mappings.
+  --
+  -- Example:
+  --
+  -- keymap = {
+  --   preset = 'default',
+  --   ['<cr>'] = { 'select_and_accept', 'fallback' },
+  -- },
+  --
+  -- In this example, the 'default' preset is used, and the `<cr>` key mapping is added or overwrites the existing one from the preset.
+  -- When defining your own keymaps without a preset, no keybinds will be assigned automatically.
+  --
+  -- Available commands:
+  --   show, hide, accept, select_and_accept, select_prev, select_next, show_documentation, hide_documentation,
+  --   scroll_documentation_up, scroll_documentation_down, snippet_forward, snippet_backward, fallback
   --
   -- "default" keymap
   --   ['<C-space>'] = { 'show', 'show_documentation', 'hide_documentation' },
@@ -203,10 +220,6 @@ MiniDeps.add({
   --
   --   ['<C-b>'] = { 'scroll_documentation_up', 'fallback' },
   --   ['<C-f>'] = { 'scroll_documentation_down', 'fallback' },
-  --
-  -- available commands:
-  --   show, hide, accept, select_and_accept, select_prev, select_next, show_documentation, hide_documentation,
-  --   scroll_documentation_up, scroll_documentation_down, snippet_forward, snippet_backward, fallback
   keymap = 'default',
 
   accept = {

--- a/lua/blink/cmp/keymap.lua
+++ b/lua/blink/cmp/keymap.lua
@@ -74,18 +74,10 @@ function keymap.setup(opts)
 
     -- Handle preset inside table
     if opts.preset then
-      local preset_keymap
-      if opts.preset == 'default' then
-        preset_keymap = default_keymap
-      elseif opts.preset == 'super-tab' then
-        preset_keymap = super_tab_keymap
-      else
-        error('Invalid blink.cmp keymap preset: ' .. opts.preset)
-      end
+      local preset_keymap = keymap.get_preset_keymap(opts.preset)
 
       -- Remove 'preset' key from opts to prevent it from being treated as a keymap
       opts.preset = nil
-
       -- Merge the preset keymap with the user-defined keymaps
       -- User-defined keymaps overwrite the preset keymaps
       mappings = vim.tbl_extend('force', preset_keymap, opts)
@@ -94,13 +86,7 @@ function keymap.setup(opts)
 
   -- handle presets
   if type(opts) == 'string' then
-    if opts == 'default' then
-      mappings = default_keymap
-    elseif opts == 'super-tab' then
-      mappings = super_tab_keymap
-    else
-      error('Invalid blink.cmp keymap preset: ' .. opts)
-    end
+    mappings = keymap.get_preset_keymap(opts)
   end
 
   -- we set on the buffer directly to avoid buffer-local keymaps (such as from autopairs)
@@ -112,6 +98,19 @@ function keymap.setup(opts)
       keymap.apply_keymap_to_current_buffer(mappings)
     end,
   })
+end
+
+--- Gets the preset keymap for the given preset name
+--- @param preset_name string
+--- @return table
+function keymap.get_preset_keymap(preset_name)
+  if preset_name == 'default' then
+    return default_keymap
+  elseif preset_name == 'super-tab' then
+    return super_tab_keymap
+  else
+    error('Invalid blink.cmp keymap preset: ' .. preset_name)
+  end
 end
 
 --- Applies the keymaps to the current buffer

--- a/lua/blink/cmp/keymap.lua
+++ b/lua/blink/cmp/keymap.lua
@@ -71,6 +71,25 @@ function keymap.setup(opts)
         error('The blink.cmp keymap recently got reworked. Please see the README for the updated configuration')
       end
     end
+
+    -- Handle preset inside table
+    if opts.preset then
+      local preset_keymap
+      if opts.preset == 'default' then
+        preset_keymap = default_keymap
+      elseif opts.preset == 'super-tab' then
+        preset_keymap = super_tab_keymap
+      else
+        error('Invalid blink.cmp keymap preset: ' .. opts.preset)
+      end
+
+      -- Remove 'preset' key from opts to prevent it from being treated as a keymap
+      opts.preset = nil
+
+      -- Merge the preset keymap with the user-defined keymaps
+      -- User-defined keymaps overwrite the preset keymaps
+      mappings = vim.tbl_extend('force', preset_keymap, opts)
+    end
   end
 
   -- handle presets


### PR DESCRIPTION
This PR adds the ability to merge a custom keymap with one of the keymap presets.
This is achieved by

1. Extending the `keymap` configuration with a `preset` key which specifies which preset to use
2. Using `vim.tbl_extend` to then merge the preset with the custom keymap

Example:
```lua
keymap = {
  preset = 'default',
  ["<cr>"] = { "select_and_accept", "fallback" },
},
```