### PR TITLE
fix(documentation): better docs

### DIFF
--- a/lua/blink/cmp/windows/documentation.lua
+++ b/lua/blink/cmp/windows/documentation.lua
@@ -111,7 +111,7 @@ function docs.update_position()
     or config.direction_priority.autocomplete_south
 
   -- remove the direction priority of the signature window if it's open
-  if signature.win:is_open() then
+  if signature.win and signature.win:is_open() then
     direction_priority = vim.tbl_filter(
       function(dir) return dir ~= (autocomplete_win_is_up and 's' or 'n') end,
       direction_priority

--- a/lua/blink/cmp/windows/lib/docs.lua
+++ b/lua/blink/cmp/windows/lib/docs.lua
@@ -17,7 +17,7 @@ function docs.render_detail_and_documentation(bufnr, detail, documentation, max_
     end
   end
 
-  -- don't show the detail if it's the same as the documentation
+  -- don't show the detail if it's part of the documentation
   local detail_str = table.concat(detail_lines, '\n')
   local doc_str = table.concat(doc_lines, '\n')
   if doc_str:find(detail_str, 1, true) then

--- a/lua/blink/cmp/windows/lib/docs.lua
+++ b/lua/blink/cmp/windows/lib/docs.lua
@@ -17,6 +17,13 @@ function docs.render_detail_and_documentation(bufnr, detail, documentation, max_
     end
   end
 
+  -- don't show the detail if it's the same as the documentation
+  local detail_str = table.concat(detail_lines, '\n')
+  local doc_str = table.concat(doc_lines, '\n')
+  if doc_str:find(detail_str, 1, true) then
+    detail_lines = {}
+  end
+
   local combined_lines = vim.list_extend({}, detail_lines)
   -- add a blank line for the --- separator
   if #detail_lines > 0 and #doc_lines > 0 then table.insert(combined_lines, '') end


### PR DESCRIPTION
Two things in this PR:
- bug fix where signature.win could be `nil`
- don't show the item detail when it's part of the documentation.

# Before
![image](https://github.com/user-attachments/assets/d83afe6f-182b-4dda-874e-ab53024810fc)

# After
![image](https://github.com/user-attachments/assets/c4722e78-3d86-468a-84b0-acbce83d3a7e)
