### PR TITLE
feat: add winblend option for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ MiniDeps.add({
 {
   -- the keymap may be a preset ('default' | 'super-tab') OR a table of keys => command[]
   -- when defining your own, no keybinds will be assigned automatically.
-  -- you may pass a function in the command array where returning true 
+  -- you may pass a function in the command array where returning true
   -- will prevent the next command from running
   --
   -- "default" keymap
@@ -297,7 +297,7 @@ MiniDeps.add({
 
   sources = {
     -- list of enabled providers
-    completion = { 
+    completion = {
       enabled_providers = { 'lsp', 'path', 'snippets', 'buffer' },
     }
 
@@ -358,6 +358,7 @@ MiniDeps.add({
       min_width = 15,
       max_height = 10,
       border = 'none',
+      winblend = 0,
       winhighlight = 'Normal:BlinkCmpMenu,FloatBorder:BlinkCmpMenuBorder,CursorLine:BlinkCmpMenuSelection,Search:None',
       -- keep the cursor X lines away from the top/bottom of the window
       scrolloff = 2,
@@ -390,6 +391,7 @@ MiniDeps.add({
       max_width = 60,
       max_height = 20,
       border = 'padded',
+      winblend = 0,
       winhighlight = 'Normal:BlinkCmpDoc,FloatBorder:BlinkCmpDocBorder,CursorLine:BlinkCmpDocCursorLine,Search:None',
       -- which directions to show the documentation window,
       -- for each of the possible autocomplete window directions,
@@ -408,6 +410,7 @@ MiniDeps.add({
       max_width = 100,
       max_height = 10,
       border = 'padded',
+      winblend = 0,
       winhighlight = 'Normal:BlinkCmpSignatureHelp,FloatBorder:BlinkCmpSignatureHelpBorder',
     },
     ghost_text = {

--- a/lua/blink/cmp/config.lua
+++ b/lua/blink/cmp/config.lua
@@ -115,6 +115,7 @@
 --- @field direction_priority? ("n" | "s")[]
 --- @field auto_show? boolean
 --- @field selection? "preselect" | "manual" | "auto_insert"
+--- @field winblend? number
 --- @field winhighlight? string
 --- @field scrolloff? number
 --- @field draw? 'simple' | 'reversed' | 'minimal' | function(blink.cmp.CompletionRenderContext): blink.cmp.Component[]
@@ -140,6 +141,7 @@
 --- @field auto_show? boolean
 --- @field auto_show_delay_ms? number Delay before showing the documentation window
 --- @field update_delay_ms? number Delay before updating the documentation window
+--- @field winblend? number
 --- @field winhighlight? string
 
 --- @class blink.cmp.SignatureHelpConfig
@@ -147,6 +149,7 @@
 --- @field max_width? number
 --- @field max_height? number
 --- @field border? blink.cmp.WindowBorder
+--- @field winblend? number
 --- @field winhighlight? string
 
 --- @class GhostTextConfig
@@ -338,6 +341,7 @@ local config = {
       min_width = 15,
       max_height = 10,
       border = 'none',
+      winblend = 0,
       winhighlight = 'Normal:BlinkCmpMenu,FloatBorder:BlinkCmpMenuBorder,CursorLine:BlinkCmpMenuSelection,Search:None',
       -- keep the cursor X lines away from the top/bottom of the window
       scrolloff = 2,
@@ -372,6 +376,7 @@ local config = {
       max_width = 60,
       max_height = 20,
       border = 'padded',
+      winblend = 0,
       winhighlight = 'Normal:BlinkCmpDoc,FloatBorder:BlinkCmpDocBorder,CursorLine:BlinkCmpDocCursorLine,Search:None',
       -- which directions to show the documentation window,
       -- for each of the possible autocomplete window directions,
@@ -390,6 +395,7 @@ local config = {
       max_width = 100,
       max_height = 10,
       border = 'padded',
+      winblend = 0,
       winhighlight = 'Normal:BlinkCmpSignatureHelp,FloatBorder:BlinkCmpSignatureHelpBorder',
     },
     ghost_text = {

--- a/lua/blink/cmp/windows/autocomplete.lua
+++ b/lua/blink/cmp/windows/autocomplete.lua
@@ -34,6 +34,7 @@ function autocomplete.setup()
     min_width = autocmp_config.min_width,
     max_height = autocmp_config.max_height,
     border = autocmp_config.border,
+    winblend = autocmp_config.winblend,
     winhighlight = autocmp_config.winhighlight,
     cursorline = false,
     scrolloff = autocmp_config.scrolloff,

--- a/lua/blink/cmp/windows/documentation.lua
+++ b/lua/blink/cmp/windows/documentation.lua
@@ -9,6 +9,7 @@ function docs.setup()
     max_width = config.max_width,
     max_height = config.max_height,
     border = config.border,
+    winblend = config.winblend,
     winhighlight = config.winhighlight,
     wrap = true,
     filetype = 'markdown',

--- a/lua/blink/cmp/windows/lib/init.lua
+++ b/lua/blink/cmp/windows/lib/init.lua
@@ -28,6 +28,7 @@ function win.new(config)
     border = config.border or 'none',
     wrap = config.wrap or false,
     filetype = config.filetype or 'cmp_menu',
+    winblend = config.winblend or vim.o.pumblend,
     winhighlight = config.winhighlight or 'Normal:NormalFloat,FloatBorder:NormalFloat',
     scrolloff = config.scrolloff or 0,
   }
@@ -72,6 +73,7 @@ function win:open()
     zindex = 1001,
     border = self.config.border == 'padded' and { ' ', '', '', ' ', '', '', ' ', ' ' } or self.config.border,
   })
+  vim.api.nvim_set_option_value('winblend', self.config.winblend, { win = self.id })
   vim.api.nvim_set_option_value('winhighlight', self.config.winhighlight, { win = self.id })
   vim.api.nvim_set_option_value('wrap', self.config.wrap, { win = self.id })
   vim.api.nvim_set_option_value('foldenable', false, { win = self.id })

--- a/lua/blink/cmp/windows/lib/init.lua
+++ b/lua/blink/cmp/windows/lib/init.lua
@@ -28,7 +28,7 @@ function win.new(config)
     border = config.border or 'none',
     wrap = config.wrap or false,
     filetype = config.filetype or 'cmp_menu',
-    winblend = config.winblend or vim.o.pumblend,
+    winblend = config.winblend or 0,
     winhighlight = config.winhighlight or 'Normal:NormalFloat,FloatBorder:NormalFloat',
     scrolloff = config.scrolloff or 0,
   }

--- a/lua/blink/cmp/windows/signature.lua
+++ b/lua/blink/cmp/windows/signature.lua
@@ -9,6 +9,7 @@ function signature.setup()
     max_width = config.max_width,
     max_height = config.max_height,
     border = config.border,
+    winblend = config.winblend,
     winhighlight = config.winhighlight,
     wrap = true,
     filetype = 'markdown',


### PR DESCRIPTION
This adds the `:h 'winblend'` option to creating windows so we can have psuedo-transparent completion windows.

![image](https://github.com/user-attachments/assets/e2f60f18-a370-48ad-8e5a-0060267aaa4c)

I think a nice default for the autocompletion winblend config would be `:h 'pumblend'`, but I don't see other options falling back to similar vim options (pumwidth/pumheight) so i've left it at 0.