### PR TITLE
fix: offset window alignment to match typed text

### DIFF
--- a/lua/blink/cmp/windows/autocomplete.lua
+++ b/lua/blink/cmp/windows/autocomplete.lua
@@ -207,7 +207,7 @@ function autocomplete.update_position(context)
   vim.api.nvim_win_set_config(winnr, {
     relative = 'cursor',
     row = row,
-    col = col - (vim.tbl_contains({ 'minimal', 'reversed' }, autocmp_config.draw) and 1 or 0),
+    col = col - (vim.tbl_contains({ 'minimal', 'reversed' }, autocmp_config.draw) and 2 or 0),
   })
   vim.api.nvim_win_set_height(winnr, pos.height)
 


### PR DESCRIPTION
Window alignment was off by one character:

![image](https://github.com/user-attachments/assets/b1feda4d-1457-48b5-84d3-1e3148f6801a)

Here we increase it to match typed text

![image](https://github.com/user-attachments/assets/0e96d215-0423-4086-8948-a93642959d4e)

