### PR TITLE
fix(types): allow resolving empty response from blink.cmd.Source

### DIFF
--- a/lua/blink/cmp/sources/lib/types.lua
+++ b/lua/blink/cmp/sources/lib/types.lua
@@ -12,7 +12,7 @@
 --- @field new fun(config: blink.cmp.SourceProviderConfig): blink.cmp.Source
 --- @field enabled? fun(self: blink.cmp.Source, context: blink.cmp.Context): boolean
 --- @field get_trigger_characters? (fun(self: blink.cmp.Source): string[]) | nil
---- @field get_completions? fun(self: blink.cmp.Source, context: blink.cmp.Context, callback: fun(response: blink.cmp.CompletionResponse)): (fun(): nil) | nil
+--- @field get_completions? fun(self: blink.cmp.Source, context: blink.cmp.Context, callback: fun(response: blink.cmp.CompletionResponse | nil)): (fun(): nil) | nil
 --- @field filter_completions? (fun(self: blink.cmp.Source, response: blink.cmp.CompletionResponse): blink.cmp.CompletionItem[]) | nil
 --- @field should_show_completions? (fun(self: blink.cmp.Source, context: blink.cmp.Context, response: blink.cmp.CompletionResponse): boolean) | nil
 --- @field resolve? (fun(self: blink.cmp.Source, item: blink.cmp.CompletionItem, callback: fun(resolved_item: lsp.CompletionItem | nil)): ((fun(): nil) | nil)) | nil


### PR DESCRIPTION
Right now it looks like the code does nil checks perfectly, and there is no actual issue in resolving a nil value. However, the types still specify that a response must always be present.