### PR TITLE
fix: completion label details containing newline characters

### DIFF
--- a/lua/blink/cmp/windows/autocomplete.lua
+++ b/lua/blink/cmp/windows/autocomplete.lua
@@ -370,6 +370,8 @@ end
 --- @param ctx blink.cmp.CompletionRenderContext
 --- @return blink.cmp.Component[]
 function autocomplete.draw_item_simple(ctx)
+  local detail = (ctx.item.labelDetails and ctx.item.labelDetails.detail) and
+      ctx.item.labelDetails.detail:gsub('\n', '\\n') or ''
   return {
     ' ',
     {
@@ -380,7 +382,7 @@ function autocomplete.draw_item_simple(ctx)
     {
       ctx.label,
       ctx.kind == 'Snippet' and '~' or '',
-      (ctx.item.labelDetails and ctx.item.labelDetails.detail) and ctx.item.labelDetails.detail or '',
+      detail,
       fill = true,
       hl_group = ctx.deprecated and 'BlinkCmpLabelDeprecated' or 'BlinkCmpLabel',
       max_width = 80,
@@ -392,12 +394,14 @@ end
 --- @param ctx blink.cmp.CompletionRenderContext
 --- @return blink.cmp.Component[]
 function autocomplete.draw_item_reversed(ctx)
+  local detail = (ctx.item.labelDetails and ctx.item.labelDetails.detail) and
+      ctx.item.labelDetails.detail:gsub('\n', '\\n') or ''
   return {
     ' ',
     {
       ctx.label,
       ctx.kind == 'Snippet' and '~' or nil,
-      (ctx.item.labelDetails and ctx.item.labelDetails.detail) and ctx.item.labelDetails.detail or '',
+      detail,
       fill = true,
       hl_group = ctx.deprecated and 'BlinkCmpLabelDeprecated' or 'BlinkCmpLabel',
       max_width = 50,
@@ -416,12 +420,14 @@ end
 --- @param ctx blink.cmp.CompletionRenderContext
 --- @return blink.cmp.Component[]
 function autocomplete.draw_item_minimal(ctx)
+  local detail = (ctx.item.labelDetails and ctx.item.labelDetails.detail) and
+      ctx.item.labelDetails.detail:gsub('\n', '\\n') or ''
   return {
     ' ',
     {
       ctx.label,
       ctx.kind == 'Snippet' and '~' or nil,
-      (ctx.item.labelDetails and ctx.item.labelDetails.detail) and ctx.item.labelDetails.detail or '',
+      detail,
       fill = true,
       hl_group = ctx.deprecated and 'BlinkCmpLabelDeprecated' or 'BlinkCmpLabel',
       max_width = 50,

--- a/lua/blink/cmp/windows/autocomplete.lua
+++ b/lua/blink/cmp/windows/autocomplete.lua
@@ -370,8 +370,6 @@ end
 --- @param ctx blink.cmp.CompletionRenderContext
 --- @return blink.cmp.Component[]
 function autocomplete.draw_item_simple(ctx)
-  local detail = (ctx.item.labelDetails and ctx.item.labelDetails.detail) and
-      ctx.item.labelDetails.detail:gsub('\n', '\\n') or ''
   return {
     ' ',
     {
@@ -382,7 +380,7 @@ function autocomplete.draw_item_simple(ctx)
     {
       ctx.label,
       ctx.kind == 'Snippet' and '~' or '',
-      detail,
+      (ctx.item.labelDetails and ctx.item.labelDetails.detail) and ctx.item.labelDetails.detail:gsub('\n', '\\n') or '',
       fill = true,
       hl_group = ctx.deprecated and 'BlinkCmpLabelDeprecated' or 'BlinkCmpLabel',
       max_width = 80,
@@ -394,14 +392,12 @@ end
 --- @param ctx blink.cmp.CompletionRenderContext
 --- @return blink.cmp.Component[]
 function autocomplete.draw_item_reversed(ctx)
-  local detail = (ctx.item.labelDetails and ctx.item.labelDetails.detail) and
-      ctx.item.labelDetails.detail:gsub('\n', '\\n') or ''
   return {
     ' ',
     {
       ctx.label,
       ctx.kind == 'Snippet' and '~' or nil,
-      detail,
+      (ctx.item.labelDetails and ctx.item.labelDetails.detail) and ctx.item.labelDetails.detail:gsub('\n', '\\n') or '',
       fill = true,
       hl_group = ctx.deprecated and 'BlinkCmpLabelDeprecated' or 'BlinkCmpLabel',
       max_width = 50,
@@ -420,14 +416,12 @@ end
 --- @param ctx blink.cmp.CompletionRenderContext
 --- @return blink.cmp.Component[]
 function autocomplete.draw_item_minimal(ctx)
-  local detail = (ctx.item.labelDetails and ctx.item.labelDetails.detail) and
-      ctx.item.labelDetails.detail:gsub('\n', '\\n') or ''
   return {
     ' ',
     {
       ctx.label,
       ctx.kind == 'Snippet' and '~' or nil,
-      detail,
+      (ctx.item.labelDetails and ctx.item.labelDetails.detail) and ctx.item.labelDetails.detail:gsub('\n', '\\n') or '',
       fill = true,
       hl_group = ctx.deprecated and 'BlinkCmpLabelDeprecated' or 'BlinkCmpLabel',
       max_width = 50,

--- a/lua/blink/cmp/windows/autocomplete.lua
+++ b/lua/blink/cmp/windows/autocomplete.lua
@@ -1,6 +1,7 @@
 --- @class blink.cmp.CompletionRenderContext
 --- @field item blink.cmp.CompletionItem
 --- @field label string
+--- @field detail string
 --- @field kind string
 --- @field kind_icon string
 --- @field icon_gap string
@@ -324,9 +325,11 @@ function autocomplete.draw()
   for _, item in ipairs(autocomplete.items) do
     local kind = require('blink.cmp.types').CompletionItemKind[item.kind] or 'Unknown'
     local kind_icon = config.kind_icons[kind] or config.kind_icons.Field
-    -- Some LSPs can return labels with newlines.
+    -- Some LSPs can return labels and details with newlines.
     -- Escape them to avoid errors in nvim_buf_set_lines when rendering the autocomplete menu.
     local label = item.label:gsub('\n', '\\n')
+    local detail = (item.labelDetails and item.labelDetails.detail) and
+        item.labelDetails.detail:gsub('\n', '\\n') or ''
     if config.nerd_font_variant == 'normal' then label = label:gsub('…', '… ') end
 
     table.insert(
@@ -334,6 +337,7 @@ function autocomplete.draw()
       draw_fn({
         item = item,
         label = label,
+        detail = detail,
         kind = kind,
         kind_icon = kind_icon,
         icon_gap = icon_gap,
@@ -380,7 +384,7 @@ function autocomplete.draw_item_simple(ctx)
     {
       ctx.label,
       ctx.kind == 'Snippet' and '~' or '',
-      (ctx.item.labelDetails and ctx.item.labelDetails.detail) and ctx.item.labelDetails.detail:gsub('\n', '\\n') or '',
+      ctx.detail,
       fill = true,
       hl_group = ctx.deprecated and 'BlinkCmpLabelDeprecated' or 'BlinkCmpLabel',
       max_width = 80,
@@ -397,7 +401,7 @@ function autocomplete.draw_item_reversed(ctx)
     {
       ctx.label,
       ctx.kind == 'Snippet' and '~' or nil,
-      (ctx.item.labelDetails and ctx.item.labelDetails.detail) and ctx.item.labelDetails.detail:gsub('\n', '\\n') or '',
+      ctx.detail,
       fill = true,
       hl_group = ctx.deprecated and 'BlinkCmpLabelDeprecated' or 'BlinkCmpLabel',
       max_width = 50,
@@ -421,7 +425,7 @@ function autocomplete.draw_item_minimal(ctx)
     {
       ctx.label,
       ctx.kind == 'Snippet' and '~' or nil,
-      (ctx.item.labelDetails and ctx.item.labelDetails.detail) and ctx.item.labelDetails.detail:gsub('\n', '\\n') or '',
+      ctx.detail,
       fill = true,
       hl_group = ctx.deprecated and 'BlinkCmpLabelDeprecated' or 'BlinkCmpLabel',
       max_width = 50,


### PR DESCRIPTION
Just as [labels can return newlines](https://github.com/Saghen/blink.cmp/blob/v0.5.1/lua/blink/cmp/windows/autocomplete.lua#L326-L328), so too can label details.