### PR TITLE
fix: check if source is in `enabled_providers` before calling source:enabled

### DIFF
--- a/lua/blink/cmp/sources/lib/init.lua
+++ b/lua/blink/cmp/sources/lib/init.lua
@@ -59,7 +59,7 @@ function sources.get_enabled_providers(context)
   --- @type table<string, blink.cmp.SourceProvider>
   local providers = {}
   for key, provider in pairs(sources.providers) do
-    if provider:enabled(context) and vim.tbl_contains(mode_providers, key) then providers[key] = provider end
+    if vim.tbl_contains(mode_providers, key) and provider:enabled(context) then providers[key] = provider end
   end
   return providers
 end


### PR DESCRIPTION
This avoids calling source:enabled if the source is not enabled, reducing the possibility for misconfigured, disabled providers to cause problems.

I ran into this issue in `blink.compat` when I removed a proxied provider from `enabled_providers` and removed its plugin, but left its provider config in the `providers` table.