### PR TITLE
fix: prevent index out of bounds in get_code_block_range

### DIFF
--- a/lua/blink/cmp/windows/lib/docs.lua
+++ b/lua/blink/cmp/windows/lib/docs.lua
@@ -154,6 +154,7 @@ end
 --- @param row number
 --- @return number?, number?
 function docs.get_code_block_range(lines, row)
+  if row < 1 or row > #lines then return end
   -- get the start of the code block
   local code_block_start = nil
   for i = 1, row do


### PR DESCRIPTION
Add bounds checking to prevent nil indexing when row parameter is outsidethe valid range

Issue #270 