### PR TITLE
fix: download mechanism works with GIT_DIR and GIT_WORK_TREE set

### DIFF
--- a/lua/blink/cmp/fuzzy/download.lua
+++ b/lua/blink/cmp/fuzzy/download.lua
@@ -10,6 +10,7 @@ function download.get_lib_extension()
 end
 
 local root_dir = debug.getinfo(1).source:match('@?(.*/)')
+local repo_dir = vim.fs.root(root_dir, '.git')
 download.lib_path = root_dir .. '../../../../target/release/libblink_cmp_fuzzy' .. download.get_lib_extension()
 local version_path = root_dir .. '../../../../target/release/version.txt'
 
@@ -71,7 +72,7 @@ end
 
 --- @param cb fun(err: string | nil, tag: string | nil)
 function download.get_git_tag(cb)
-  vim.system({ 'git', 'describe', '--tags', '--exact-match' }, { cwd = root_dir }, function(out)
+  vim.system({ 'git', '--git-dir', vim.fs.joinpath(repo_dir, '.git'), "--work-tree", repo_dir, 'describe', '--tags', '--exact-match' }, { cwd = root_dir }, function(out)
     if out.code == 128 then return cb() end
     if out.code ~= 0 then
       return cb('While getting git tag, git exited with code ' .. out.code .. ': ' .. out.stderr)


### PR DESCRIPTION
Explicitly provide `--git-dir` and `--work-tree` in git commands.

Issue #274 