### PR TITLE
refactor: remove unused trigger.get_current_word function

### DIFF
--- a/lua/blink/cmp/trigger/completion.lua
+++ b/lua/blink/cmp/trigger/completion.lua
@@ -221,13 +221,6 @@ function trigger.within_query_bounds(cursor)
   return row == bounds.line_number and col >= bounds.start_col and col <= bounds.end_col
 end
 
----@return string?
-function trigger.get_current_word()
-  if not trigger.context then return end
-
-  local bounds = trigger.context.bounds
-  return trigger.context.line:sub(bounds.start_col, bounds.end_col)
-end
 --- Moves forward and backwards around the cursor looking for word boundaries
 --- @param regex string
 --- @return blink.cmp.ContextBounds


### PR DESCRIPTION
The last usage of this function was removed in
https://github.com/Saghen/blink.cmp/commit/7f5a3d9a820125e7da0a1816efaddb84d47a7f18

- fix: always hide window on accept
- (Tue Oct 22 12:23:33 2024 -0400)