### PR TITLE
fix: make ghost-text extmark with pcall

### DIFF
--- a/lua/blink/cmp/windows/ghost-text.lua
+++ b/lua/blink/cmp/windows/ghost-text.lua
@@ -86,13 +86,19 @@ function ghost_text.draw_preview(bufnr)
     text_edit.range['end'].character,
   }
 
-  ghost_text.extmark_id = vim.api.nvim_buf_set_extmark(bufnr, config.highlight.ns, cursor_pos[1], cursor_pos[2], {
-    id = ghost_text.extmark_id,
-    virt_text_pos = 'inline',
-    virt_text = { { display_lines[1], 'BlinkCmpGhostText' } },
-    virt_lines = virt_lines,
-    hl_mode = 'combine',
-  })
+  local success, id = pcall(
+    function()
+      return vim.api.nvim_buf_set_extmark(bufnr, config.highlight.ns, cursor_pos[1], cursor_pos[2], {
+        id = ghost_text.extmark_id,
+        virt_text_pos = 'inline',
+        virt_text = { { display_lines[1], 'BlinkCmpGhostText' } },
+        virt_lines = virt_lines,
+        hl_mode = 'combine',
+      })
+    end
+  )
+
+  if success then ghost_text.extmark_id = id end
 end
 
 return ghost_text

--- a/lua/blink/cmp/windows/ghost-text.lua
+++ b/lua/blink/cmp/windows/ghost-text.lua
@@ -17,8 +17,7 @@ local ghost_text = {
 --- @param textEdit lsp.TextEdit
 local function get_still_untyped_text(textEdit)
   local type_text_length = textEdit.range['end'].character - textEdit.range.start.character
-  local result = textEdit.newText:sub(type_text_length + 1)
-  return result
+  return textEdit.newText:sub(type_text_length + 1)
 end
 
 function ghost_text.setup()
@@ -86,19 +85,13 @@ function ghost_text.draw_preview(bufnr)
     text_edit.range['end'].character,
   }
 
-  local success, id = pcall(
-    function()
-      return vim.api.nvim_buf_set_extmark(bufnr, config.highlight.ns, cursor_pos[1], cursor_pos[2], {
-        id = ghost_text.extmark_id,
-        virt_text_pos = 'inline',
-        virt_text = { { display_lines[1], 'BlinkCmpGhostText' } },
-        virt_lines = virt_lines,
-        hl_mode = 'combine',
-      })
-    end
-  )
-
-  if success then ghost_text.extmark_id = id end
+  ghost_text.extmark_id = vim.api.nvim_buf_set_extmark(bufnr, config.highlight.ns, cursor_pos[1], cursor_pos[2], {
+    id = ghost_text.extmark_id,
+    virt_text_pos = 'inline',
+    virt_text = { { display_lines[1], 'BlinkCmpGhostText' } },
+    virt_lines = virt_lines,
+    hl_mode = 'combine',
+  })
 end
 
 return ghost_text


### PR DESCRIPTION
Fixes #257 

This issue also happens to me in a large Rust project where the LSP is slow. It tries to show a slightly outdated text edit and errors, but shows the correct text edit instantly after. So maybe this could also be fixed with better scheduling.

Now I just make the extmark with pcall to not render outdated ghost-texts and cause errors. Nvim-cmp also does this.