### PR TITLE
fix: signature help now highlights the right parameter

### DIFF
--- a/lua/blink/cmp/windows/signature.lua
+++ b/lua/blink/cmp/windows/signature.lua
@@ -105,7 +105,6 @@ function signature.scroll_down(amount)
   vim.api.nvim_win_set_cursor(signature.win:get_win(), { desired_line, 0 })
 end
 
---- @param context blink.cmp.SignatureHelpContext
 function signature.update_position()
   local win = signature.win
   if not win:is_open() then return end

--- a/lua/blink/cmp/windows/signature.lua
+++ b/lua/blink/cmp/windows/signature.lua
@@ -63,20 +63,18 @@ function signature.open_with_signature_help(context, signature_help)
     sources.get_signature_help_trigger_characters().trigger_characters
   )
   if active_highlight ~= nil then
-    local start_region, end_region
-    if vim.version.gt(vim.version(), {0, 10, 0}) then
+    local start_region = active_highlight[1]
+    local end_region = active_highlight[2]
+    if vim.version.gt(vim.version(), {0, 10, 2}) then
             start_region = active_highlight[2]
             end_region = active_highlight[4]
-    else
-            start_region = active_highlight[1]
-            end_region = active_highlight[2]
     end
     vim.api.nvim_buf_add_highlight(
       signature.win:get_buf(),
       require('blink.cmp.config').highlight.ns,
       'BlinkCmpSignatureHelpActiveParameter',
       0,
-            start_region, end_region
+      start_region, end_region
     )
   end
 

--- a/lua/blink/cmp/windows/signature.lua
+++ b/lua/blink/cmp/windows/signature.lua
@@ -63,18 +63,25 @@ function signature.open_with_signature_help(context, signature_help)
     sources.get_signature_help_trigger_characters().trigger_characters
   )
   if active_highlight ~= nil then
+    local start_region, end_region
+    if vim.version.gt(vim.version(), {0, 10, 0}) then
+            start_region = active_highlight[2]
+            end_region = active_highlight[4]
+    else
+            start_region = active_highlight[1]
+            end_region = active_highlight[2]
+    end
     vim.api.nvim_buf_add_highlight(
       signature.win:get_buf(),
       require('blink.cmp.config').highlight.ns,
       'BlinkCmpSignatureHelpActiveParameter',
       0,
-      active_highlight[1],
-      active_highlight[2]
+            start_region, end_region
     )
   end
 
   signature.win:open()
-  signature.update_position(context)
+  signature.update_position()
 end
 
 function signature.close()

--- a/lua/blink/cmp/windows/signature.lua
+++ b/lua/blink/cmp/windows/signature.lua
@@ -65,16 +65,17 @@ function signature.open_with_signature_help(context, signature_help)
   if active_highlight ~= nil then
     local start_region = active_highlight[1]
     local end_region = active_highlight[2]
-    if vim.version.gt(vim.version(), {0, 10, 2}) then
-            start_region = active_highlight[2]
-            end_region = active_highlight[4]
+    if vim.fn.has('nvim-0.11.0') == 1 then
+      start_region = active_highlight[2]
+      end_region = active_highlight[4]
     end
     vim.api.nvim_buf_add_highlight(
       signature.win:get_buf(),
       require('blink.cmp.config').highlight.ns,
       'BlinkCmpSignatureHelpActiveParameter',
       0,
-      start_region, end_region
+      start_region,
+      end_region
     )
   end
 


### PR DESCRIPTION
Currently, signature help does not highlight the current parameter but always starts from the second character (see image)
![image_2024-11-08_11-49-02](https://github.com/user-attachments/assets/63694e9d-48ef-41e5-9bec-8e4fed899bae)


By using the right indexes, this gets fixed:
![image_2024-11-08_11-50-12](https://github.com/user-attachments/assets/5ca030da-8211-4789-8abd-9637b2c672a6)
