### PR TITLE
fix: handle gap for empty text

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,33 +429,30 @@ MiniDeps.add({
         components = {
           kind_icon = {
             ellipsis = false,
-            text = function(ctx) return ctx.kind_icon .. ' ' end,
+            text = function(ctx) return ctx.kind_icon end,
             highlight = function(ctx) return 'BlinkCmpKind' .. ctx.kind end,
           },
 
           kind = {
             ellipsis = false,
-            text = function(ctx) return ctx.kind .. ' ' end,
+            width = { fill = true },
+            text = function(ctx) return ctx.kind end,
             highlight = function(ctx) return 'BlinkCmpKind' .. ctx.kind end,
           },
 
           label = {
             width = { fill = true, max = 60 },
-            text = function(ctx) return ctx.label .. (ctx.label_detail or '') end,
+            text = function(ctx) return ctx.label .. ctx.label_detail end,
             highlight = function(ctx)
               -- label and label details
               local highlights = {
                 { 0, #ctx.label, group = ctx.deprecated and 'BlinkCmpLabelDeprecated' or 'BlinkCmpLabel' },
               }
-              if ctx.label_detail then
-                table.insert(highlights, { #ctx.label, #ctx.label + #ctx.label_detail, group = 'BlinkCmpLabelDetail' })
-              end
+              table.insert(highlights, { #ctx.label, #ctx.label + #ctx.label_detail, group = 'BlinkCmpLabelDetail' })
 
               -- characters matched on the label by the fuzzy matcher
-              if ctx.label_matched_indices ~= nil then
-                for _, idx in ipairs(ctx.label_matched_indices) do
-                  table.insert(highlights, { idx, idx + 1, group = 'BlinkCmpLabelMatch' })
-                end
+              for _, idx in ipairs(ctx.label_matched_indices) do
+                table.insert(highlights, { idx, idx + 1, group = 'BlinkCmpLabelMatch' })
               end
 
               return highlights
@@ -464,7 +461,7 @@ MiniDeps.add({
 
           label_description = {
             width = { max = 30 },
-            text = function(ctx) return ctx.label_description or '' end,
+            text = function(ctx) return ctx.label_description end,
             highlight = 'BlinkCmpLabelDescription',
           },
         },

--- a/README.md
+++ b/README.md
@@ -448,7 +448,9 @@ MiniDeps.add({
               local highlights = {
                 { 0, #ctx.label, group = ctx.deprecated and 'BlinkCmpLabelDeprecated' or 'BlinkCmpLabel' },
               }
-              table.insert(highlights, { #ctx.label, #ctx.label + #ctx.label_detail, group = 'BlinkCmpLabelDetail' })
+              if ctx.label_detail then
+                table.insert(highlights, { #ctx.label, #ctx.label + #ctx.label_detail, group = 'BlinkCmpLabelDetail' })
+              end
 
               -- characters matched on the label by the fuzzy matcher
               for _, idx in ipairs(ctx.label_matched_indices) do

--- a/lua/blink/cmp/config.lua
+++ b/lua/blink/cmp/config.lua
@@ -270,7 +270,7 @@ local config = {
         timeout_ms = 400,
       },
     },
-    expand_snippet = vim.snippet.expand
+    expand_snippet = vim.snippet.expand,
   },
 
   trigger = {
@@ -407,34 +407,31 @@ local config = {
         components = {
           kind_icon = {
             ellipsis = false,
-            text = function(ctx) return ctx.kind_icon .. ' ' end,
+            text = function(ctx) return ctx.kind_icon end,
             highlight = function(ctx) return 'BlinkCmpKind' .. ctx.kind end,
           },
 
           kind = {
             ellipsis = false,
-            text = function(ctx) return ctx.kind .. ' ' end,
+            width = { fill = true },
+            text = function(ctx) return ctx.kind end,
             highlight = function(ctx) return 'BlinkCmpKind' .. ctx.kind end,
           },
 
           label = {
             width = { fill = true, max = 60 },
-            text = function(ctx) return ctx.label .. (ctx.label_detail or '') end,
+            text = function(ctx) return ctx.label .. ctx.label_detail end,
             highlight = function(ctx)
               -- label and label details
               local label = ctx.label
               local highlights = {
                 { 0, #label, group = ctx.deprecated and 'BlinkCmpLabelDeprecated' or 'BlinkCmpLabel' },
               }
-              if ctx.label_detail then
-                table.insert(highlights, { #label, #label + #ctx.label_detail, group = 'BlinkCmpLabelDetail' })
-              end
+              table.insert(highlights, { #label, #label + #ctx.label_detail, group = 'BlinkCmpLabelDetail' })
 
               -- characters matched on the label by the fuzzy matcher
-              if ctx.label_matched_indices ~= nil then
-                for _, idx in ipairs(ctx.label_matched_indices) do
-                  table.insert(highlights, { idx, idx + 1, group = 'BlinkCmpLabelMatch' })
-                end
+              for _, idx in ipairs(ctx.label_matched_indices) do
+                table.insert(highlights, { idx, idx + 1, group = 'BlinkCmpLabelMatch' })
               end
 
               return highlights
@@ -443,7 +440,7 @@ local config = {
 
           label_description = {
             width = { max = 30 },
-            text = function(ctx) return ctx.label_description or '' end,
+            text = function(ctx) return ctx.label_description end,
             highlight = 'BlinkCmpLabelDescription',
           },
         },

--- a/lua/blink/cmp/config.lua
+++ b/lua/blink/cmp/config.lua
@@ -427,7 +427,9 @@ local config = {
               local highlights = {
                 { 0, #label, group = ctx.deprecated and 'BlinkCmpLabelDeprecated' or 'BlinkCmpLabel' },
               }
-              table.insert(highlights, { #label, #label + #ctx.label_detail, group = 'BlinkCmpLabelDetail' })
+              if ctx.label_detail then
+                table.insert(highlights, { #label, #label + #ctx.label_detail, group = 'BlinkCmpLabelDetail' })
+              end
 
               -- characters matched on the label by the fuzzy matcher
               for _, idx in ipairs(ctx.label_matched_indices) do

--- a/lua/blink/cmp/utils.lua
+++ b/lua/blink/cmp/utils.lua
@@ -83,7 +83,7 @@ function utils.get_regex_around_cursor(range, regex, exclude_from_prefix_regex)
   return { start_col = start_col, length = length }
 end
 
---- @param ctx blink.cmp.CompletionRenderContext
+--- @param ctx blink.cmp.DrawItemContext
 --- @return string|nil
 function utils.try_get_tailwind_hl(ctx)
   local doc = ctx.item.documentation
@@ -91,9 +91,7 @@ function utils.try_get_tailwind_hl(ctx)
     local content = type(doc) == 'string' and doc or doc.value
     if ctx.kind == 'Color' and content and content:match('^#%x%x%x%x%x%x$') then
       local hl_name = 'HexColor' .. content:sub(2)
-      if #vim.api.nvim_get_hl(0, { name = hl_name }) == 0 then
-        vim.api.nvim_set_hl(0, hl_name, { fg = content })
-      end
+      if #vim.api.nvim_get_hl(0, { name = hl_name }) == 0 then vim.api.nvim_set_hl(0, hl_name, { fg = content }) end
       return hl_name
     end
   end

--- a/lua/blink/cmp/windows/render/column.lua
+++ b/lua/blink/cmp/windows/render/column.lua
@@ -48,7 +48,7 @@ function column:render(ctxs)
   for _, max_component_width in ipairs(max_component_widths) do
     if max_component_width > 0 then column_width = column_width + max_component_width + self.gap end
   end
-  column_width = column_width - self.gap
+  column_width = math.max(column_width - self.gap, 0)
 
   --- find the component that will fill the empty space
   local fill_idx = -1
@@ -91,8 +91,8 @@ function column:get_line_highlights(line_idx)
   local offset = 0
   local highlights = {}
 
-  for idx, component in ipairs(self.components) do
-    local text = self.lines[line_idx][idx]
+  for component_idx, component in ipairs(self.components) do
+    local text = self.lines[line_idx][component_idx]
     if #text > 0 then
       local column_highlights = type(component.highlight) == 'function' and component.highlight(ctx, text)
         or component.highlight

--- a/lua/blink/cmp/windows/render/column.lua
+++ b/lua/blink/cmp/windows/render/column.lua
@@ -3,11 +3,11 @@
 --- @field gap number
 --- @field lines string[][]
 --- @field width number
---- @field ctxs blink.cmp.CompletionRenderContext[]
+--- @field ctxs blink.cmp.DrawItemContext[]
 ---
 --- @field new fun(components: blink.cmp.DrawComponent[], gap: number): blink.cmp.DrawColumn
 --- @field render fun(self: blink.cmp.DrawColumn, ctxs: blink.cmp.DrawItemContext[])
---- @field get_line_text fun(self: blink.cmp.DrawColumn, line_idx: number): string[]
+--- @field get_line_text fun(self: blink.cmp.DrawColumn, line_idx: number): string
 --- @field get_line_highlights fun(self: blink.cmp.DrawColumn, line_idx: number): blink.cmp.DrawHighlight[]
 
 local text_lib = require('blink.cmp.windows.render.text')
@@ -46,9 +46,9 @@ function column:render(ctxs)
   --- get the total width of the column
   local column_width = 0
   for _, max_component_width in ipairs(max_component_widths) do
-    column_width = column_width + max_component_width
+    if max_component_width > 0 then column_width = column_width + max_component_width + self.gap end
   end
-  column_width = column_width + self.gap * (#self.components - 1)
+  column_width = column_width - self.gap
 
   --- find the component that will fill the empty space
   local fill_idx = -1
@@ -63,9 +63,10 @@ function column:render(ctxs)
   --- and add extra spaces until we reach the column width
   for _, line in ipairs(lines) do
     local line_width = 0
-    for idx, component_text in ipairs(line) do
-      line_width = line_width + vim.api.nvim_strwidth(component_text) + (idx == #line and 0 or self.gap)
+    for _, component_text in ipairs(line) do
+      if #component_text > 0 then line_width = line_width + vim.api.nvim_strwidth(component_text) + self.gap end
     end
+    line_width = line_width - self.gap
     local remaining_width = column_width - line_width
     line[fill_idx] = text_lib.pad(line[fill_idx], vim.api.nvim_strwidth(line[fill_idx]) + remaining_width)
   end
@@ -77,12 +78,12 @@ function column:render(ctxs)
 end
 
 function column:get_line_text(line_idx)
+  local text = ''
   local line = self.lines[line_idx]
-  local concatenated = ''
-  for idx, component in ipairs(line) do
-    concatenated = concatenated .. component .. string.rep(' ', idx == #line and 0 or self.gap)
+  for _, component in ipairs(line) do
+    if #component > 0 then text = text .. component .. string.rep(' ', self.gap) end
   end
-  return concatenated
+  return text:sub(1, -self.gap - 1)
 end
 
 function column:get_line_highlights(line_idx)
@@ -90,26 +91,27 @@ function column:get_line_highlights(line_idx)
   local offset = 0
   local highlights = {}
 
-  for component_idx, component in ipairs(self.components) do
-    local text = self.lines[line_idx][component_idx]
+  for idx, component in ipairs(self.components) do
+    local text = self.lines[line_idx][idx]
+    if #text > 0 then
+      local column_highlights = type(component.highlight) == 'function' and component.highlight(ctx, text)
+        or component.highlight
 
-    local column_highlights = type(component.highlight) == 'function' and component.highlight(ctx, text)
-      or component.highlight
-
-    if type(column_highlights) == 'string' then
-      table.insert(highlights, { offset, offset + #text, group = column_highlights })
-    elseif type(column_highlights) == 'table' then
-      for _, highlight in ipairs(column_highlights) do
-        table.insert(highlights, {
-          offset + highlight[1],
-          offset + highlight[2],
-          group = highlight.group,
-          params = highlight.params,
-        })
+      if type(column_highlights) == 'string' then
+        table.insert(highlights, { offset, offset + #text, group = column_highlights })
+      elseif type(column_highlights) == 'table' then
+        for _, highlight in ipairs(column_highlights) do
+          table.insert(highlights, {
+            offset + highlight[1],
+            offset + highlight[2],
+            group = highlight.group,
+            params = highlight.params,
+          })
+        end
       end
-    end
 
-    offset = offset + #text + self.gap
+      offset = offset + #text + self.gap
+    end
   end
 
   return highlights

--- a/lua/blink/cmp/windows/render/types.lua
+++ b/lua/blink/cmp/windows/render/types.lua
@@ -19,5 +19,5 @@
 --- @class blink.cmp.DrawComponent
 --- @field width? blink.cmp.DrawWidth
 --- @field ellipsis? boolean Whether to add an ellipsis when truncating the text
---- @field text fun(ctx: blink.cmp.DrawItemContext): string Renders the text of the component
+--- @field text fun(ctx: blink.cmp.DrawItemContext): string? Renders the text of the component
 --- @field highlight? string | fun(ctx: blink.cmp.DrawItemContext, text: string): string | blink.cmp.DrawHighlight[] Renders the highlights of the component


### PR DESCRIPTION
## Problem:

If there is a component returning an empty string, the renderer will take it as non-empty and will add a gap:
```lua
windows = {
  autocomplete = {
    min_width = 1,
    draw = {
      columns = {
        { "label" },
        { "kind", "label_description", gap = 1 },
      },
    },
  },
}
```

In this case, label_description is empty but the renderer is adding a gap

![image](https://github.com/user-attachments/assets/bf63ccc5-07c2-4410-8985-d24b05e3eaf1)

## Solution:

![image](https://github.com/user-attachments/assets/61af423f-e457-40c0-b4ea-34d2e23ecff3)
I have also removed the manual spacing within the `kind` and `kind_icon` components as it should be handled by the gap