### PR TITLE
docs: add blink-ripgrep community plugin to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,7 @@ MiniDeps.add({
 - [lazydev](https://github.com/folke/lazydev.nvim)
 - [ctags](https://github.com/netmute/blink-cmp-ctags)
 - [ripgrep](https://github.com/niuiic/blink-cmp-rg.nvim)
+- [blink-ripgrep](https://github.com/mikavilpas/blink-ripgrep.nvim)
 - [vim-dadbod-completion](https://github.com/kristijanhusak/vim-dadbod-completion)
 
 </details>


### PR DESCRIPTION
Hi! I forked the existing ripgrep plugin after some discussion with its author. So far I have added features like syntax highlighted match previews, unicode support, as well as unit + end to end testing.

https://github.com/mikavilpas/blink-ripgrep.nvim

I wanted to suggest adding it to the readme. Right now it may look a bit confusing in this PR, so let me know if you'd like to have some clarification or something.