### PR TITLE
fix: padded window

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ MiniDeps.add({
 | `BlinkCmpKind` | Special | Kind icon/text of the completion item |
 | `BlinkCmpKind<kind>` | Special | Kind icon/text of the completion item |
 | `BlinkCmpDoc` | NormalFloat | The documentation window |
-| `BlinkCmpDocBorder` | FloatBorder | The documentation window border |
+| `BlinkCmpDocBorder` | NormalFloat | The documentation window border |
 | `BlinkCmpDocCursorLine` | Visual | The documentation window cursor line |
 | `BlinkCmpSignatureHelp` | NormalFloat | The signature help window |
-| `BlinkCmpSignatureHelpBorder` | FloatBorder | The signature help window border |
+| `BlinkCmpSignatureHelpBorder` | NormalFloat | The signature help window border |
 | `BlinkCmpSignatureHelpActiveParameter` | LspSignatureActiveParameter | Active parameter of the signature help |
 
 </details>

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -110,11 +110,11 @@ cmp.add_default_highlights = function()
   set_hl('BlinkCmpMenuSelection', { link = 'PmenuSel' })
 
   set_hl('BlinkCmpDoc', { link = 'NormalFloat' })
-  set_hl('BlinkCmpDocBorder', { link = 'FloatBorder' })
+  set_hl('BlinkCmpDocBorder', { link = 'NormalFloat' })
   set_hl('BlinkCmpDocCursorLine', { link = 'Visual' })
 
   set_hl('BlinkCmpSignatureHelp', { link = 'NormalFloat' })
-  set_hl('BlinkCmpSignatureHelpBorder', { link = 'FloatBorder' })
+  set_hl('BlinkCmpSignatureHelpBorder', { link = 'NormalFloat' })
   set_hl('BlinkCmpSignatureHelpActiveParameter', { link = 'LspSignatureActiveParameter' })
 end
 

--- a/lua/blink/cmp/windows/lib/scrollbar/geometry.lua
+++ b/lua/blink/cmp/windows/lib/scrollbar/geometry.lua
@@ -28,27 +28,34 @@ local function get_win_buf_height(target_win)
   return height
 end
 
+--- @param border string|string[]
+--- @return number
+local function get_col_offset(border)
+  -- we only need an extra offset when working with a padded window
+  if type(border) == 'table' and border[1] == ' ' and border[4] == ' ' and border[7] == ' ' and border[8] == ' ' then
+    return 1
+  end
+  return 0
+end
+
 --- @param target_win number
 --- @return { should_hide: boolean, thumb: blink.cmp.ScrollbarGeometry, gutter: blink.cmp.ScrollbarGeometry }
 function M.get_geometry(target_win)
-  local width = vim.api.nvim_win_get_width(target_win)
-  local height = vim.api.nvim_win_get_height(target_win)
-  local zindex = vim.api.nvim_win_get_config(target_win).zindex or 1
+  local config = vim.api.nvim_win_get_config(target_win)
+  local width = config.width
+  local height = config.height
+  local zindex = config.zindex
 
   local buf_height = get_win_buf_height(target_win)
-
-  local thumb_height = math.max(1, math.floor(height * height / buf_height + 0.5) - 1)
-
   local start_line = math.max(1, vim.fn.line('w0', target_win))
-
   local pct = (start_line - 1) / (buf_height - height)
-
+  local thumb_height = math.max(1, math.floor(height * height / buf_height + 0.5) - 1)
   local thumb_offset = math.floor((pct * (height - thumb_height)) + 0.5)
 
   local common_geometry = {
     width = 1,
     row = thumb_offset,
-    col = width,
+    col = width + get_col_offset(config.border),
     relative = 'win',
     win = target_win,
   }

--- a/lua/blink/cmp/windows/lib/scrollbar/init.lua
+++ b/lua/blink/cmp/windows/lib/scrollbar/init.lua
@@ -2,9 +2,9 @@
 --- @field enable_gutter boolean
 
 --- @class blink.cmp.Scrollbar
---- @field target_win? number
---- @field win? blink.cmp.ScrollbarWin
+--- @field win blink.cmp.ScrollbarWin
 --- @field autocmd? number
+--- @field target_win? number
 ---
 --- @field new fun(opts: blink.cmp.ScrollbarConfig): blink.cmp.Scrollbar
 --- @field is_visible fun(self: blink.cmp.Scrollbar): boolean
@@ -56,6 +56,7 @@ function scrollbar:mount(target_win)
     { 'WinScrolled', 'WinClosed', 'WinResized', 'CursorMoved', 'CursorMovedI' },
     { callback = update }
   )
+  self.target_win = target_win
 end
 
 function scrollbar:unmount()
@@ -63,6 +64,7 @@ function scrollbar:unmount()
 
   if self.autocmd then vim.api.nvim_del_autocmd(self.autocmd) end
   self.autocmd = nil
+  self.target_win = nil
 end
 
 return scrollbar

--- a/lua/blink/cmp/windows/lib/scrollbar/win.lua
+++ b/lua/blink/cmp/windows/lib/scrollbar/win.lua
@@ -25,12 +25,12 @@ function scrollbar_win:show_thumb(geometry)
   -- create window if it doesn't exist
   if self.thumb_win == nil or not vim.api.nvim_win_is_valid(self.thumb_win) then
     self.thumb_win = self:_make_win(geometry, 'BlinkCmpScrollBarThumb')
+  else
+    -- update with the geometry
+    local thumb_existing_config = vim.api.nvim_win_get_config(self.thumb_win)
+    local thumb_config = vim.tbl_deep_extend('force', thumb_existing_config, geometry)
+    vim.api.nvim_win_set_config(self.thumb_win, thumb_config)
   end
-
-  -- update with the geometry
-  local thumb_existing_config = vim.api.nvim_win_get_config(self.thumb_win)
-  local thumb_config = vim.tbl_deep_extend('force', thumb_existing_config, geometry)
-  vim.api.nvim_win_set_config(self.thumb_win, thumb_config)
 end
 
 function scrollbar_win:show_gutter(geometry)
@@ -39,12 +39,12 @@ function scrollbar_win:show_gutter(geometry)
   -- create window if it doesn't exist
   if self.gutter_win == nil or not vim.api.nvim_win_is_valid(self.gutter_win) then
     self.gutter_win = self:_make_win(geometry, 'BlinkCmpScrollBarGutter')
+  else
+    -- update with the geometry
+    local gutter_existing_config = vim.api.nvim_win_get_config(self.gutter_win)
+    local gutter_config = vim.tbl_deep_extend('force', gutter_existing_config, geometry)
+    vim.api.nvim_win_set_config(self.gutter_win, gutter_config)
   end
-
-  -- update with the geometry
-  local gutter_existing_config = vim.api.nvim_win_get_config(self.gutter_win)
-  local gutter_config = vim.tbl_deep_extend('force', gutter_existing_config, geometry)
-  vim.api.nvim_win_set_config(self.gutter_win, gutter_config)
 end
 
 function scrollbar_win:hide_thumb()


### PR DESCRIPTION
## Before

![image](https://github.com/user-attachments/assets/a0ce4a05-0530-4955-8a3d-83860c3c672a)

## After

![image](https://github.com/user-attachments/assets/84916bfc-68f2-4d28-b71b-40074ca7105a)

## Notes
- I'm linking documentation and signature help border groups to NormalFloat (similar to the completion menu) as we don't use bordered windows by default. This should be prioritized, resulting in a much better experience with the defaults