### PR TITLE
fix: get the cursor position relative to the window instead of the sc…

### DIFF
--- a/lua/blink/cmp/windows/documentation.lua
+++ b/lua/blink/cmp/windows/documentation.lua
@@ -105,10 +105,10 @@ function docs.update_position()
   local autocomplete_win_height = autocomplete.win:get_height()
   local autocomplete_border_size = autocomplete.win:get_border_size()
 
-  local cursor_screen_row = vim.fn.screenpos(0, unpack(vim.api.nvim_win_get_cursor(0))).row
+  local cursor_win_row = vim.fn.winline()
 
   -- decide direction priority based on the autocomplete window's position
-  local autocomplete_win_is_up = autocomplete_win_config.row - cursor_screen_row < 0
+  local autocomplete_win_is_up = autocomplete_win_config.row - cursor_win_row < 0
   local direction_priority = autocomplete_win_is_up and config.direction_priority.autocomplete_north
     or config.direction_priority.autocomplete_south
 


### PR DESCRIPTION
Whether it's `nvim_win_get_config` or the later used `nvim_win_set_config`, the `row` used is relative to the window, not the screen.