### PR TITLE
docs: Add missing comma in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,14 +440,18 @@ MiniDeps.add({
           kind_icon = {
             ellipsis = false,
             text = function(ctx) return ctx.kind_icon .. ctx.icon_gap end,
-            highlight = function(ctx) return utils.get_tailwind_hl(ctx) or 'BlinkCmpKind' .. ctx.kind end,
+            highlight = function(ctx)
+              return require('blink.cmp.utils').get_tailwind_hl(ctx) or 'BlinkCmpKind' .. ctx.kind
+            end,
           },
 
           kind = {
             ellipsis = false,
             width = { fill = true },
             text = function(ctx) return ctx.kind end,
-            highlight = function(ctx) return utils.get_tailwind_hl(ctx) or 'BlinkCmpKind' .. ctx.kind end,
+            highlight = function(ctx)
+              return require('blink.cmp.utils').get_tailwind_hl(ctx) or 'BlinkCmpKind' .. ctx.kind
+            end,
           },
 
           label = {

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ MiniDeps.add({
     -- list of enabled providers
     completion = {
       enabled_providers = { 'lsp', 'path', 'snippets', 'buffer' },
-    }
+    },
 
     -- Please see https://github.com/Saghen/blink.compat for using `nvim-cmp` sources
     providers = {

--- a/lua/blink/cmp/config.lua
+++ b/lua/blink/cmp/config.lua
@@ -180,8 +180,6 @@
 --- @field kind_icons? table<string, string>
 --- @field blocked_filetypes? string[]
 
-local utils = require('blink.cmp.utils')
-
 --- @type blink.cmp.Config
 local config = {
   -- The keymap can be:
@@ -427,14 +425,18 @@ local config = {
           kind_icon = {
             ellipsis = false,
             text = function(ctx) return ctx.kind_icon .. ctx.icon_gap end,
-            highlight = function(ctx) return utils.get_tailwind_hl(ctx) or 'BlinkCmpKind' .. ctx.kind end,
+            highlight = function(ctx)
+              return require('blink.cmp.utils').get_tailwind_hl(ctx) or 'BlinkCmpKind' .. ctx.kind
+            end,
           },
 
           kind = {
             ellipsis = false,
             width = { fill = true },
             text = function(ctx) return ctx.kind end,
-            highlight = function(ctx) return utils.get_tailwind_hl(ctx) or 'BlinkCmpKind' .. ctx.kind end,
+            highlight = function(ctx)
+              return require('blink.cmp.utils').get_tailwind_hl(ctx) or 'BlinkCmpKind' .. ctx.kind
+            end,
           },
 
           label = {


### PR DESCRIPTION
Fixes the workflow of copy-pasting the default config.