### PR TITLE
feat: add prebuilt binaries for android

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,3 +15,13 @@ rustflags = ["-C", "target-feature=-crt-static"]
 
 [target.aarch64-unknown-linux-musl]
 rustflags = ["-C", "target-feature=-crt-static"]
+
+[target.aarch64-linux-android]
+rustflags = [
+  "-C",
+  "linker=aarch64-linux-android-clang",
+  "-C",
+  "link-args=-rdynamic",
+  "-C",
+  "default-linker-libraries",
+]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,10 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             artifact_name: target/aarch64-unknown-linux-musl/release/libblink_cmp_fuzzy.so
+          # Android(Termux)
+          - os: ubuntu-latest
+            target: aarch64-linux-android
+            artifact_name: target/aarch64-linux-android/release/libblink_cmp_fuzzy.so
 
           ## macOS builds
           - os: macos-latest


### PR DESCRIPTION
Resolves #145 

Also includes a refactor of the `system_triple` logic in `download.lua` to make maintaining this a bit easier moving forward. I've abstracted the os/arch definitions into their own table now.

Naturally, I've tested this on Windows, Linux, and Android to make sure this hasn't broken the binary download in any way.