### PR TITLE
refactor: remove unused filter_completions from source types

### DIFF
--- a/lua/blink/cmp/sources/lib/types.lua
+++ b/lua/blink/cmp/sources/lib/types.lua
@@ -13,7 +13,6 @@
 --- @field enabled? fun(self: blink.cmp.Source, context: blink.cmp.Context): boolean
 --- @field get_trigger_characters? fun(self: blink.cmp.Source): string[]
 --- @field get_completions? fun(self: blink.cmp.Source, context: blink.cmp.Context, callback: fun(response?: blink.cmp.CompletionResponse)): (fun(): nil) | nil
---- @field filter_completions? fun(self: blink.cmp.Source, response: blink.cmp.CompletionResponse): blink.cmp.CompletionItem[]
 --- @field should_show_completions? fun(self: blink.cmp.Source, context: blink.cmp.Context, response: blink.cmp.CompletionResponse): boolean
 --- @field resolve? fun(self: blink.cmp.Source, item: blink.cmp.CompletionItem, callback: fun(resolved_item?: lsp.CompletionItem)): ((fun(): nil) | nil)
 --- @field should_execute? fun(self: blink.cmp.Source, item: blink.cmp.CompletionItem): boolean Optional function to check if the source should execute the specified item
@@ -26,7 +25,6 @@
 --- @field enabled? fun(self: blink.cmp.Source, context: blink.cmp.Context): boolean
 --- @field get_trigger_characters? fun(self: blink.cmp.Source): string[]
 --- @field get_completions? fun(self: blink.cmp.Source, context: blink.cmp.Context, callback: fun(response: blink.cmp.CompletionResponse | nil)): (fun(): nil) | nil
---- @field filter_completions? fun(self: blink.cmp.Source, response: blink.cmp.CompletionResponse): blink.cmp.CompletionItem[]
 --- @field should_show_completions? fun(self: blink.cmp.Source, context: blink.cmp.Context, response: blink.cmp.CompletionResponse): boolean
 --- @field resolve? fun(self: blink.cmp.Source, item: blink.cmp.CompletionItem, callback: fun(resolved_item: lsp.CompletionItem | nil)): ((fun(): nil) | nil)
 --- @field should_execute? fun(self: blink.cmp.Source, item: blink.cmp.CompletionItem): boolean


### PR DESCRIPTION
No references to this field are left, so it looks like it was left behind from the issue https://github.com/Saghen/blink.cmp/issues/144

and closed by the commit in that issue,
https://github.com/Saghen/blink.cmp/commit/7fea65c4e4c83d3b194a4d9e4d813204fd9f0ded