### PR TITLE
feat(render): support `source_id` and `source_name` in menu render

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,9 +661,10 @@ MiniDeps.add({
 | `BlinkCmpLabel` | Pmenu | Label of the completion item |
 | `BlinkCmpLabelDeprecated` | Comment | Deprecated label of the completion item |
 | `BlinkCmpLabelMatch` | Pmenu | (Currently unused) Label of the completion item when it matches the query |
-| `BlinkCmpGhostText` | Comment | Preview item with ghost text  |
 | `BlinkCmpKind` | Special | Kind icon/text of the completion item |
 | `BlinkCmpKind<kind>` | Special | Kind icon/text of the completion item |
+| `BlinkCmpSourceName` | NonText | Source name of the completion item |
+| `BlinkCmpGhostText` | Comment | Preview item with ghost text  |
 | `BlinkCmpDoc` | NormalFloat | The documentation window |
 | `BlinkCmpDocBorder` | NormalFloat | The documentation window border |
 | `BlinkCmpDocCursorLine` | Visual | The documentation window cursor line |
@@ -801,6 +802,13 @@ completion.menu.draw = {
       width = { max = 30 },
       text = function(ctx) return ctx.label_description end,
       highlight = 'BlinkCmpLabelDescription',
+    },
+
+    source_name = {
+      width = { max = 30 },
+      -- source_name or source_id are supported
+      text = function(ctx) return ctx.source_name end,
+      highlight = 'BlinkCmpSource',
     },
   },
 }

--- a/README.md
+++ b/README.md
@@ -422,6 +422,12 @@ MiniDeps.add({
             text = function(ctx) return ctx.label_description end,
             highlight = 'BlinkCmpLabelDescription',
           },
+
+          source_name = {
+            width = { max = 30 },
+            text = function(ctx) return '[' .. ctx.source_name .. ']' end,
+            highlight = 'BlinkCmpSource',
+          },
         },
       },
     },

--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ MiniDeps.add({
 
           source_name = {
             width = { max = 30 },
-            text = function(ctx) return '[' .. ctx.source_name .. ']' end,
+            text = function(ctx) return ctx.source_name end,
             highlight = 'BlinkCmpSource',
           },
         },

--- a/lua/blink/cmp/completion/windows/render/context.lua
+++ b/lua/blink/cmp/completion/windows/render/context.lua
@@ -9,6 +9,8 @@
 --- @field kind_icon string
 --- @field icon_gap string
 --- @field deprecated boolean
+--- @field source_id string
+--- @field source_name string
 
 local context = {}
 
@@ -46,6 +48,8 @@ function context.new(draw, item, matched_indices)
 
   local label_detail = (item.labelDetails and item.labelDetails.detail or ''):gsub('\n', newline_char)
   local label_description = (item.labelDetails and item.labelDetails.description or ''):gsub('\n', newline_char)
+  local source_id = item.source_id
+  local source_name = item.source_name
 
   return {
     self = draw,
@@ -58,6 +62,8 @@ function context.new(draw, item, matched_indices)
     kind_icon = kind_icon,
     icon_gap = config.nerd_font_variant == 'mono' and '' or ' ',
     deprecated = item.deprecated or (item.tags and vim.tbl_contains(item.tags, 1)) or false,
+    source_id = source_id,
+    source_name = source_name,
   }
 end
 

--- a/lua/blink/cmp/config/completion/menu.lua
+++ b/lua/blink/cmp/config/completion/menu.lua
@@ -96,6 +96,13 @@ local window = {
           text = function(ctx) return ctx.label_description end,
           highlight = 'BlinkCmpLabelDescription',
         },
+
+        source_name = {
+          width = { max = 30 },
+          -- source_name or source_id are supported
+          text = function(ctx) return ctx.source_name end,
+          highlight = 'BlinkCmpSource',
+        },
       },
     },
   },

--- a/lua/blink/cmp/highlights.lua
+++ b/lua/blink/cmp/highlights.lua
@@ -17,6 +17,7 @@ function highlights.setup()
   set_hl('BlinkCmpLabelDetail', { link = use_nvim_cmp and 'CmpItemMenu' or 'NonText' })
   set_hl('BlinkCmpLabelDescription', { link = use_nvim_cmp and 'CmpItemMenu' or 'NonText' })
   set_hl('BlinkCmpKind', { link = use_nvim_cmp and 'CmpItemKind' or 'Special' })
+  set_hl('BlinkCmpSource', { link = use_nvim_cmp and 'CmpItemMenu' or 'NonText' })
   for _, kind in ipairs(require('blink.cmp.types').CompletionItemKind) do
     set_hl('BlinkCmpKind' .. kind, { link = use_nvim_cmp and 'CmpItemKind' .. kind or 'BlinkCmpKind' })
   end


### PR DESCRIPTION
allow blink to show source related info in completion menu

example (`LSP` and `Snippets` are item's source_name):

![image](https://github.com/user-attachments/assets/93380d12-f1da-447f-a214-d03e9302aa52)

related config from example

```lua
		---@module 'blink.cmp'
		opts = {
				menu = {
					draw = {
						columns = {
							{ "label", "label_description", gap = 1 },
							{ "kind_icon", "kind", gap = 1 },
							{ "source_name" },
						},
					},
				},
			},
		},
```

`source_name` has been added as one of default config components for demonstration, but I'm not sure if it's appropriate.