### PR TITLE
feat: treesitter highlighter

### DIFF
--- a/lua/blink/cmp/completion/windows/render/treesitter.lua
+++ b/lua/blink/cmp/completion/windows/render/treesitter.lua
@@ -1,0 +1,42 @@
+local treesitter = {}
+
+--- @param ctx blink.cmp.DrawItemContext
+--- @param opts? {offset?: number}
+function treesitter.highlight(ctx, opts)
+  ---@type blink.cmp.DrawHighlight[]
+  local ret = {}
+  local source = ctx.label
+  local offset = opts and opts.offset or 0
+
+  local lang = vim.treesitter.language.get_lang(vim.bo.filetype)
+  if not lang then return ret end
+
+  local ok, parser = pcall(vim.treesitter.get_string_parser, source, lang)
+  if not ok then return ret end
+
+  parser:parse(true)
+
+  parser:for_each_tree(function(tstree, tree)
+    if not tstree then return end
+    local query = vim.treesitter.query.get(tree:lang(), 'highlights')
+    -- Some injected languages may not have highlight queries.
+    if not query then return end
+
+    for capture, node in query:iter_captures(tstree:root(), source) do
+      local _, start_col, _, end_col = node:range()
+
+      ---@type string
+      local name = query.captures[capture]
+      if name ~= 'spell' then
+        ret[#ret + 1] = {
+          offset + start_col,
+          offset + end_col,
+          group = '@' .. name .. '.' .. lang,
+        }
+      end
+    end
+  end)
+  return ret
+end
+
+return treesitter

--- a/lua/blink/cmp/completion/windows/render/treesitter.lua
+++ b/lua/blink/cmp/completion/windows/render/treesitter.lua
@@ -1,13 +1,44 @@
 local treesitter = {}
 
+---@type table<string, blink.cmp.DrawHighlight[]>
+local cache = {}
+local cache_size = 0
+local MAX_CACHE_SIZE = 1000
+
 --- @param ctx blink.cmp.DrawItemContext
 --- @param opts? {offset?: number}
 function treesitter.highlight(ctx, opts)
-  ---@type blink.cmp.DrawHighlight[]
-  local ret = {}
-  local source = ctx.label
-  local offset = opts and opts.offset or 0
+  -- early return if treesitter highlight is disabled
+  if not vim.b.ts_highlight then return {} end
 
+  local ret = cache[ctx.label]
+  if not ret then
+    -- cleanup cache if it's too big
+    cache_size = cache_size + 1
+    if cache_size > MAX_CACHE_SIZE then
+      cache = {}
+      cache_size = 0
+    end
+    ret = treesitter._highlight(ctx)
+    cache[ctx.label] = ret
+  end
+
+  -- offset highlights if needed
+  if opts and opts.offset then
+    ret = vim.deepcopy(ret)
+    for _, hl in ipairs(ret) do
+      hl[1] = hl[1] + opts.offset
+      hl[2] = hl[2] + opts.offset
+    end
+  end
+  return ret
+end
+
+--- @param ctx blink.cmp.DrawItemContext
+function treesitter._highlight(ctx)
+  local ret = {} ---@type blink.cmp.DrawHighlight[]
+
+  local source = ctx.label
   local lang = vim.treesitter.language.get_lang(vim.bo.filetype)
   if not lang then return ret end
 
@@ -29,8 +60,8 @@ function treesitter.highlight(ctx, opts)
       local name = query.captures[capture]
       if name ~= 'spell' then
         ret[#ret + 1] = {
-          offset + start_col,
-          offset + end_col,
+          start_col,
+          end_col,
           group = '@' .. name .. '.' .. lang,
         }
       end

--- a/lua/blink/cmp/completion/windows/render/types.lua
+++ b/lua/blink/cmp/completion/windows/render/types.lua
@@ -4,6 +4,7 @@
 --- @field gap? number Gap between columns
 --- @field columns? { [number]: string, gap?: number }[] Components to render, grouped by column
 --- @field components? table<string, blink.cmp.DrawComponent> Component definitions
+--- @field treesitter? boolean Use treesitter to highlight the label text
 ---
 --- @class blink.cmp.DrawHighlight
 --- @field [number] number Start and end index of the highlight

--- a/lua/blink/cmp/config/completion/menu.lua
+++ b/lua/blink/cmp/config/completion/menu.lua
@@ -82,6 +82,9 @@ local window = {
               table.insert(highlights, { #label, #label + #ctx.label_detail, group = 'BlinkCmpLabelDetail' })
             end
 
+            -- add treesitter highlights
+            vim.list_extend(highlights, require('blink.cmp.completion.windows.render.treesitter').highlight(ctx))
+
             -- characters matched on the label by the fuzzy matcher
             for _, idx in ipairs(ctx.label_matched_indices) do
               table.insert(highlights, { idx, idx + 1, group = 'BlinkCmpLabelMatch' })

--- a/lua/blink/cmp/config/completion/menu.lua
+++ b/lua/blink/cmp/config/completion/menu.lua
@@ -44,6 +44,7 @@ local window = {
       padding = 1,
       -- Gap between columns
       gap = 1,
+      treesitter = false, -- Use treesitter to highlight the label text
       -- Components to render, grouped by column
       columns = { { 'kind_icon' }, { 'label', 'label_description', gap = 1 } },
       -- Definitions for possible components to render. Each component defines:
@@ -82,8 +83,10 @@ local window = {
               table.insert(highlights, { #label, #label + #ctx.label_detail, group = 'BlinkCmpLabelDetail' })
             end
 
-            -- add treesitter highlights
-            vim.list_extend(highlights, require('blink.cmp.completion.windows.render.treesitter').highlight(ctx))
+            if ctx.self.treesitter then
+              -- add treesitter highlights
+              vim.list_extend(highlights, require('blink.cmp.completion.windows.render.treesitter').highlight(ctx))
+            end
 
             -- characters matched on the label by the fuzzy matcher
             for _, idx in ipairs(ctx.label_matched_indices) do


### PR DESCRIPTION
Quick test of a treesitter highlighter for labels.

Should not be merged yet, since it is currently configured as the default highlighter.

Let me know what you think and if this is something you'd like to have in blink.
Maybe disabled by default and under a config flag somewhere?

![image](https://github.com/user-attachments/assets/d8a28c7d-a2e4-4dbf-af9d-48f6f5845ffa)

![image](https://github.com/user-attachments/assets/26593593-a745-4474-b949-3fbaa1c01bc8)
