### PR TITLE
fix: add missing luasnip documentation

### DIFF
--- a/lua/blink/cmp/sources/luasnip.lua
+++ b/lua/blink/cmp/sources/luasnip.lua
@@ -67,7 +67,11 @@ function source:get_completions(ctx, callback)
         insertText = snip.trigger,
         insertTextFormat = vim.lsp.protocol.InsertTextFormat.PlainText,
         sortText = sort_text,
-        data = { snip_id = snip.id, show_condition = snip.show_condition },
+        data = {
+          snip_id = snip.id,
+          documentation = { (snip.dscr or ''), { '```' .. ft, snip:get_docstring(), '```' } },
+          show_condition = snip.show_condition,
+        },
       }
       table.insert(items, item)
     end
@@ -95,7 +99,7 @@ function source:resolve(item, callback)
   local snip = require('luasnip').get_id_snippet(item.data.snip_id)
 
   local resolved_item = vim.deepcopy(item)
-  resolved_item.detail = snip:get_docstring()
+  resolved_item.detail = table.concat(snip:get_docstring(), '\n')
   resolved_item.documentation = {
     kind = 'markdown',
     value = table.concat(vim.lsp.util.convert_input_to_markdown_lines(item.data.documentation or ''), '\n'),


### PR DESCRIPTION
This fix an error when attempting to show the doc of a lua snippet, parsing the `details` fails because it expects a string not a table.

```
...re/nvim/lazy/blink.cmp/lua/blink/cmp/lib/window/docs.lua:239: attempt to call method 'gmatch'
(a nil value)
```

Also add the missing description

![image](https://github.com/user-attachments/assets/054ebe3b-c871-4a5f-995f-a71b7320c311)
