### PR TITLE
fix(highlight): fix invalid highlight for doc separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ MiniDeps.add({
 | `BlinkCmpGhostText` | Comment | Preview item with ghost text  |
 | `BlinkCmpDoc` | NormalFloat | The documentation window |
 | `BlinkCmpDocBorder` | NormalFloat | The documentation window border |
+| `BlinkCmpDocSeparator` | NormalFloat | The documentation separator between doc and detail |
 | `BlinkCmpDocCursorLine` | Visual | The documentation window cursor line |
 | `BlinkCmpSignatureHelp` | NormalFloat | The signature help window |
 | `BlinkCmpSignatureHelpBorder` | NormalFloat | The signature help window border |

--- a/lua/blink/cmp/highlights.lua
+++ b/lua/blink/cmp/highlights.lua
@@ -33,6 +33,7 @@ function highlights.setup()
 
   set_hl('BlinkCmpDoc', { link = 'NormalFloat' })
   set_hl('BlinkCmpDocBorder', { link = 'NormalFloat' })
+  set_hl('BlinkCmpDocSeparator', { link = 'NormalFloat' })
   set_hl('BlinkCmpDocCursorLine', { link = 'Visual' })
 
   set_hl('BlinkCmpSignatureHelp', { link = 'NormalFloat' })

--- a/lua/blink/cmp/lib/window/docs.lua
+++ b/lua/blink/cmp/lib/window/docs.lua
@@ -39,10 +39,8 @@ function docs.render_detail_and_documentation(bufnr, detail, documentation, max_
   -- Only add the separator if there are documentation lines (otherwise only display the detail)
   if #detail_lines > 0 and #doc_lines > 0 then
     vim.api.nvim_buf_set_extmark(bufnr, highlight_ns, #detail_lines, 0, {
-      virt_text = { { string.rep('─', max_width) } },
+      virt_text = { { string.rep('─', max_width), 'BlinkCmpDocSeparator' } },
       virt_text_pos = 'overlay',
-      hl_eol = true,
-      hl_group = 'BlinkCmpDocDetail',
     })
   end
 


### PR DESCRIPTION
Found highlight group for separator not work, and no description for the highlight group in README.

Not familiar with `nvim_buf_set_extmark`, but it seems work fine.

Before ( separator in doc window should be RED `#9e2e2e` after setting highlight group) :

![image](https://github.com/user-attachments/assets/881476f0-a8cf-4a53-b8e6-1d617a1e5258)

After (highlight group works)

![image](https://github.com/user-attachments/assets/fd6f4ca3-4091-4b69-9159-faca4b73998a)

---

Also I think maybe previous highlight group naming ( `BlinkCmpDocDetail` ) have some ambiguity, therefore currently using `BlinkCmpDocSeparator` as a substitute in the PR.
