### PR TITLE
fix(render): not render two separator for doc window

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,12 +679,14 @@ MiniDeps.add({
 | `BlinkCmpScrollBarThumb` | PmenuThumb | The scrollbar thumb |
 | `BlinkCmpScrollBarGutter` | PmenuSbar | The scrollbar gutter |
 | `BlinkCmpLabel` | Pmenu | Label of the completion item |
-| `BlinkCmpLabelDeprecated` | Comment | Deprecated label of the completion item |
+| `BlinkCmpLabelDeprecated` | NonText | Deprecated label of the completion item |
 | `BlinkCmpLabelMatch` | Pmenu | (Currently unused) Label of the completion item when it matches the query |
+| `BlinkCmpLabelDetail` | NonText | Label description of the completion item |
+| `BlinkCmpLabelDescription` | NonText | Label description of the completion item |
 | `BlinkCmpKind` | Special | Kind icon/text of the completion item |
 | `BlinkCmpKind<kind>` | Special | Kind icon/text of the completion item |
 | `BlinkCmpSource` | NonText | Source of the completion item |
-| `BlinkCmpGhostText` | Comment | Preview item with ghost text  |
+| `BlinkCmpGhostText` | NonText | Preview item with ghost text  |
 | `BlinkCmpDoc` | NormalFloat | The documentation window |
 | `BlinkCmpDocBorder` | NormalFloat | The documentation window border |
 | `BlinkCmpDocSeparator` | NormalFloat | The documentation separator between doc and detail |

--- a/lua/blink/cmp/lib/window/docs.lua
+++ b/lua/blink/cmp/lib/window/docs.lua
@@ -24,9 +24,12 @@ function docs.render_detail_and_documentation(bufnr, detail, documentation, max_
   detail_lines, doc_lines = docs.extract_detail_from_doc(detail_lines, doc_lines)
 
   local combined_lines = vim.list_extend({}, detail_lines)
+
   -- add a blank line for the --- separator
-  if #detail_lines > 0 and #doc_lines > 0 then table.insert(combined_lines, '') end
-  vim.list_extend(combined_lines, doc_lines)
+  local doc_already_has_separator = #doc_lines > 1 and (doc_lines[1] == '---' or doc_lines[1] == '***')
+  if #detail_lines > 0 and #doc_lines > 0  then table.insert(combined_lines, '') end
+  -- skip original separator in doc_lines, so we can highlight it later
+  vim.list_extend(combined_lines, doc_lines, doc_already_has_separator and 2 or 1)
 
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, combined_lines)
   vim.api.nvim_set_option_value('modified', false, { buf = bufnr })


### PR DESCRIPTION
Some LSP servers like lua_ls would return `---` for function doc, so the manually added separator would make two separator in doc window.

This PR adds some specialized logic to handle this, tested for lua_ls and rust analyzer (lsp server won't return separator), work fine for now.

Before:

- lua_ls (would return `---` for function doc)
![image](https://github.com/user-attachments/assets/37c82f88-3775-44fd-b6ef-d2ede3dc3bac)

- rust analyzer
![image](https://github.com/user-attachments/assets/4c7ba87e-f1d8-4cec-be74-eaa242fa2a68)

After:

- lua_ls (would return `---` for function doc)
![image](https://github.com/user-attachments/assets/bb4ab6e4-42fc-4108-9ccd-3f0b505f60b3)

- rust analyzer (works like before)
![image](https://github.com/user-attachments/assets/b6e5e384-d9a7-436e-bdd1-6671653ab083)
