### PR TITLE
feat: fallback to regex highlighting when treesitter is not available

### DIFF
--- a/lua/blink/cmp/lib/window/docs.lua
+++ b/lua/blink/cmp/lib/window/docs.lua
@@ -27,7 +27,7 @@ function docs.render_detail_and_documentation(bufnr, detail, documentation, max_
 
   -- add a blank line for the --- separator
   local doc_already_has_separator = #doc_lines > 1 and (doc_lines[1] == '---' or doc_lines[1] == '***')
-  if #detail_lines > 0 and #doc_lines > 0  then table.insert(combined_lines, '') end
+  if #detail_lines > 0 and #doc_lines > 0 then table.insert(combined_lines, '') end
   -- skip original separator in doc_lines, so we can highlight it later
   vim.list_extend(combined_lines, doc_lines, doc_already_has_separator and 2 or 1)
 
@@ -37,7 +37,9 @@ function docs.render_detail_and_documentation(bufnr, detail, documentation, max_
   -- Highlight with treesitter
   vim.api.nvim_buf_clear_namespace(bufnr, highlight_ns, 0, -1)
 
-  if #detail_lines > 0 and use_treesitter_highlighting then docs.highlight_with_treesitter(bufnr, vim.bo.filetype, 0, #detail_lines) end
+  if #detail_lines > 0 and use_treesitter_highlighting then
+    docs.highlight_with_treesitter(bufnr, vim.bo.filetype, 0, #detail_lines)
+  end
 
   -- Only add the separator if there are documentation lines (otherwise only display the detail)
   if #detail_lines > 0 and #doc_lines > 0 then
@@ -202,12 +204,10 @@ function docs.extract_detail_from_doc(detail_lines, doc_lines)
   local doc_str_detail_row = doc_str:find(detail_str, 1, true)
 
   -- didn't find the detail in the doc, so return as is
-  if doc_str_detail_row == nil or #detail_str == 0 or #doc_str == 0 then
-    return detail_lines, doc_lines
-  end
+  if doc_str_detail_row == nil or #detail_str == 0 or #doc_str == 0 then return detail_lines, doc_lines end
 
   -- get the line of the match
-  -- hack: surely there's a better way to do this but it's late 
+  -- hack: surely there's a better way to do this but it's late
   -- and I can't be bothered
   local offset = 1
   local detail_line = 1


### PR DESCRIPTION
Issue
=====

Documentation for completions can include markdown fenced code blocks
that should be highlighted with the appropriate syntax. When a
treesitter parser is not available for the language used in the
codeblock, the code inside is not highlighted correctly.

Incorrect highlighting example:

<img width="755" alt="image" src="https://github.com/user-attachments/assets/838e32fc-97eb-4e08-a180-9f50a8fecad3">


This can be an issue when using
https://github.com/mikavilpas/blink-ripgrep.nvim which displays ripgrep
(rg) matches for all the files in the project. Many big projects include
a large variety of programming languages, and the user may not have all
the treesitter parsers installed for all the languages.

Solution
========

Right now, neovim comes bundled with a regex-based syntax highlighter
that supports 743 languages. We can use this syntax highlighter as a
fallback when a treesitter parser is not available for the language.

Improved highlighting example:

<img width="772" alt="image" src="https://github.com/user-attachments/assets/72b94947-044c-4f8c-b4ef-02f1fdc33100">


The solution is not perfect but an 80% solution. The entire
documentation text is highlighted in the syntax of the first codeblock.
This means the code will be displayed correctly, but any markdown syntax
in the documentation will look weird.

The idea is to provide a "better than nothing" experience out of the box, but if the user wants better highlighting, they should install the parser(s) for the languages they are interested in 🙂 

Related issue: https://github.com/Saghen/blink.cmp/issues/336