### PR TITLE
docs: fix `enabled_providers` example function, correct typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Setting capabilities for `nvim-lspconfig`:
   config = function(_, opts)
     local lspconfig = require('lspconfig')
     for server, config in pairs(opts.servers) do
-      -- passing config.capabilities to blink.cmp merges with the capabilities in your 
+      -- passing config.capabilities to blink.cmp merges with the capabilities in your
       -- `opts[server].capabilities, if you've defined it
       config.capabilities = require('blink.cmp').get_lsp_capabilities(config.capabilities)
       lspconfig[server].setup(config)
@@ -123,7 +123,7 @@ Setting capabilities for `nvim-lspconfig`:
   config = function()
     local capabilities = require('blink.cmp').get_lsp_capabilities()
     local lspconfig = require('lspconfig')
-  
+
     lspconfig['lua-ls'].setup({ capabilities = capabilities })
   end
 }
@@ -183,7 +183,7 @@ MiniDeps.add({
   --   preset = 'default',
   --   ['<Up>'] = { 'select_prev', 'fallback' },
   --   ['<Down>'] = { 'select_next', 'fallback' },
-  -- 
+  --
   --   -- disable a keymap from the preset
   --   ['<C-e>'] = {},
   -- },
@@ -310,7 +310,7 @@ MiniDeps.add({
       -- 'manual' will not select any item by default
       -- 'auto_insert' will not select any item by default, and insert the completion items automatically
       -- when selecting them
-      -- 
+      --
       -- You may want to bind a key to the `cancel` command, which will undo the selection
       -- when using 'auto_insert'
       cycle = {
@@ -475,7 +475,7 @@ MiniDeps.add({
       enabled = false,
     },
   },
-  
+
   -- Experimental signature help support
   signature = {
     enabled = false,
@@ -507,7 +507,7 @@ MiniDeps.add({
     -- when enabled, allows for a number of typos relative to the length of the query
     -- disabling this matches the behavior of fzf
     use_typo_resistance = true,
-    -- frencency tracks the most recently/frequently used items and boosts the score of the item
+    -- frecency tracks the most recently/frequently used items and boosts the score of the item
     use_frecency = true,
     -- proximity bonus boosts the score of items matching nearby words
     use_proximity = true,
@@ -542,12 +542,12 @@ MiniDeps.add({
       --   local node = vim.treesitter.get_node()
       --   if vim.bo.filetype == 'lua' then
       --     return { 'lsp', 'path' }
-      --   elseif node and vim.tbl_contains({ 'comment', 'line_comment', 'block_comment' }), node:type())
+      --   elseif node and vim.tbl_contains({ 'comment', 'line_comment', 'block_comment' }, node:type()) then
       --     return { 'buffer' }
       --   else
       --     return { 'lsp', 'path', 'snippets', 'buffer' }
       --   end
-      -- end
+      -- end,
     },
 
     -- Please see https://github.com/Saghen/blink.compat for using `nvim-cmp` sources


### PR DESCRIPTION
Just a minor fix in the docs...