### PR TITLE
fix: check response.err instead of response.error

### DIFF
--- a/lua/blink/cmp/sources/lsp.lua
+++ b/lua/blink/cmp/sources/lsp.lua
@@ -101,7 +101,7 @@ function lsp:get_completions(context, callback)
     local responses = {}
     for client_id, response in pairs(result) do
       -- todo: pass error upstream
-      if response.error or response.result == nil then
+      if response.err or response.result == nil then
         responses[client_id] = { is_incomplete_forward = true, is_incomplete_backward = true, items = {} }
 
       -- as per the spec, we assume it's complete if we get CompletionItem[]


### PR DESCRIPTION
Seems to be a type error. Should be err instead of error.
Reference: https://github.com/neovim/neovim/blob/master/runtime/lua/vim/lsp/_meta.lua#L5