### PR TITLE
fix(sort): nil check `item.kind`

### DIFF
--- a/lua/blink/cmp/fuzzy/sort.lua
+++ b/lua/blink/cmp/fuzzy/sort.lua
@@ -23,7 +23,7 @@ function sort.score(a, b)
 end
 
 function sort.kind(a, b)
-  if a.kind == b.kind then return end
+  if not (a.kind and b.kind) or a.kind == b.kind then return end
   return a.kind < b.kind
 end
 


### PR DESCRIPTION
`kind` is an optional property of `CompletionItem` in the LSP spec, so not all sources provide it. I noticed this with  [`cmp-digraphs`](https://github.com/dmitmel/cmp-digraphs/blob/5efc1f0078d7c5f3ea1c8e3aad04da3fd6e081a9/lua/cmp_digraphs.lua#L50-L55) through compat.