### PR TITLE
feat(window): add `filetype` configuration

### DIFF
--- a/lua/blink/cmp/completion/windows/documentation.lua
+++ b/lua/blink/cmp/completion/windows/documentation.lua
@@ -29,6 +29,7 @@ local docs = {
     winhighlight = win_config.winhighlight,
     scrollbar = win_config.scrollbar,
     wrap = true,
+    filetype = 'blink-cmp-documentation',
   }),
   last_context_id = nil,
   auto_show_timer = vim.uv.new_timer(),

--- a/lua/blink/cmp/completion/windows/menu.lua
+++ b/lua/blink/cmp/completion/windows/menu.lua
@@ -28,6 +28,7 @@ local menu = {
     cursorline = false,
     scrolloff = config.scrolloff,
     scrollbar = config.scrollbar,
+    filetype = 'blink-cmp-menu',
   }),
   items = {},
   context = nil,

--- a/lua/blink/cmp/lib/window/init.lua
+++ b/lua/blink/cmp/lib/window/init.lua
@@ -9,7 +9,7 @@
 --- @field winhighlight? string
 --- @field scrolloff? number
 --- @field scrollbar? boolean
---- @field filetype? string
+--- @field filetype string
 
 --- @class blink.cmp.Window
 --- @field id? number
@@ -55,7 +55,7 @@ function win.new(config)
     winhighlight = config.winhighlight or 'Normal:NormalFloat,FloatBorder:NormalFloat',
     scrolloff = config.scrolloff or 0,
     scrollbar = config.scrollbar,
-    filetype = config.filetype or 'blink-cmp',
+    filetype = config.filetype,
   }
 
   if self.config.scrollbar then

--- a/lua/blink/cmp/lib/window/init.lua
+++ b/lua/blink/cmp/lib/window/init.lua
@@ -9,6 +9,7 @@
 --- @field winhighlight? string
 --- @field scrolloff? number
 --- @field scrollbar? boolean
+--- @field filetype? string
 
 --- @class blink.cmp.Window
 --- @field id? number
@@ -54,6 +55,7 @@ function win.new(config)
     winhighlight = config.winhighlight or 'Normal:NormalFloat,FloatBorder:NormalFloat',
     scrolloff = config.scrolloff or 0,
     scrollbar = config.scrollbar,
+    filetype = config.filetype or 'blink-cmp',
   }
 
   if self.config.scrollbar then
@@ -106,6 +108,7 @@ function win:open()
   vim.api.nvim_set_option_value('cursorlineopt', 'line', { win = self.id })
   vim.api.nvim_set_option_value('cursorline', self.config.cursorline, { win = self.id })
   vim.api.nvim_set_option_value('scrolloff', self.config.scrolloff, { win = self.id })
+  vim.api.nvim_set_option_value('filetype', self.config.filetype, { buf = self.buf })
 
   if self.scrollbar then self.scrollbar:mount(self.id) end
 end

--- a/lua/blink/cmp/signature/window.lua
+++ b/lua/blink/cmp/signature/window.lua
@@ -22,6 +22,7 @@ local signature = {
     winhighlight = config.winhighlight,
     scrollbar = config.scrollbar,
     wrap = true,
+    filetype = 'blink-cmp-signature',
   }),
   context = nil,
 }


### PR DESCRIPTION
Allow window `filetype` configuration. This makes it easier to prevent other plugins from interfering with blink windows