### PR TITLE
fix(provider): restore path completion source

### DIFF
--- a/lua/blink/cmp/sources/path/fs.lua
+++ b/lua/blink/cmp/sources/path/fs.lua
@@ -46,13 +46,7 @@ function fs.fs_stat_all(cwd, entries)
       end)
     )
   end
-  return async.task.await_all(tasks):map(function(tasks_results)
-    local resolved_entries = {}
-    for _, entry in ipairs(tasks_results) do
-      if entry.status == async.STATUS.COMPLETED then table.insert(resolved_entries, entry.result) end
-    end
-    return resolved_entries
-  end)
+  return async.task.await_all(tasks)
 end
 
 --- @param path string


### PR DESCRIPTION
Regression introduced in recent refactoring (#465) where the path
provider was not returning any results.

Ensures that all successfully completed stat operations are returned.
