### PR TITLE
feat(trigger): prefetch on InsertEnter

### DIFF
--- a/lua/blink/cmp/completion/init.lua
+++ b/lua/blink/cmp/completion/init.lua
@@ -29,6 +29,8 @@ function completion.setup()
     vim.schedule(function()
       -- since this was performed asynchronously, we check if the context has changed
       if trigger.context == nil or event.context.id ~= trigger.context.id then return end
+      -- don't show the list if prefetching results
+      if trigger.prefetch then return end
       list.show(event.context, event.items)
     end)
   end)

--- a/lua/blink/cmp/completion/trigger.lua
+++ b/lua/blink/cmp/completion/trigger.lua
@@ -24,12 +24,13 @@
 --- @field context? blink.cmp.Context
 --- @field show_emitter blink.cmp.EventEmitter<{ context: blink.cmp.Context }>
 --- @field hide_emitter blink.cmp.EventEmitter<{}>
+--- @field prefetch boolean
 ---
 --- @field activate fun()
 --- @field is_trigger_character fun(char: string, is_retrigger?: boolean): boolean
 --- @field suppress_events_for_callback fun(cb: fun())
 --- @field show_if_on_trigger_character fun(opts?: { is_accept?: boolean })
---- @field show fun(opts?: { trigger_character?: string, force?: boolean, send_upstream?: boolean, providers?: string[] })
+--- @field show fun(opts?: { trigger_character?: string, force?: boolean, send_upstream?: boolean, providers?: string[], prefetch?: boolean })
 --- @field hide fun()
 --- @field within_query_bounds fun(cursor: number[]): boolean
 --- @field get_context_bounds fun(regex: string): blink.cmp.ContextBounds
@@ -106,6 +107,10 @@ function trigger.activate()
       elseif is_on_keyword_char and trigger.context ~= nil and cursor_col == trigger.context.bounds.start_col - 1 then
         trigger.context = nil
         trigger.show()
+
+      -- prefetch completions without opening window on InsertEnter
+      elseif event == 'InsertEnter' then
+        trigger.show({ prefetch = true })
 
       -- otherwise hide
       else
@@ -196,6 +201,7 @@ function trigger.show(opts)
     },
     providers = providers,
   }
+  trigger.prefetch = opts.prefetch == true
 
   if opts.send_upstream ~= false then trigger.show_emitter:emit({ context = trigger.context }) end
 end


### PR DESCRIPTION
Mostly a proof of concept, and probably missing some edge cases. Only prefetches completion responses from sources. Fuzzy still occurs on the first regular trigger, but there is still noticeably less latency.