### PR TITLE
feat(window): add docs default filetype

### DIFF
--- a/lua/blink/cmp/lib/window/docs.lua
+++ b/lua/blink/cmp/lib/window/docs.lua
@@ -63,8 +63,7 @@ end
 function docs.highlight_with_treesitter(bufnr, filetype, start_line, end_line)
   local Range = require('vim.treesitter._range')
 
-  local root_lang = vim.treesitter.language.get_lang(filetype)
-  if root_lang == nil then return end
+  local root_lang = vim.treesitter.language.get_lang(filetype) or "markdown"
 
   local success, trees = pcall(vim.treesitter.get_parser, bufnr, root_lang)
   if not success or not trees then return end


### PR DESCRIPTION
It seems that some docs have their filetype set to nil even though they contain content like code blocks (e.g., ```).

I'm not sure if it's appropriate to assign a default filetype in this case,
but I've submitted a PR to address this issue.

### before
![image](https://github.com/user-attachments/assets/dac9c491-f2ca-49ae-bec0-765327eff8ce)


### after
![image](https://github.com/user-attachments/assets/1ef614c0-269b-4d15-a165-f42b43c05a51)
