### PR TITLE
fix(cmdline): Conditionally apply cmdline keymaps based on user config

### DIFF
--- a/lua/blink/cmp/keymap/init.lua
+++ b/lua/blink/cmp/keymap/init.lua
@@ -31,8 +31,10 @@ function keymap.setup()
     require('blink.cmp.keymap.apply').keymap_to_current_buffer(mappings)
   end
 
-  -- Always apply cmdline keymaps since they're global
-  require('blink.cmp.keymap.apply').cmdline_keymaps(mappings)
+  -- Conditionally apply cmdline keymaps based on user config
+  if type(require('blink.cmp.config').sources.cmdline) ~= 'table' then
+    require('blink.cmp.keymap.apply').cmdline_keymaps(mappings)
+  end
 end
 
 return keymap


### PR DESCRIPTION
Problem:
Cmdline keymaps are applied even when the user disables cmdline completions. For example, `<UP>` and `<DOWN>` do nothing when `sources.cmdline = {}`, instead of cycling through cmdline history.

Solution:
Conditionally apply cmdline keymaps based on user config. Only apply keymaps when `type(sources.cmdline) ~= "table"`.