### PR TITLE
feat: enable treesiter highlight in menu per source

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ MiniDeps.add({
         gap = 1,
         -- Use treesitter to highlight the label text of completions from these sources
         treesitter = {},
+        -- Recommended to enable it just for the LSP source
+        -- treesitter = { 'lsp' }
 
         -- Components to render, grouped by column
         columns = { { 'kind_icon' }, { 'label', 'label_description', gap = 1 } },

--- a/README.md
+++ b/README.md
@@ -399,8 +399,8 @@ MiniDeps.add({
         padding = 1,
         -- Gap between columns
         gap = 1,
-        -- Use treesitter to highlight the label text
-        treesitter = false,
+        -- Use treesitter to highlight the label text of completions from these sources
+        treesitter = {},
 
         -- Components to render, grouped by column
         columns = { { 'kind_icon' }, { 'label', 'label_description', gap = 1 } },
@@ -814,8 +814,8 @@ completion.menu.draw = {
   padding = 1,
   -- Gap between columns
   gap = 1,
-  -- Use treesitter to highlight the label text
-  treesitter = false,
+  -- Use treesitter to highlight the label text of completions from these sources
+  treesitter = {},
 
   -- Components to render, grouped by column
   columns = { { 'kind_icon' }, { 'label', 'label_description', gap = 1 } },

--- a/lua/blink/cmp/completion/windows/render/types.lua
+++ b/lua/blink/cmp/completion/windows/render/types.lua
@@ -4,7 +4,7 @@
 --- @field gap? number Gap between columns
 --- @field columns? { [number]: string, gap?: number }[] Components to render, grouped by column
 --- @field components? table<string, blink.cmp.DrawComponent> Component definitions
---- @field treesitter? boolean Use treesitter to highlight the label text
+--- @field treesitter? string[] Use treesitter to highlight the label text of completions from these sources
 ---
 --- @class blink.cmp.DrawHighlight
 --- @field [number] number Start and end index of the highlight

--- a/lua/blink/cmp/config/completion/menu.lua
+++ b/lua/blink/cmp/config/completion/menu.lua
@@ -58,7 +58,7 @@ local window = {
       padding = 1,
       -- Gap between columns
       gap = 1,
-      treesitter = false, -- Use treesitter to highlight the label text
+      treesitter = {}, -- Use treesitter to highlight the label text of completions from these sources
       -- Components to render, grouped by column
       columns = { { 'kind_icon' }, { 'label', 'label_description', gap = 1 } },
       -- Definitions for possible components to render. Each component defines:
@@ -100,7 +100,7 @@ local window = {
               table.insert(highlights, { #label, #label + #ctx.label_detail, group = 'BlinkCmpLabelDetail' })
             end
 
-            if ctx.self.treesitter then
+            if vim.list_contains(ctx.self.treesitter, ctx.source_id) then
               -- add treesitter highlights
               vim.list_extend(highlights, require('blink.cmp.completion.windows.render.treesitter').highlight(ctx))
             end
@@ -188,7 +188,7 @@ function window.validate(config)
     },
     gap = { config.draw.gap, 'number' },
 
-    treesitter = { config.draw.treesitter, 'boolean' },
+    treesitter = { config.draw.treesitter, 'table' },
 
     columns = {
       config.draw.columns,


### PR DESCRIPTION
Closes #438

I'm not sure where exactly to recommend `treesitter = { "lsp" }` in the documentation as was mentioned in the issue. Please also feel free to reword the new description of the `treesitter` field.