### PR TITLE
fix: auto hide cmp windows when exec snippet_forward/snippet_backward

### DIFF
--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -126,6 +126,7 @@ function cmp.snippet_active(filter) return require('blink.cmp.config').snippets.
 function cmp.snippet_forward()
   local snippets = require('blink.cmp.config').snippets
   if not snippets.active({ direction = 1 }) then return end
+  cmp.hide()
   vim.schedule(function() snippets.jump(1) end)
   return true
 end
@@ -133,6 +134,7 @@ end
 function cmp.snippet_backward()
   local snippets = require('blink.cmp.config').snippets
   if not snippets.active({ direction = -1 }) then return end
+  cmp.hide()
   vim.schedule(function() snippets.jump(-1) end)
   return true
 end


### PR DESCRIPTION
maybe useful :)

If there is something inappropriate, you can modify it to something better, but I think this behavior should be necessary.