### PR TITLE
fix(luasnip): Add snippets with ft="all" to completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,14 @@ MiniDeps.add({
       luasnip = {
         name = 'Luasnip',
         module = 'blink.cmp.sources.luasnip',
+        opts = {
+          -- Whether to use show_condition for filtering snippets
+          use_show_condition = true,
+          -- Whether to show autosnippets in the completion list
+          show_autosnippets = true,
+          -- Snippet filetypes to always include in the completion list
+          global_snippets = { 'all' },
+        }
       },
       buffer = {
         name = 'Buffer',

--- a/lua/blink/cmp/sources/luasnip.lua
+++ b/lua/blink/cmp/sources/luasnip.lua
@@ -39,15 +39,14 @@ function source:get_completions(ctx, callback)
     --- @type blink.cmp.CompletionItem[]
     local items = {}
 
+    local ls = require('luasnip')
     -- Gather filetype snippets and, optionally, autosnippets
-    local snippets = vim.list_extend(
-      require('luasnip').get_snippets('all', { type = 'snippets' }),
-      require('luasnip').get_snippets(ft, { type = 'snippets' })
-    )
+    local snippets =
+      vim.list_extend(ls.get_snippets('all', { type = 'snippets' }), ls.get_snippets(ft, { type = 'snippets' }))
     if self.config.show_autosnippets then
       local autosnippets = vim.list_extend(
-        require('luasnip').get_snippets('all', { type = 'autosnippets' }),
-        require('luasnip').get_snippets(ft, { type = 'autosnippets' })
+        ls.get_snippets('all', { type = 'autosnippets' }),
+        ls.get_snippets(ft, { type = 'autosnippets' })
       )
       snippets = require('blink.cmp.lib.utils').shallow_copy(snippets)
       vim.list_extend(snippets, autosnippets)

--- a/lua/blink/cmp/sources/luasnip.lua
+++ b/lua/blink/cmp/sources/luasnip.lua
@@ -40,14 +40,12 @@ function source:get_completions(ctx, callback)
     local items = {}
 
     -- Gather filetype snippets and, optionally, autosnippets
-    local snippets = vim.tbl_extend(
-      'force',
+    local snippets = vim.list_extend(
       require('luasnip').get_snippets('all', { type = 'snippets' }),
       require('luasnip').get_snippets(ft, { type = 'snippets' })
     )
     if self.config.show_autosnippets then
-      local autosnippets = vim.tbl_extend(
-        'force',
+      local autosnippets = vim.list_extend(
         require('luasnip').get_snippets('all', { type = 'autosnippets' }),
         require('luasnip').get_snippets(ft, { type = 'autosnippets' })
       )

--- a/lua/blink/cmp/sources/luasnip.lua
+++ b/lua/blink/cmp/sources/luasnip.lua
@@ -40,9 +40,17 @@ function source:get_completions(ctx, callback)
     local items = {}
 
     -- Gather filetype snippets and, optionally, autosnippets
-    local snippets = require('luasnip').get_snippets(ft, { type = 'snippets' })
+    local snippets = vim.tbl_extend(
+      'force',
+      require('luasnip').get_snippets('all', { type = 'snippets' }),
+      require('luasnip').get_snippets(ft, { type = 'snippets' })
+    )
     if self.config.show_autosnippets then
-      local autosnippets = require('luasnip').get_snippets(ft, { type = 'autosnippets' })
+      local autosnippets = vim.tbl_extend(
+        'force',
+        require('luasnip').get_snippets('all', { type = 'autosnippets' }),
+        require('luasnip').get_snippets(ft, { type = 'autosnippets' })
+      )
       snippets = require('blink.cmp.lib.utils').shallow_copy(snippets)
       vim.list_extend(snippets, autosnippets)
     end


### PR DESCRIPTION
Luasnip enables to add snippets for all filetypes. These are not added to the completion list. This should be fixed with
this PR.
