### PR TITLE
fix: don't duplicate `.` when completing hidden files in path source

### DIFF
--- a/lua/blink/cmp/sources/path/init.lua
+++ b/lua/blink/cmp/sources/path/init.lua
@@ -44,7 +44,7 @@ function path:get_completions(context, callback)
       and context.bounds.length > 0
     )
   lib
-    .candidates(dirname, include_hidden, context, self.opts)
+    .candidates(context, dirname, include_hidden, self.opts)
     :map(
       function(candidates)
         callback({ is_incomplete_forward = false, is_incomplete_backward = false, items = candidates })

--- a/lua/blink/cmp/sources/path/init.lua
+++ b/lua/blink/cmp/sources/path/init.lua
@@ -44,7 +44,7 @@ function path:get_completions(context, callback)
       and context.bounds.length > 0
     )
   lib
-    .candidates(dirname, include_hidden, self.opts)
+    .candidates(dirname, include_hidden, context, self.opts)
     :map(
       function(candidates)
         callback({ is_incomplete_forward = false, is_incomplete_backward = false, items = candidates })

--- a/lua/blink/cmp/sources/path/lib.lua
+++ b/lua/blink/cmp/sources/path/lib.lua
@@ -43,11 +43,11 @@ function lib.dirname(path_regex, get_cwd, context)
   return nil
 end
 
+--- @param context blink.cmp.Context
 --- @param dirname string
 --- @param include_hidden boolean
---- @param context blink.cmp.Context
 --- @param opts table
-function lib.candidates(dirname, include_hidden, context, opts)
+function lib.candidates(context, dirname, include_hidden, opts)
   local fs = require('blink.cmp.sources.path.fs')
   return fs.scan_dir_async(dirname)
     :map(function(entries) return fs.fs_stat_all(dirname, entries) end)

--- a/lua/blink/cmp/sources/path/lib.lua
+++ b/lua/blink/cmp/sources/path/lib.lua
@@ -56,7 +56,7 @@ function lib.candidates(dirname, include_hidden, context, opts)
     end)
     :map(function(entries)
       return vim.tbl_map(
-        function(entry) return lib.entry_to_completion_item(entry, dirname, context, opts) end,
+        function(entry) return lib.entry_to_completion_item(context, entry, dirname, opts) end,
         entries
       )
     end)
@@ -71,12 +71,12 @@ function lib.is_slash_comment()
   return is_slash_comment and not no_filetype
 end
 
+--- @param context blink.cmp.Context
 --- @param entry { name: string, type: string, stat: table }
 --- @param dirname string
---- @param context blink.cmp.Context
 --- @param opts table
 --- @return blink.cmp.CompletionItem[]
-function lib.entry_to_completion_item(entry, dirname, context, opts)
+function lib.entry_to_completion_item(context, entry, dirname, opts)
   local is_dir = entry.type == 'directory'
   local CompletionItemKind = require('blink.cmp.types').CompletionItemKind
   local insert_text = is_dir and entry.name .. '/' or entry.name
@@ -84,7 +84,7 @@ function lib.entry_to_completion_item(entry, dirname, context, opts)
     label = (opts.label_trailing_slash and is_dir) and entry.name .. '/' or entry.name,
     kind = is_dir and CompletionItemKind.Folder or CompletionItemKind.File,
     insertText = insert_text,
-    textEdit = lib.get_text_edit(insert_text, context),
+    textEdit = lib.get_text_edit(context, insert_text),
     word = opts.trailing_slash and entry.name or nil,
     data = { path = entry.name, full_path = dirname .. '/' .. entry.name, type = entry.type, stat = entry.stat },
   }
@@ -93,7 +93,7 @@ end
 --- @param insert_text string
 --- @param context blink.cmp.Context
 --- @return lsp.Range | nil
-function lib.get_text_edit(insert_text, context)
+function lib.get_text_edit(context, insert_text)
   local line_before_cursor = context.line:sub(1, context.cursor[2])
 
   local parts = vim.split(line_before_cursor, '/')


### PR DESCRIPTION
Current the path auto-complete duplicates the `.` character when auto-completing dot files:

https://github.com/user-attachments/assets/528740a4-3f6d-4429-aaec-59a7286215b5

With corrected edit range for files with dot:

https://github.com/user-attachments/assets/0d4f759c-e4d5-419e-9d83-284b6ae24734

