### PR TITLE
fix(completion): disable in prompt buffers

### DIFF
--- a/lua/blink/cmp/config/init.lua
+++ b/lua/blink/cmp/config/init.lua
@@ -16,7 +16,7 @@
 local validate = require('blink.cmp.config.utils').validate
 --- @type blink.cmp.ConfigStrict
 local config = {
-  enabled = function() return vim.bo.buftype ~= 'prompt' and vim.b.completion ~= false end,
+  enabled = function() return vim.bo.buftype ~= 'prompt' or vim.b.completion ~= false end,
   keymap = require('blink.cmp.config.keymap').default,
   completion = require('blink.cmp.config.completion').default,
   fuzzy = require('blink.cmp.config.fuzzy').default,


### PR DESCRIPTION
Fixes a regression where the completion list was incorrectly enabled in
prompt buffers.
