### PR TITLE
fix: re-disable in buffers where b:completion is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,10 +263,14 @@ MiniDeps.add({
   keymap = { preset = 'default' },
 
   -- Enables keymaps, completions and signature help when true
-  enabled = function() return vim.bo.buftype ~= "prompt" end,
+  enabled = function() return not (vim.bo.buftype == 'prompt' or vim.b.completion == false) end,
   -- Example for blocking multiple filetypes
   -- enabled = function()
-  --  return not vim.tbl_contains({ "lua", "markdown" }, vim.bo.filetype) and vim.bo.buftype ~= "prompt"
+  --   return not (
+  --     vim.tbl_contains({ 'lua', 'markdown' }, vim.bo.filetype)
+  --     or vim.bo.buftype == 'prompt'
+  --     or vim.b.completion == false
+  --   )
   -- end,
 
   snippets = {

--- a/lua/blink/cmp/config/init.lua
+++ b/lua/blink/cmp/config/init.lua
@@ -11,7 +11,7 @@
 local validate = require('blink.cmp.config.utils').validate
 --- @type blink.cmp.ConfigStrict
 local config = {
-  enabled = function() return vim.bo.buftype ~= 'prompt' or vim.b.completion ~= false end,
+  enabled = function() return not (vim.bo.buftype == 'prompt' or vim.b.completion == false) end,
   keymap = require('blink.cmp.config.keymap').default,
   completion = require('blink.cmp.config.completion').default,
   fuzzy = require('blink.cmp.config.fuzzy').default,


### PR DESCRIPTION
Fixes logic from #574 for when `b:completion` is false. Also updated example configuration in `README.md`.