### PR TITLE
not delete buf when hide scrollbar cause it seems not necessary

### DIFF
--- a/lua/blink/cmp/lib/window/scrollbar/win.lua
+++ b/lua/blink/cmp/lib/window/scrollbar/win.lua
@@ -70,7 +70,6 @@ end
 function scrollbar_win:hide()
   self:hide_thumb()
   self:hide_gutter()
-  if self.buf and vim.api.nvim_buf_is_valid(self.buf) then vim.api.nvim_buf_delete(self.buf, { force = true }) end
 end
 
 function scrollbar_win:_make_win(geometry, hl_group)


### PR DESCRIPTION
Closes #580 

There were errors for command-line window cause it's not allowed to delete buffer in command-line window.

At first I want to check if we are in command-line window by checking `getcmdwintype()`, but seems there is no need to always trying to delete buffer for scrollbar thumb and gutter. Cause blink already can reuse existing buffer for scrollbar thumb and gutter.

see below [scrollbar_win:_make_win](https://github.com/Saghen/blink.cmp/blob/76230d5a4a02cd1db8dec33b6eed0b4bc2dcbc53/lua/blink/cmp/lib/window/scrollbar/win.lua#L76C1-L87C4)

```lua
function scrollbar_win:_make_win(geometry, hl_group)
  if self.buf == nil or not vim.api.nvim_buf_is_valid(self.buf) then self.buf = vim.api.nvim_create_buf(false, true) end

  local win_config = vim.tbl_deep_extend('force', geometry, {
    style = 'minimal',
    focusable = false,
    noautocmd = true,
  })
  local win = vim.api.nvim_open_win(self.buf, false, win_config)
  vim.api.nvim_set_option_value('winhighlight', 'Normal:' .. hl_group .. ',EndOfBuffer:' .. hl_group, { win = win })
  return win
end
```

If there are something I missed or got wrong, feel free to modify or give advice :)