### PR TITLE
Normalize Keymap Capitalization

### DIFF
--- a/lua/blink/cmp/keymap/init.lua
+++ b/lua/blink/cmp/keymap/init.lua
@@ -1,5 +1,16 @@
 local keymap = {}
 
+--- Lowercases all keys in the mappings table
+--- @param mappings table<string, blink.cmp.KeymapCommand[]>
+--- @return table<string, blink.cmp.KeymapCommand[]>
+function keymap.normalize_mappings(mappings)
+  local normalized_mappings = {}
+  for key, map in pairs(mappings) do
+    normalized_mappings[key:lower()] = map
+  end
+  return normalized_mappings
+end
+
 ---@param keymap_config blink.cmp.BaseKeymapConfig
 function keymap.get_mappings(keymap_config)
   local mappings = vim.deepcopy(keymap_config)
@@ -13,11 +24,7 @@ function keymap.get_mappings(keymap_config)
 
     -- Merge the preset keymap with the user-defined keymaps
     -- User-defined keymaps overwrite the preset keymaps
-    local normalized_mappings = {}
-    for key, map in pairs(mappings) do
-      normalized_mappings[key:lower()] = map
-    end
-    mappings = vim.tbl_extend('force', preset_keymap, normalized_mappings)
+    mappings = vim.tbl_extend('force', keymap.normalize_mappings(preset_keymap), keymap.normalize_mappings(mappings))
   end
   return mappings
 end

--- a/lua/blink/cmp/keymap/init.lua
+++ b/lua/blink/cmp/keymap/init.lua
@@ -13,7 +13,11 @@ function keymap.get_mappings(keymap_config)
 
     -- Merge the preset keymap with the user-defined keymaps
     -- User-defined keymaps overwrite the preset keymaps
-    mappings = vim.tbl_extend('force', preset_keymap, mappings)
+    local normalized_mappings = {}
+    for key, map in pairs(mappings) do
+      normalized_mappings[key:lower()] = map
+    end
+    mappings = vim.tbl_extend('force', preset_keymap, normalized_mappings)
   end
   return mappings
 end


### PR DESCRIPTION
After debugg my issue [here](https://github.com/Saghen/blink.cmp/discussions/598) I found out that mapping keymaps with lowercase codes (i.e. `<c-space>`, not `<C-space>`) was broken.

The current keymapping logic simply overrides the default preset by overwriting exact matches - in this case, ignoring all my keybindings

(Neo)Vim supports arbitrary capitalization for keymaps (`<Up>`, `<up>`), etc. so I figured blink should too.
