### PR TITLE
fix(super-tab): tab should respect manual selection

### DIFF
--- a/lua/blink/cmp/keymap/presets.lua
+++ b/lua/blink/cmp/keymap/presets.lua
@@ -1,3 +1,5 @@
+local config = require('blink.cmp.config')
+
 local presets = {
   none = {},
 
@@ -22,7 +24,7 @@ local presets = {
 
     ['<Tab>'] = {
       function(cmp)
-        if cmp.snippet_active() then
+        if cmp.snippet_active() or config.completion.list.selection == 'manual' then
           return cmp.accept()
         else
           return cmp.select_and_accept()


### PR DESCRIPTION
When using the `super-tab` preset and the `completion.list.selection` option is set to `"manual"`, the custom `<Tab>` keymap doesn't respect it and still selects and accepts the first option.

Simply ensuring `cmp.accept()` is triggered when this option is set (instead of `cmp.select_and_accept()`) works because `cmp.accept()` internally checks whether a completion item is selected, and if it isn't it exits without executing anything.