### PR TITLE
fix(tailwind): color rendering

### DIFF
--- a/lua/blink/cmp/completion/windows/render/tailwind.lua
+++ b/lua/blink/cmp/completion/windows/render/tailwind.lua
@@ -1,10 +1,12 @@
 local tailwind = {}
 
+local kinds = require('blink.cmp.types').CompletionItemKind
+
 --- @param item blink.cmp.CompletionItem
 --- @return string|nil
 function tailwind.get_hex_color(item)
   local doc = item.documentation
-  if item.kind ~= 'Color' or not doc then return end
+  if item.kind ~= kinds.Color or not doc then return end
   local content = type(doc) == 'string' and doc or doc.value
   if content and content:match('^#%x%x%x%x%x%x$') then return content end
 end


### PR DESCRIPTION
@Saghen unfortunately I think you introduced a bit of a regression when you tweaked #544 before merging: Seems like you switched from passing a `DrawItemContext` to just passing a `CompletionItem`, and the latter gets the unmapped integer kind values from the LSP. This is causing highlights and icon override to break.

This should fix it.