### PR TITLE
Clear LuaSnip cache on reload/snippets added

### DIFF
--- a/lua/blink/cmp/sources/luasnip.lua
+++ b/lua/blink/cmp/sources/luasnip.lua
@@ -24,6 +24,24 @@ function source.new(opts)
   local self = setmetatable({}, { __index = source })
   self.config = config
   self.items_cache = {}
+  local luasnip_ag = vim.api.nvim_create_augroup('BlinkCmpLuaSnipReload', { clear = true })
+  vim.api.nvim_create_autocmd('User', {
+    pattern = 'LuasnipSnippetsAdded',
+    callback = function()
+      local ok, _ = pcall(require, 'luasnip.session')
+      if not ok then return end
+      local ft = require('luasnip.session').latest_load_ft
+      self.items_cache[ft] = nil
+    end,
+    group = luasnip_ag,
+    desc = 'Reset internal cache of luasnip source of blink.cmp when new snippets are added',
+  })
+  vim.api.nvim_create_autocmd('User', {
+    pattern = 'LuasnipCleanup',
+    callback = function() require('blink.cmp').reload('luasnip') end,
+    group = luasnip_ag,
+    desc = 'Reload luasnip source of blink.cmp when snippets are cleared',
+  })
   return self
 end
 


### PR DESCRIPTION
Fixes #662 - Ensure the internal snippet cache is cleared whenever snippets are added or modified. This allows updated snippets to be reflected immediately without requiring a `nvim` restart, addressing the current behavior.

Hey, I think this piece of code fits well in `source.new(opts)`. It works as intended, but if you believe there's a better place for it, let me know, and I’ll make the necessary changes!

Feel free to tell me if I need to make any other changes to this.