### PR TITLE
fix: Completion item label spacing for non "function-like" items

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ MiniDeps.add({
   --
   --   -- disable a keymap from the preset
   --   ['<C-e>'] = {},
-  --   
+  --
   --   -- show with a list of providers
   --   ['<C-space>'] = { function(cmp) cmp.show({ providers = { 'snippets' } }) end },
   --
@@ -306,7 +306,7 @@ MiniDeps.add({
       -- always show the window. We block these by default.
       show_on_blocked_trigger_characters = function()
         if vim.api.nvim_get_mode().mode == 'c' then return {} end
-  
+
         -- you can also block per filetype, for example:
         -- if vim.bo.filetype == 'markdown' then
         --   return { ' ', '\n', '\t', '.', '/', '(', '[' }
@@ -431,7 +431,19 @@ MiniDeps.add({
         components = {
           kind_icon = {
             ellipsis = false,
-            text = function(ctx) return ctx.kind_icon .. ctx.icon_gap end,
+            text = function(ctx)
+              local converted_kind = types.CompletionItemKind[ctx.kind]
+
+              if
+                converted_kind ~= types.CompletionItemKind.Method
+                and converted_kind ~= types.CompletionItemKind.Function
+                and converted_kind ~= types.CompletionItemKind.Constructor
+              then
+                return ctx.label .. ' ' .. ctx.label_detail
+              else
+                return ctx.label .. ctx.label_detail
+              end
+            end,
             highlight = function(ctx)
               return require('blink.cmp.completion.windows.render.tailwind').get_hl(ctx) or 'BlinkCmpKind' .. ctx.kind
             end,
@@ -589,7 +601,7 @@ MiniDeps.add({
     --     return { 'lsp', 'path', 'snippets', 'buffer' }
     --   end
     -- end
-    
+
     -- You may also define providers per filetype
     per_filetype = {
       -- lua = { 'lsp', 'path' },

--- a/lua/blink/cmp/config/completion/menu.lua
+++ b/lua/blink/cmp/config/completion/menu.lua
@@ -1,4 +1,5 @@
 local validate = require('blink.cmp.config.utils').validate
+local types = require('blink.cmp.types')
 
 --- @class (exact) blink.cmp.CompletionMenuConfig
 --- @field enabled boolean
@@ -88,7 +89,25 @@ local window = {
 
         label = {
           width = { fill = true, max = 60 },
-          text = function(ctx) return ctx.label .. ctx.label_detail end,
+          text = function(ctx)
+            -- Make sure that we add a "space" between the `label` & `label_detail`
+            -- if the component kind is not a function/method/constructor.
+            -- This is to avoid situations like: "ModuleNamestruct".
+
+            -- We need to convert to an integer so that we can compare since
+            -- `ctx.kind` is a string like "Method", "Interface", etc.
+            local converted_kind = types.CompletionItemKind[ctx.kind]
+
+            if
+              converted_kind ~= types.CompletionItemKind.Method
+              and converted_kind ~= types.CompletionItemKind.Function
+              and converted_kind ~= types.CompletionItemKind.Constructor
+            then
+              return ctx.label .. ' ' .. ctx.label_detail
+            else
+              return ctx.label .. ctx.label_detail
+            end
+          end,
           highlight = function(ctx)
             -- label and label details
             local label = ctx.label


### PR DESCRIPTION
## Issue

When dealing with completion items the default
`completion.menu.draw.components.label.text(ctx)` function just returns the concatenation of `ctx.label` and `ctx.label_detail` which creates scenarios such as "MyAwesomeModinterface" which is wrongly formatted.

## Solution

The solution consists in checking the `ctx.kind` against the internal `types.CompletionItemKind` table and for any kind that is not either `Method`, `Function`, `Constructor` or `Snippet` we add a space between the `ctx.label` and `ctx.label_detail`.


## Examples

**Before:**
<img width="494" alt="Screenshot 2024-12-20 at 11 23 00" src="https://github.com/user-attachments/assets/50fa7f16-5c17-4200-a85e-b0b7e0ca14cb" />


**After:**
<img width="1015" alt="Screenshot 2024-12-20 at 11 23 38" src="https://github.com/user-attachments/assets/83dd599a-44e8-4eff-9db0-0e31d19416c3" />
