### PR TITLE
fix: auto_show function logic

### DIFF
--- a/lua/blink/cmp/completion/windows/menu.lua
+++ b/lua/blink/cmp/completion/windows/menu.lua
@@ -54,7 +54,8 @@ function menu.open_with_items(context, items)
   if not menu.renderer then menu.renderer = require('blink.cmp.completion.windows.render').new(config.draw) end
   menu.renderer:draw(context, menu.win:get_buf(), items)
 
-  local auto_show = type(menu.auto_show) == 'function' and menu.auto_show(context, items) or menu.auto_show
+  local auto_show = menu.auto_show
+  if type(auto_show) == 'function' then auto_show = auto_show(context, items) end
   if auto_show then
     menu.open()
     menu.update_position()


### PR DESCRIPTION
This code was reduced by a line before merging PR #697, but it's now hitting the case where the Lua 'ternary' doesn't behave like a proper ternary operator. Specifically, when the `auto_show` function returns false, the result of
```lua
auto_show = type(auto_show) == "function" and auto_show(...) or auto_show
```
becomes
```lua
auto_show = (true and false) or <function>
```
which is the truthy function reference itself.