### PR TITLE
docs: Add missing window table to set the documentation border

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -15,10 +15,10 @@ end,
 
 ```lua
 completion = {
-  menu = { border = 'single' }
-  documentation = { border = 'single' }
+  menu = { border = 'single' },
+  documentation = { window = { border = 'single' } },
 },
-signature = { window = { border = 'single' } }
+signature = { window = { border = 'single' } },
 ```
 
 ## Select Nth item from the list


### PR DESCRIPTION
The recipe was missing the window, so Blink complains at running. This fix the snippet