### PR TITLE
fix(notifications): add title to notifications

### DIFF
--- a/lua/blink/cmp/accept/init.lua
+++ b/lua/blink/cmp/accept/init.lua
@@ -78,7 +78,7 @@ local function accept(ctx, item)
       -- TODO: why is this so slow? (10ms)
       vim.schedule(function() require('blink.cmp.fuzzy').access(item) end)
     end)
-    :catch(function(err) vim.notify(err, vim.log.levels.ERROR) end)
+    :catch(function(err) vim.notify(err, vim.log.levels.ERROR, { title = 'blink.cmp' }) end)
 end
 
 return accept

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -7,7 +7,7 @@ cmp.setup = function(opts)
 
   require('blink.cmp.fuzzy.download').ensure_downloaded(function(err)
     if err then
-      vim.notify('Error while downloading blink.cmp pre-built binary: ' .. err, vim.log.levels.ERROR)
+      vim.notify('Error while downloading blink.cmp pre-built binary: ' .. err, vim.log.levels.ERROR, { title = 'blink.cmp' })
       return
     end
 

--- a/lua/blink/cmp/sources/snippets/utils.lua
+++ b/lua/blink/cmp/sources/snippets/utils.lua
@@ -8,7 +8,8 @@ function utils.parse_json_with_error_msg(path, json)
   if not ok then
     vim.notify(
       'Failed to parse json file "' .. path .. '" for blink.cmp snippets. Error: ' .. parsed,
-      vim.log.levels.ERROR
+      vim.log.levels.ERROR,
+      { title = 'blink.cmp' }
     )
     return {}
   end

--- a/lua/blink/cmp/windows/documentation.lua
+++ b/lua/blink/cmp/windows/documentation.lua
@@ -74,7 +74,7 @@ function docs.show_item(item)
         docs.update_position()
       end
     end)
-    :catch(function(err) vim.notify(err, vim.log.levels.ERROR) end)
+    :catch(function(err) vim.notify(err, vim.log.levels.ERROR, { title = 'blink.cmp' }) end)
 end
 
 function docs.scroll_up(amount)


### PR DESCRIPTION
Adds the missing `title` to the notification, which is an informal standard used by notification plugins like `snacks.nvim` or `nvim-notify`. Adding a title is relevant, since without a title it can create confusion which plugin created the notification.

I added the title to all instances of `vim.notify`. Could not find the `Downloading pre-built binary` notification though, which appears to be sent via some other method?