### PR TITLE
fix(notifications): add title to notifications

### DIFF
--- a/lua/blink/cmp/completion/accept/init.lua
+++ b/lua/blink/cmp/completion/accept/init.lua
@@ -99,7 +99,7 @@ local function accept(ctx, item, callback)
         require('blink.cmp.fuzzy').access(item)
       end)
     end)
-    :catch(function(err) vim.notify(err, vim.log.levels.ERROR) end)
+    :catch(function(err) vim.notify(err, vim.log.levels.ERROR, { title = 'blink.cmp' }) end)
 end
 
 return accept

--- a/lua/blink/cmp/completion/windows/documentation.lua
+++ b/lua/blink/cmp/completion/windows/documentation.lua
@@ -100,7 +100,7 @@ function docs.show_item(context, item)
         docs.update_position()
       end
     end)
-    :catch(function(err) vim.notify(err, vim.log.levels.ERROR) end)
+    :catch(function(err) vim.notify(err, vim.log.levels.ERROR, { title = 'blink.cmp' }) end)
 end
 
 function docs.scroll_up(amount)

--- a/lua/blink/cmp/fuzzy/download/init.lua
+++ b/lua/blink/cmp/fuzzy/download/init.lua
@@ -41,8 +41,12 @@ function download.ensure_downloaded(callback)
       if state.version == target_version and state.is_downloaded then
         return files.verify_checksum():catch(function(err)
           vim.schedule(function()
-            vim.notify(err, vim.log.levels.WARN)
-            vim.notify('Pre-built binary failed checksum verification, re-downloading', vim.log.levels.WARN)
+            vim.notify(err, vim.log.levels.WARN, { title = 'blink.cmp' })
+            vim.notify(
+              'Pre-built binary failed checksum verification, re-downloading',
+              vim.log.levels.WARN,
+              { title = 'blink.cmp' }
+            )
           end)
           return download.download(target_version)
         end)
@@ -52,7 +56,9 @@ function download.ensure_downloaded(callback)
       if not target_version then error('Unknown error while getting pre-built binary. Consider re-installing') end
 
       -- download as per usual
-      vim.schedule(function() vim.notify('Downloading pre-built binary', vim.log.levels.INFO) end)
+      vim.schedule(
+        function() vim.notify('Downloading pre-built binary', vim.log.levels.INFO, { title = 'blink.cmp' }) end
+      )
       return download.download(target_version)
     end)
     :map(function() callback() end)

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -10,7 +10,7 @@ function cmp.setup(opts)
 
   local version = vim.version()
   if version.major == 0 and version.minor < 10 then
-    vim.notify('blink.cmp only supports nvim 0.10 and newer', vim.log.levels.ERROR)
+    vim.notify('blink.cmp only supports nvim 0.10 and newer', vim.log.levels.ERROR, { title = 'blink.cmp' })
     return
   end
 

--- a/lua/blink/cmp/sources/cmdline/init.lua
+++ b/lua/blink/cmp/sources/cmdline/init.lua
@@ -78,7 +78,7 @@ function cmdline:get_completions(context, callback)
       })
     end)
     :catch(function(err)
-      vim.notify('Error while fetching completions: ' .. err, vim.log.levels.ERROR)
+      vim.notify('Error while fetching completions: ' .. err, vim.log.levels.ERROR, { title = 'blink.cmp' })
       callback({ is_incomplete_backward = false, is_incomplete_forward = false, items = {} })
     end)
 

--- a/lua/blink/cmp/sources/snippets/utils.lua
+++ b/lua/blink/cmp/sources/snippets/utils.lua
@@ -10,7 +10,8 @@ function utils.parse_json_with_error_msg(path, json)
   if not ok then
     vim.notify(
       'Failed to parse json file "' .. path .. '" for blink.cmp snippets. Error: ' .. parsed,
-      vim.log.levels.ERROR
+      vim.log.levels.ERROR,
+      { title = 'blink.cmp' }
     )
     return {}
   end


### PR DESCRIPTION
Adds the missing title to the notification, which is an informal standard used by notification plugins like `snacks.nvim` or `nvim-notify`. Adding a title is relevant, since without a title it can create confusion which plugin created the notification.