### PR TITLE
FIX(#725): inherit package.cpath in worker thread

### DIFF
--- a/lua/blink/cmp/fuzzy/init.lua
+++ b/lua/blink/cmp/fuzzy/init.lua
@@ -24,8 +24,11 @@ function fuzzy.access(item)
 
   -- writing to the db takes ~10ms, so schedule writes in another thread
   vim.uv
-    .new_work(function(itm) require('blink.cmp.fuzzy.rust').access(vim.mpack.decode(itm)) end, function() end)
-    :queue(vim.mpack.encode(item))
+    .new_work(function(itm, cpath)
+      package.cpath = cpath
+      require('blink.cmp.fuzzy.rust').access(vim.mpack.decode(itm))
+    end, function() end)
+    :queue(vim.mpack.encode(item), package.cpath)
 end
 
 ---@param lines string

--- a/lua/blink/cmp/sources/buffer.lua
+++ b/lua/blink/cmp/sources/buffer.lua
@@ -52,13 +52,16 @@ local function run_sync(buf_text, callback) callback(words_to_items(require('bli
 local function run_async(buf_text, callback)
   local worker = uv.new_work(
     -- must use ffi directly since the normal one requires the config which isnt present
-    function(items) return table.concat(require('blink.cmp.fuzzy.rust').get_words(items), '\n') end,
+    function(items, cpath)
+      package.cpath = cpath
+      return table.concat(require('blink.cmp.fuzzy.rust').get_words(items), '\n')
+    end,
     function(words)
       local items = words_to_items(vim.split(words, '\n'))
       vim.schedule(function() callback(items) end)
     end
   )
-  worker:queue(buf_text)
+  worker:queue(buf_text, package.cpath)
 end
 
 --- @class blink.cmp.BufferOpts


### PR DESCRIPTION
Fixes #725, just makes sure that `package.cpath` is inherited into the worker thread so that user can add their own entries to `package.cpath`.