### PR TITLE
fix: add java to blocked filetypes for semantic token auto_brackets

### DIFF
--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -135,7 +135,7 @@ completion.accept = {
     -- Asynchronously use semantic token to determine if brackets should be added
     semantic_token_resolution = {
       enabled = true,
-      blocked_filetypes = {},
+      blocked_filetypes = { 'java' },
       -- How long to wait for semantic tokens to return before assuming no brackets should be added
       timeout_ms = 400,
     },

--- a/lua/blink/cmp/config/completion/accept.lua
+++ b/lua/blink/cmp/config/completion/accept.lua
@@ -37,7 +37,7 @@ local accept = {
       },
       semantic_token_resolution = {
         enabled = true,
-        blocked_filetypes = {},
+        blocked_filetypes = { 'java' },
         timeout_ms = 400,
       },
     },


### PR DESCRIPTION
I think JDTLS already has built in auto-bracket support, but setting this seems to make stuff behave as it should on my part, and [these docs](https://cmp.saghen.dev/configuration/completion.html#auto-brackets) suggested creating a PR.