### PR TITLE
Refactor and cleanup flake.nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+watch_file **/*.nix
+
+use flake

--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,0 @@
-watch_file **/*.nix
-
-use flake

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
         packages = let
           src = ./.;
           version = "0.8.2";
-        in rec {
+        in {
           blink-fuzzy-lib = let
             inherit (inputs.fenix.packages.${system}.minimal) toolchain;
             rustPlatform = pkgs.makeRustPlatform {
@@ -36,37 +36,15 @@
             inherit src version;
             useFetchCargoVendor = true;
             cargoHash = "sha256-t84hokb2loZ6FPPt4eN8HzgNQJrQUdiG5//ZbmlasWY=";
-
-            nativeBuildInputs = with pkgs; [ git ];
-
-            passthru.updateScript = pkgs.nix-update-script;
           };
 
-          blink-cmp = let
-            inherit (pkgs.stdenv) hostPlatform;
-            libExt = if hostPlatform.isDarwin then
-              "dylib"
-            else if hostPlatform.isWindows then
-              "dll"
-            else
-              "so";
-          in pkgs.vimUtils.buildVimPlugin {
+          blink-cmp = pkgs.vimUtils.buildVimPlugin {
             pname = "blink-cmp";
             inherit src version;
             preInstall = ''
               mkdir -p target/release
-              ln -s ${blink-fuzzy-lib}/lib/libblink_cmp_fuzzy.${libExt} target/release/libblink_cmp_fuzzy.${libExt}
+              ln -s ${self'.packages.blink-fuzzy-lib}/lib/libblink_cmp_fuzzy.* target/release/
             '';
-
-            passthru.updateScript = pkgs.nix-update-script;
-
-            meta = {
-              description =
-                "Performant, batteries-included completion plugin for Neovim ";
-              homepage = "https://github.com/saghen/blink.cmp";
-              license = lib.licenses.mit;
-              maintainers = with lib.maintainers; [ redxtech ];
-            };
           };
 
           default = self'.packages.blink-cmp;

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,8 @@
             inherit src version;
             useFetchCargoVendor = true;
             cargoHash = "sha256-t84hokb2loZ6FPPt4eN8HzgNQJrQUdiG5//ZbmlasWY=";
+
+            nativeBuildInputs = with pkgs; [ git ];
           };
 
           blink-cmp = pkgs.vimUtils.buildVimPlugin {
@@ -67,12 +69,13 @@
         # define the default dev environment
         devShells.default = pkgs.mkShell {
           name = "blink";
+          inputsFrom = [
+            self'.packages.blink-fuzzy-lib
+            self'.packages.blink-cmp
+            self'.apps.build-plugin
+          ];
           packages = with pkgs; [
-            git
-            gcc
-            fenix.complete.toolchain
             rust-analyzer-nightly
-            nix-update
           ];
         };
       };


### PR DESCRIPTION
Hey, please take a look at this proposition of cleaning the flake.nix in this repo:
- kind of unrelated but added a basic .envrc file
- meta, updater scripts etc. are not used outside nixpkgs, can be safely removed (unless you use them in some way?)
- if/else regarding extension can be replaced with a simple glob pattern (tested on linux and darwin)
- removed `rec` and replaced with `self'` - safer
- added inputsFrom to devshell so that we don't need to repeat the same packages and remember about it

As future improvements that build on top of this we could:
- adopt nixfmt-rfc-style https://github.com/Saghen/blink.cmp/pull/736
- make separate src for rust and lua (e.g. now blink-fuzzy-lib compiles every time I change flake.nix or some lua file, it should not be that way)
- find a way to use cargoLock.lockFile instead of hash which changes and makes updates painful

Let me know what you think and whether the above suggestions sound ok. If so I can work on them in the following days.
