### PR TITLE
Nixfmt rfc style

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+watch_file **/*.nix
+
+use flake

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
         packages = let
           src = ./.;
           version = "0.8.2";
-        in rec {
+        in {
           blink-fuzzy-lib = let
             inherit (inputs.fenix.packages.${system}.minimal) toolchain;
             rustPlatform = pkgs.makeRustPlatform {
@@ -36,37 +36,15 @@
             inherit src version;
             useFetchCargoVendor = true;
             cargoHash = "sha256-t84hokb2loZ6FPPt4eN8HzgNQJrQUdiG5//ZbmlasWY=";
-
-            nativeBuildInputs = with pkgs; [ git ];
-
-            passthru.updateScript = pkgs.nix-update-script;
           };
 
-          blink-cmp = let
-            inherit (pkgs.stdenv) hostPlatform;
-            libExt = if hostPlatform.isDarwin then
-              "dylib"
-            else if hostPlatform.isWindows then
-              "dll"
-            else
-              "so";
-          in pkgs.vimUtils.buildVimPlugin {
+          blink-cmp = pkgs.vimUtils.buildVimPlugin {
             pname = "blink-cmp";
             inherit src version;
             preInstall = ''
               mkdir -p target/release
-              ln -s ${blink-fuzzy-lib}/lib/libblink_cmp_fuzzy.${libExt} target/release/libblink_cmp_fuzzy.${libExt}
+              ln -s ${self'.packages.blink-fuzzy-lib}/lib/libblink_cmp_fuzzy.* target/release/
             '';
-
-            passthru.updateScript = pkgs.nix-update-script;
-
-            meta = {
-              description =
-                "Performant, batteries-included completion plugin for Neovim ";
-              homepage = "https://github.com/saghen/blink.cmp";
-              license = lib.licenses.mit;
-              maintainers = with lib.maintainers; [ redxtech ];
-            };
           };
 
           default = self'.packages.blink-cmp;

--- a/flake.nix
+++ b/flake.nix
@@ -8,78 +8,103 @@
     fenix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = inputs@{ flake-parts, nixpkgs, ... }:
+  outputs =
+    inputs@{ flake-parts, nixpkgs, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
-      systems =
-        [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      systems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
 
-      perSystem = { self, config, self', inputs', pkgs, system, lib, ... }: {
-        # use fenix overlay
-        _module.args.pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ inputs.fenix.overlays.default ];
-        };
-
-        # define the packages provided by this flake
-        packages = let
-          src = ./.;
-          version = "0.8.2";
-        in {
-          blink-fuzzy-lib = let
-            inherit (inputs.fenix.packages.${system}.minimal) toolchain;
-            rustPlatform = pkgs.makeRustPlatform {
-              cargo = toolchain;
-              rustc = toolchain;
-            };
-          in rustPlatform.buildRustPackage {
-            pname = "blink-fuzzy-lib";
-            inherit src version;
-            useFetchCargoVendor = true;
-            cargoHash = "sha256-t84hokb2loZ6FPPt4eN8HzgNQJrQUdiG5//ZbmlasWY=";
-
-            nativeBuildInputs = with pkgs; [ git ];
+      perSystem =
+        {
+          self,
+          config,
+          self',
+          inputs',
+          pkgs,
+          system,
+          lib,
+          ...
+        }:
+        {
+          # use fenix overlay
+          _module.args.pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ inputs.fenix.overlays.default ];
           };
 
-          blink-cmp = pkgs.vimUtils.buildVimPlugin {
-            pname = "blink-cmp";
-            inherit src version;
-            preInstall = ''
-              mkdir -p target/release
-              ln -s ${self'.packages.blink-fuzzy-lib}/lib/libblink_cmp_fuzzy.* target/release/
-            '';
+          # define the packages provided by this flake
+          packages =
+            let
+              src = ./.;
+              version = "0.8.2";
+            in
+            {
+              blink-fuzzy-lib =
+                let
+                  inherit (inputs.fenix.packages.${system}.minimal) toolchain;
+                  rustPlatform = pkgs.makeRustPlatform {
+                    cargo = toolchain;
+                    rustc = toolchain;
+                  };
+                in
+                rustPlatform.buildRustPackage {
+                  pname = "blink-fuzzy-lib";
+                  inherit src version;
+                  useFetchCargoVendor = true;
+                  cargoHash = "sha256-t84hokb2loZ6FPPt4eN8HzgNQJrQUdiG5//ZbmlasWY=";
+
+                  nativeBuildInputs = with pkgs; [ git ];
+                };
+
+              blink-cmp = pkgs.vimUtils.buildVimPlugin {
+                pname = "blink-cmp";
+                inherit src version;
+                preInstall = ''
+                  mkdir -p target/release
+                  ln -s ${self'.packages.blink-fuzzy-lib}/lib/libblink_cmp_fuzzy.* target/release/
+                '';
+              };
+
+              default = self'.packages.blink-cmp;
+            };
+
+          # builds the native module of the plugin
+          apps.build-plugin = {
+            type = "app";
+            program =
+              let
+                buildScript = pkgs.writeShellApplication {
+                  name = "build-plugin";
+                  runtimeInputs = with pkgs; [
+                    fenix.minimal.toolchain
+                    gcc
+                  ];
+                  text = ''
+                    cargo build --release
+                  '';
+                };
+              in
+              (lib.getExe buildScript);
           };
 
-          default = self'.packages.blink-cmp;
-        };
+          # define the default dev environment
+          devShells.default = pkgs.mkShell {
+            name = "blink";
+            inputsFrom = [
+              self'.packages.blink-fuzzy-lib
+              self'.packages.blink-cmp
+              self'.apps.build-plugin
+            ];
+            packages = with pkgs; [
+              rust-analyzer-nightly
+            ];
+          };
 
-        # builds the native module of the plugin
-        apps.build-plugin = {
-          type = "app";
-          program = let
-            buildScript = pkgs.writeShellApplication {
-              name = "build-plugin";
-              runtimeInputs = with pkgs; [ fenix.minimal.toolchain gcc ];
-              text = ''
-                cargo build --release
-              '';
-            };
-          in (lib.getExe buildScript);
+          formatter = pkgs.nixfmt-rfc-style;
         };
-
-        # define the default dev environment
-        devShells.default = pkgs.mkShell {
-          name = "blink";
-          inputsFrom = [
-            self'.packages.blink-fuzzy-lib
-            self'.packages.blink-cmp
-            self'.apps.build-plugin
-          ];
-          packages = with pkgs; [
-            rust-analyzer-nightly
-          ];
-        };
-
-        formatter = pkgs.nixfmt-rfc-style;
-      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,8 @@
             rust-analyzer-nightly
           ];
         };
+
+        formatter = pkgs.nixfmt-rfc-style;
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,8 @@
             inherit src version;
             useFetchCargoVendor = true;
             cargoHash = "sha256-t84hokb2loZ6FPPt4eN8HzgNQJrQUdiG5//ZbmlasWY=";
+
+            nativeBuildInputs = with pkgs; [ git ];
           };
 
           blink-cmp = pkgs.vimUtils.buildVimPlugin {
@@ -67,12 +69,13 @@
         # define the default dev environment
         devShells.default = pkgs.mkShell {
           name = "blink";
+          inputsFrom = [
+            self'.packages.blink-fuzzy-lib
+            self'.packages.blink-cmp
+            self'.apps.build-plugin
+          ];
           packages = with pkgs; [
-            git
-            gcc
-            fenix.complete.toolchain
             rust-analyzer-nightly
-            nix-update
           ];
         };
       };


### PR DESCRIPTION
Note: this builds on top of https://github.com/Saghen/blink.cmp/pull/735

Here we adopt a standard nixpkgs formatter - nixfmt-rfc-style and then reformat flake.nix using that.

To use it: `nix fmt **/*.nix`