### PR TITLE
fix: documentation losing syntax highlighting on doc reopen

### DIFF
--- a/lua/blink/cmp/completion/windows/documentation.lua
+++ b/lua/blink/cmp/completion/windows/documentation.lua
@@ -37,10 +37,7 @@ local docs = {
 }
 
 menu.position_update_emitter:on(function() docs.update_position() end)
-menu.close_emitter:on(function()
-  docs.win:close()
-  docs.auto_show_timer:stop()
-end)
+menu.close_emitter:on(function() docs.close() end)
 
 function docs.auto_show_item(context, item)
   docs.auto_show_timer:stop()
@@ -66,7 +63,7 @@ function docs.show_item(context, item)
     ---@param item blink.cmp.CompletionItem
     :map(function(item)
       if item.documentation == nil and item.detail == nil then
-        docs.win:close()
+        docs.close()
         return
       end
 
@@ -220,6 +217,12 @@ function docs.update_position()
       set_config({ row = -menu_border_size.top, col = -width - menu_border_size.left })
     end
   end
+end
+
+function docs.close()
+  docs.win:close()
+  docs.auto_show_timer:stop()
+  docs.shown_item = nil
 end
 
 return docs

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -126,7 +126,7 @@ function cmp.hide_documentation()
   local documentation = require('blink.cmp.completion.windows.documentation')
   if not documentation.win:is_open() then return end
 
-  vim.schedule(function() documentation.win:close() end)
+  vim.schedule(function() documentation.close() end)
   return true
 end
 


### PR DESCRIPTION
Issue
=====

Providers (completion plugins) can provide a custom implementation for rendering the documentation. Some need to use e.g. Neovim's built-in regex based syntax highlighting. If the documentation window is closed and reopened, the syntax highlighting is lost.

https://github.com/user-attachments/assets/07793221-fc83-49cd-b310-c54c401f562b

Solution
========

Allow plugins to redraw the documentation window when the documentation window is reopened.


https://github.com/user-attachments/assets/7dfe9d62-50a8-4f26-99e3-b73683a1005d



Solves https://github.com/Saghen/blink.cmp/issues/703