### PR TITLE
docs: add blink-emoji.nvim to community sources

### DIFF
--- a/docs/configuration/sources.md
+++ b/docs/configuration/sources.md
@@ -61,3 +61,4 @@ Blink can use `nvim-cmp` sources through a compatibility layer developed by [ste
 - [blink-cmp-ctags](https://github.com/netmute/blink-cmp-ctags)
 - [blink-cmp-copilot](https://github.com/giuxtaposition/blink-cmp-copilot)
 - [minuet-ai.nvim](https://github.com/milanglacier/minuet-ai.nvim)
+- [blink-emoji.nvim](https://github.com/moyiz/blink-emoji.nvim)


### PR DESCRIPTION
Hi there,

Adding [blink-emoji.nvim](https://github.com/moyiz/blink-emoji.nvim) to Community Sources.
It is an adaptation of [cmp-emoji](https://github.com/hrsh7th/cmp-emoji/) to better support `blink.cmp`.

Thanks for `blink` :muscle: 