### PR TITLE
signatures: show all overloads

### DIFF
--- a/lua/blink/cmp/lib/window/docs.lua
+++ b/lua/blink/cmp/lib/window/docs.lua
@@ -4,7 +4,7 @@ local docs = {}
 
 --- @class blink.cmp.RenderDetailAndDocumentationOpts
 --- @field bufnr number
---- @field detail? string
+--- @field detail? string|string[]
 --- @field documentation? lsp.MarkupContent | string
 --- @field max_width number
 --- @field use_treesitter_highlighting boolean?
@@ -19,7 +19,20 @@ local docs = {}
 --- @param opts blink.cmp.RenderDetailAndDocumentationOpts
 function docs.render_detail_and_documentation(opts)
   local detail_lines = {}
-  if opts.detail and opts.detail ~= '' then detail_lines = docs.split_lines(opts.detail) end
+
+  if opts.detail then
+    if type(opts.detail) == 'table' then
+      for _, detail in ipairs(opts.detail) do
+        if detail ~= '' then
+          for _, v in ipairs(docs.split_lines(detail)) do
+            detail_lines[#detail_lines + 1] = v
+          end
+        end
+      end
+    elseif type(opts.detail) == 'string' then
+      if opts.detail and opts.detail ~= '' then detail_lines = docs.split_lines(opts.detail) end
+    end
+  end
 
   local doc_lines = {}
   if opts.documentation ~= nil then

--- a/lua/blink/cmp/lib/window/docs.lua
+++ b/lua/blink/cmp/lib/window/docs.lua
@@ -20,20 +20,11 @@ local docs = {}
 function docs.render_detail_and_documentation(opts)
   local detail_lines = {}
 
-  if opts.detail then
-    if type(opts.detail) == 'table' then
-      local already_added = {}
-      for _, detail in ipairs(opts.detail) do
-        if detail ~= '' and not already_added[detail] then
-          already_added[detail] = true
-          for _, v in ipairs(docs.split_lines(detail)) do
-            detail_lines[#detail_lines + 1] = v
-          end
-        end
-      end
-    elseif type(opts.detail) == 'string' then
-      if opts.detail and opts.detail ~= '' then detail_lines = docs.split_lines(opts.detail) end
-    end
+  local details = type(opts.detail) == 'string' and { opts.detail } or opts.detail
+  details = require('blink.cmp.lib.utils').deduplicate(details)
+
+  for _, v in ipairs(details) do
+    vim.list_extend(detail_lines, docs.split_lines(v))
   end
 
   local doc_lines = {}

--- a/lua/blink/cmp/lib/window/docs.lua
+++ b/lua/blink/cmp/lib/window/docs.lua
@@ -22,8 +22,10 @@ function docs.render_detail_and_documentation(opts)
 
   if opts.detail then
     if type(opts.detail) == 'table' then
+      local already_added = {}
       for _, detail in ipairs(opts.detail) do
-        if detail ~= '' then
+        if detail ~= '' and not already_added[detail] then
+          already_added[detail] = true
           for _, v in ipairs(docs.split_lines(detail)) do
             detail_lines[#detail_lines + 1] = v
           end

--- a/lua/blink/cmp/signature/window.lua
+++ b/lua/blink/cmp/signature/window.lua
@@ -52,10 +52,7 @@ function signature.open_with_signature_help(context, signature_help)
 
   local active_signature = signature_help.signatures[(signature_help.activeSignature or 0) + 1]
 
-  local labels = {}
-  for _, v in ipairs(signature_help.signatures) do
-    labels[#labels + 1] = v.label
-  end
+  local labels = vim.tbl_map(function(signature) return signature.label end, signature_help.signatures)
 
   if signature.shown_signature ~= active_signature then
     require('blink.cmp.lib.window.docs').render_detail_and_documentation({

--- a/lua/blink/cmp/signature/window.lua
+++ b/lua/blink/cmp/signature/window.lua
@@ -52,10 +52,15 @@ function signature.open_with_signature_help(context, signature_help)
 
   local active_signature = signature_help.signatures[(signature_help.activeSignature or 0) + 1]
 
+  local labels = {}
+  for _, v in ipairs(signature_help.signatures) do
+    labels[#labels + 1] = v.label
+  end
+
   if signature.shown_signature ~= active_signature then
     require('blink.cmp.lib.window.docs').render_detail_and_documentation({
       bufnr = signature.win:get_buf(),
-      detail = active_signature.label,
+      detail = labels,
       documentation = active_signature.documentation,
       max_width = config.max_width,
       use_treesitter_highlighting = config.treesitter_highlighting,


### PR DESCRIPTION
with this change the signature help should show all signatures that are possible given the current parameters.
This is useful for languages that support function overloading.

Given

```cpp
void fn_ov();
void fn_ov(int i, float f, float f2);
void fn_ov(int i, float f);
void fn_ov(int i);
```

it should show:
![signatures](https://github.com/user-attachments/assets/62bc9b11-f7f1-4d29-a07f-3c548c5b95e7)
