### PR TITLE
fix: remove `providers` from transform_items

### DIFF
--- a/docs/configuration/snippets.md
+++ b/docs/configuration/snippets.md
@@ -63,7 +63,7 @@ By default, the `snippets` source will check `~/.config/nvim/snippets` for your 
 ## Disable all snippets
 
 ```lua
-sources.providers.transform_items = function(_, items)
+sources.transform_items = function(_, items)
   return vim.tbl_filter(function(item)
     return item.kind ~= require('blink.cmp.types').CompletionItemKind.Snippet
   end, items)


### PR DESCRIPTION
I was unable to disable all of the snippets and kept getting a failure for trying to index into providers. I think the docs might be mistaken here. 