### PR TITLE
docs(recipes): dont show when searching

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -42,6 +42,21 @@ completion = {
 }
 ```
 
+## Don't show completion menu automatically only when searching
+
+```lua
+completion = {
+  menu = {
+    auto_show = function(ctx)
+      if ctx.mode == "cmdline" then
+        return not vim.fn.getcmdtype():match("[/\\?]")
+      end
+      return true
+    end,
+  },
+}
+```
+
 ## Select Nth item from the list
 
 Here's an example configuration that allows you to select the nth item from the list, based on [#382](https://github.com/Saghen/blink.cmp/issues/382):

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -42,16 +42,13 @@ completion = {
 }
 ```
 
-## Don't show completion menu automatically only when searching
+## Don't show completion menu automatically when searching
 
 ```lua
 completion = {
   menu = {
     auto_show = function(ctx)
-      if ctx.mode == "cmdline" then
-        return not vim.fn.getcmdtype():match("[/\\?]")
-      end
-      return true
+      return ctx.mode ~= "cmdline" or not vim.tbl_contains({ '/', '?' }, vim.fn.getcmdtype())
     end,
   },
 }


### PR DESCRIPTION
I find the auto-complete when searching to be distracting and prefer this pattern to maintain the auto-complete when using the command line for commands. Thought it might make a good recipe to include. No biggie if not. 

Thanks for the plugin!

![Screenshot 2024-12-25 at 10 42 15 AM](https://github.com/user-attachments/assets/4d8669c2-23ab-419f-a369-e3002a2fc793)
![Screenshot 2024-12-25 at 10 42 44 AM](https://github.com/user-attachments/assets/1481d218-6f9a-4361-9116-00f5b017b336)
