### PR TITLE
Allow show() to trigger while ghost-text is visible

### DIFF
--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -39,7 +39,7 @@ end
 
 --- @params opts? { providers?: string[] }
 function cmp.show(opts)
-  if cmp.is_visible() and not (opts and opts.providers) then return end
+  if require('blink.cmp.completion.windows.menu').win:is_open() and not (opts and opts.providers) then return end
 
   vim.schedule(function()
     require('blink.cmp.completion.windows.menu').auto_show = true


### PR DESCRIPTION
This is a fix for https://github.com/Saghen/blink.cmp/issues/762: an issue where manually triggering `show()` via a key combo (for those of us that don't use `auto_show`) isn't possible while ghost text is visible.

Note that the current "fix" is very low effort. I simply looked at the definition for `cmp.is_visible()` and decided to just copy one half of that function without the "ghost text is visible part". **This is on purpose! You can interpret this as a _draft_ PR.** I'd be glad to refactor this a bit even if that only means splitting a `cmp.is_menu_visible()` helper function. But...

...I first want to make sure that this fix is desired. I can verify after running this locally that this fixes my issue. But I'm unsure if this breaks anything else.

I'm happy to polish this further, write a test, you name it! Let me know 😆

Thanks for all of the work on `blink.cmp`. Thanks to it I now finally have a completion setup that I'm happy with!