### PR TITLE
feat: add `BlinkCmpStatus` command

### DIFF
--- a/docs/configuration/sources.md
+++ b/docs/configuration/sources.md
@@ -54,7 +54,7 @@ Blink can use `nvim-cmp` sources through a compatibility layer developed by [ste
 
 ## Checking status of sources providers
 
-The command `:BlinkCmpStatus` can be used to view which sources providers are enabled or not enabled.
+The command `:BlinkCmp status` can be used to view which sources providers are enabled or not enabled.
 
 ## Community sources
 

--- a/docs/configuration/sources.md
+++ b/docs/configuration/sources.md
@@ -52,6 +52,10 @@ sources.providers.lsp = {
 
 Blink can use `nvim-cmp` sources through a compatibility layer developed by [stefanboca](https://github.com/stefanboca): [blink.compat](https://github.com/Saghen/blink.compat). Please open any issues with `blink.compat` in that repo
 
+## Checking status of sources providers
+
+The command `:BlinkCmpStatus` can be used to view which sources providers are enabled or not enabled.
+
 ## Community sources
 
 - [lazydev](https://github.com/folke/lazydev.nvim)

--- a/lua/blink/cmp/commands.lua
+++ b/lua/blink/cmp/commands.lua
@@ -1,0 +1,43 @@
+local commands = {}
+
+function commands.status()
+  local sources = require('blink.cmp.sources.lib')
+  local all_providers = sources.get_all_providers()
+  local enabled_provider_ids = sources.get_enabled_provider_ids('default')
+
+  --- @type string[]
+  local not_enabled_provider_ids = {}
+  for provider_id, _ in pairs(all_providers) do
+    if not vim.list_contains(enabled_provider_ids, provider_id) then
+      table.insert(not_enabled_provider_ids, provider_id)
+    end
+  end
+
+  if #enabled_provider_ids > 0 then
+    vim.api.nvim_echo({ { '\n', 'Normal' } }, false, {})
+    vim.api.nvim_echo({ { '# enabled sources providers\n', 'Special' } }, false, {})
+
+    for _, provider_id in ipairs(enabled_provider_ids) do
+      vim.api.nvim_echo({ { ('- %s\n'):format(provider_id), 'Normal' } }, false, {})
+    end
+  end
+
+  if #not_enabled_provider_ids > 0 then
+    vim.api.nvim_echo({ { '\n', 'Normal' } }, false, {})
+    vim.api.nvim_echo({ { '# not enabled sources providers\n', 'Comment' } }, false, {})
+
+    for _, provider_id in pairs(not_enabled_provider_ids) do
+      vim.api.nvim_echo({ { ('- %s\n'):format(provider_id), 'Normal' } }, false, {})
+    end
+  end
+end
+
+function commands.setup()
+  vim.api.nvim_create_user_command(
+    'BlinkCmpStatus',
+    function() commands.status() end,
+    { desc = 'Check status of blink.cmp sources providers' }
+  )
+end
+
+return commands

--- a/lua/blink/cmp/commands.lua
+++ b/lua/blink/cmp/commands.lua
@@ -33,11 +33,13 @@ function commands.status()
 end
 
 function commands.setup()
-  vim.api.nvim_create_user_command(
-    'BlinkCmpStatus',
-    function() commands.status() end,
-    { desc = 'Check status of blink.cmp sources providers' }
-  )
+  vim.api.nvim_create_user_command('BlinkCmp', function(cmd)
+    if cmd.fargs[1] == 'status' then
+      commands.status()
+    else
+      vim.notify("[blink.cmp] invalid command '" .. cmd.args .. "'", vim.log.levels.ERROR)
+    end
+  end, { nargs = 1, complete = function() return { 'status' } end, desc = 'blink.cmp' })
 end
 
 return commands

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -184,4 +184,42 @@ function cmp.add_provider(id, provider_config)
   config.sources.providers[id] = provider_config
 end
 
+function cmp.status()
+  local sources = require('blink.cmp.sources.lib')
+  local all_providers = sources.get_all_providers()
+  local enabled_provider_ids = sources.get_enabled_provider_ids('default')
+
+  --- @type string[]
+  local not_enabled_provider_ids = {}
+  for provider_id, _ in pairs(all_providers) do
+    if not vim.list_contains(enabled_provider_ids, provider_id) then
+      table.insert(not_enabled_provider_ids, provider_id)
+    end
+  end
+
+  if #enabled_provider_ids > 0 then
+    vim.api.nvim_echo({ { '\n', 'Normal' } }, false, {})
+    vim.api.nvim_echo({ { '# enabled sources providers\n', 'Special' } }, false, {})
+
+    for _, provider_id in ipairs(enabled_provider_ids) do
+      vim.api.nvim_echo({ { ('- %s\n'):format(provider_id), 'Normal' } }, false, {})
+    end
+  end
+
+  if #not_enabled_provider_ids > 0 then
+    vim.api.nvim_echo({ { '\n', 'Normal' } }, false, {})
+    vim.api.nvim_echo({ { '# not enabled sources providers\n', 'Comment' } }, false, {})
+
+    for _, provider_id in pairs(not_enabled_provider_ids) do
+      vim.api.nvim_echo({ { ('- %s\n'):format(provider_id), 'Normal' } }, false, {})
+    end
+  end
+end
+
+vim.api.nvim_create_user_command(
+  'BlinkCmpStatus',
+  function() cmp.status() end,
+  { desc = 'Check status of blink.cmp sources providers' }
+)
+
 return cmp

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -20,10 +20,11 @@ function cmp.setup(opts)
   require('blink.cmp.fuzzy.download').ensure_downloaded(function(err)
     if err then vim.notify(err, vim.log.levels.ERROR) end
 
-    -- setup highlights, keymap, completion and signature help
+    -- setup highlights, keymap, completion, commands and signature help
     require('blink.cmp.highlights').setup()
     require('blink.cmp.keymap').setup()
     require('blink.cmp.completion').setup()
+    require("blink.cmp.commands").setup()
     if config.signature.enabled then require('blink.cmp.signature').setup() end
   end)
 end
@@ -183,43 +184,5 @@ function cmp.add_provider(id, provider_config)
   require('blink.cmp.config.sources').validate_provider(id, provider_config)
   config.sources.providers[id] = provider_config
 end
-
-function cmp.status()
-  local sources = require('blink.cmp.sources.lib')
-  local all_providers = sources.get_all_providers()
-  local enabled_provider_ids = sources.get_enabled_provider_ids('default')
-
-  --- @type string[]
-  local not_enabled_provider_ids = {}
-  for provider_id, _ in pairs(all_providers) do
-    if not vim.list_contains(enabled_provider_ids, provider_id) then
-      table.insert(not_enabled_provider_ids, provider_id)
-    end
-  end
-
-  if #enabled_provider_ids > 0 then
-    vim.api.nvim_echo({ { '\n', 'Normal' } }, false, {})
-    vim.api.nvim_echo({ { '# enabled sources providers\n', 'Special' } }, false, {})
-
-    for _, provider_id in ipairs(enabled_provider_ids) do
-      vim.api.nvim_echo({ { ('- %s\n'):format(provider_id), 'Normal' } }, false, {})
-    end
-  end
-
-  if #not_enabled_provider_ids > 0 then
-    vim.api.nvim_echo({ { '\n', 'Normal' } }, false, {})
-    vim.api.nvim_echo({ { '# not enabled sources providers\n', 'Comment' } }, false, {})
-
-    for _, provider_id in pairs(not_enabled_provider_ids) do
-      vim.api.nvim_echo({ { ('- %s\n'):format(provider_id), 'Normal' } }, false, {})
-    end
-  end
-end
-
-vim.api.nvim_create_user_command(
-  'BlinkCmpStatus',
-  function() cmp.status() end,
-  { desc = 'Check status of blink.cmp sources providers' }
-)
 
 return cmp


### PR DESCRIPTION
The command `:BlinkCmpStatus` can be used to view which sources providers are enabled or not enabled.

This is inspired by and implemented based on the `:CmpStatus` command from `hrsh7th/nvim-cmp`.