### PR TITLE
feat: add type annotation for keymap function params

### DIFF
--- a/lua/blink/cmp/config/keymap.lua
+++ b/lua/blink/cmp/config/keymap.lua
@@ -13,7 +13,7 @@
 --- | 'scroll_documentation_down' Scroll the documentation window down
 --- | 'snippet_forward' Move the cursor forward to the next snippet placeholder
 --- | 'snippet_backward' Move the cursor backward to the previous snippet placeholder
---- | (fun(cmp: table): boolean?) Custom function where returning true will prevent the next command from running
+--- | (fun(cmp: blink.cmp.PublicAPI): boolean?) Custom function where returning true will prevent the next command from running
 
 --- @alias blink.cmp.KeymapPreset
 --- | 'none' No keymaps

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -1,4 +1,5 @@
 local has_setup = false
+---@class blink.cmp.PublicAPI
 local cmp = {}
 
 --- @param opts? blink.cmp.Config


### PR DESCRIPTION
```lua
    keymap = {
      preset = "super-tab",
      ["<C-k>"] = {
        function(blink_cmp)
          if blink_cmp.is_visible() then
            blink_cmp.hide()
          else
            blink_cmp.show()
          end
        end,
      },
    },
```

While configuring the key mappings above, I noticed that `blink_cmp` did not provide type annotations, so I add thsi type