### PR TITLE
doc: add a source for dictionary

### DIFF
--- a/docs/configuration/sources.md
+++ b/docs/configuration/sources.md
@@ -62,3 +62,4 @@ Blink can use `nvim-cmp` sources through a compatibility layer developed by [ste
 - [blink-cmp-copilot](https://github.com/giuxtaposition/blink-cmp-copilot)
 - [minuet-ai.nvim](https://github.com/milanglacier/minuet-ai.nvim)
 - [blink-emoji.nvim](https://github.com/moyiz/blink-emoji.nvim)
+- [blink-cmp-dictionary](https://github.com/Kaiser-Yang/blink-cmp-dictionary)


### PR DESCRIPTION
Hi! I've written a new source for `blink`, this source makes it possible to query word without leaving the editor:

![image](https://github.com/user-attachments/assets/8b42f6e3-a934-40f6-b74b-5652d162d7f3)
