### PR TITLE
fix: fix window direction sorting on Windows

### DIFF
--- a/lua/blink/cmp/lib/window/init.lua
+++ b/lua/blink/cmp/lib/window/init.lua
@@ -400,11 +400,14 @@ function win:get_direction_with_window_constraints(anchor_win, direction_priorit
     local is_desired_b = desired_min_size.height <= constraints_b.vertical
       and desired_min_size.width <= constraints_b.horizontal
 
-    -- prioritize "a" if it has the desired size
+    -- If both have desired size, preserve original priority
+    if is_desired_a and is_desired_b then return 0 end
+
+    -- prioritize "a" if it has the desired size and "b" doesn't
     if is_desired_a then return -1 end
 
     -- prioritize "b" if it has the desired size and "a" doesn't
-    if not is_desired_a and is_desired_b then return 1 end
+    if is_desired_b then return 1 end
 
     -- neither have the desired size, so pick based on which has the most space
     local distance_a = math.min(max_height, constraints_a.vertical, constraints_a.horizontal)


### PR DESCRIPTION
The current sorting function is not deterministic, because it unfairly prioritizes the first argument. It's not reflexive (I think), which is required for ordering to work correctly.

It sorts the list correctly by accident on Linux, but doesn't on Windows.

I think the intended way is to preserve the original priorities in the case where both have enough space.

Fixes #845 


