### PR TITLE
Fix comparison link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - Auto-bracket support based on semantic tokens
 - Signature help (experimental, opt-in)
 - Command line completion
-- [Comparison with nvim-cmp](#compared-to-nvim-cmp)
+- [Comparison with nvim-cmp](https://cmp.saghen.dev/#compared-to-nvim-cmp)
 
 ## Installation
 


### PR DESCRIPTION
The old link assumed the section to be in the README.md, but looks like it only exists on the documentation site now.