### PR TITLE
feat(nix): add formatter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,8 @@
           ];
           packages = with pkgs; [ rust-analyzer-nightly ];
         };
+
+        formatter = pkgs.nixfmt-classic;
       };
     };
 }


### PR DESCRIPTION
I believe there should be some defined formatter, otherwise it's not clear what standards to follow when cotributing to nix files in this repo.

`nixfmt-classic` produces no changes on the current flake.nix.

This is contrary to #736 which introduced a bunch of changes and was rejected.

Use with `nix fmt **/*.nix`