### PR TITLE
perf: use faster 0.11 vim.validate

### DIFF
--- a/lua/blink/cmp/config/keymap.lua
+++ b/lua/blink/cmp/config/keymap.lua
@@ -168,7 +168,7 @@ function keymap.validate(config)
       }
     end
   end
-  require("blink.cmp.config.utils").fastValidate(validation_schema)
+  require('blink.cmp.config.utils')._validate(validation_schema)
 end
 
 return keymap

--- a/lua/blink/cmp/config/keymap.lua
+++ b/lua/blink/cmp/config/keymap.lua
@@ -168,7 +168,7 @@ function keymap.validate(config)
       }
     end
   end
-  vim.validate(validation_schema)
+  require("blink.cmp.config.utils").fastValidate(validation_schema)
 end
 
 return keymap

--- a/lua/blink/cmp/config/utils.lua
+++ b/lua/blink/cmp/config/utils.lua
@@ -9,16 +9,11 @@ local utils = {}
 -- realize that we're using an overloaded function.
 ---@param spec table<string, {[1]:any, [2]:function|string, [3]:string|true|nil}>
 function utils.fastValidate(spec)
-  if vim.fn.has "nvim-0.11" == 1 then
-    for key, key_spec in pairs(spec) do
-      local message = type(key_spec[3]) == "string" and key_spec[3] or nil --[[@as string?]]
-      local optional = type(key_spec[3]) == "boolean" and key_spec[3] or nil --[[@as boolean?]]
-      ---@diagnostic disable-next-line:param-type-mismatch, redundant-parameter
-      vim.validate(key, key_spec[1], key_spec[2], optional, message)
-      end
-  else
-    ---@diagnostic disable-next-line:param-type-mismatch
-    vim.validate(spec)
+  for key, key_spec in pairs(spec) do
+    local message = type(key_spec[3]) == "string" and key_spec[3] or nil --[[@as string?]]
+    local optional = type(key_spec[3]) == "boolean" and key_spec[3] or nil --[[@as boolean?]]
+    ---@diagnostic disable-next-line:param-type-mismatch, redundant-parameter
+    vim.validate(key, key_spec[1], key_spec[2], optional, message)
   end
 end
 

--- a/lua/blink/cmp/config/utils.lua
+++ b/lua/blink/cmp/config/utils.lua
@@ -1,12 +1,34 @@
 local utils = {}
 
+-- Code taken from @MariaSolOs in a indent-blankline.nvim PR:
+-- https://github.com/lukas-reineke/indent-blankline.nvim/pull/934/files#diff-09ebcaa8c75cd1e92d25640e377ab261cfecaf8351c9689173fd36c2d0c23d94R16
+-- According to https://github.com/neovim/neovim/pull/28977 it's ~ 39 000% faster
+
+-- Use the faster validate version if available.
+-- NOTE: We disable some Lua diagnostics here since lua_ls isn't smart enough to
+-- realize that we're using an overloaded function.
+---@param spec table<string, {[1]:any, [2]:function|string, [3]:string|true|nil}>
+function utils.fastValidate(spec)
+  if vim.fn.has "nvim-0.11" == 1 then
+    for key, key_spec in pairs(spec) do
+      local message = type(key_spec[3]) == "string" and key_spec[3] or nil --[[@as string?]]
+      local optional = type(key_spec[3]) == "boolean" and key_spec[3] or nil --[[@as boolean?]]
+      ---@diagnostic disable-next-line:param-type-mismatch, redundant-parameter
+      vim.validate(key, key_spec[1], key_spec[2], optional, message)
+      end
+  else
+    ---@diagnostic disable-next-line:param-type-mismatch
+    vim.validate(spec)
+  end
+end
+
 ---@param path string The path to the field being validated
 ---@param tbl table The table to validate
 ---@param source table The original table that we're validating against
 ---@see vim.validate
 function utils.validate(path, tbl, source)
   -- validate
-  local _, err = pcall(vim.validate, tbl)
+  local _, err = pcall(utils.fastValidate, tbl)
   if err then error(path .. '.' .. err) end
 
   -- check for erroneous fields

--- a/lua/blink/cmp/config/utils.lua
+++ b/lua/blink/cmp/config/utils.lua
@@ -2,28 +2,29 @@ local utils = {}
 
 -- Code taken from @MariaSolOs in a indent-blankline.nvim PR:
 -- https://github.com/lukas-reineke/indent-blankline.nvim/pull/934/files#diff-09ebcaa8c75cd1e92d25640e377ab261cfecaf8351c9689173fd36c2d0c23d94R16
--- According to https://github.com/neovim/neovim/pull/28977 it's ~ 39 000% faster
+-- Saves a whopping 20% compared to vim.validate (0.8ms -> 0.64ms)
 
--- Use the faster validate version if available.
--- NOTE: We disable some Lua diagnostics here since lua_ls isn't smart enough to
--- realize that we're using an overloaded function.
----@param spec table<string, {[1]:any, [2]:function|string, [3]:string|true|nil}>
-function utils.fastValidate(spec)
+--- Use the faster validate version if available
+--- @param spec table<string, {[1]:any, [2]:function|string, [3]:string|true|nil}>
+--- NOTE: We disable some Lua diagnostics here since lua_ls isn't smart enough to
+--- realize that we're using an overloaded function.
+function utils._validate(spec)
+  if vim.fn.has('nvim-0.11') == 0 then return vim.validate(spec) end
   for key, key_spec in pairs(spec) do
-    local message = type(key_spec[3]) == "string" and key_spec[3] or nil --[[@as string?]]
-    local optional = type(key_spec[3]) == "boolean" and key_spec[3] or nil --[[@as boolean?]]
+    local message = type(key_spec[3]) == 'string' and key_spec[3] or nil --[[@as string?]]
+    local optional = type(key_spec[3]) == 'boolean' and key_spec[3] or nil --[[@as boolean?]]
     ---@diagnostic disable-next-line:param-type-mismatch, redundant-parameter
     vim.validate(key, key_spec[1], key_spec[2], optional, message)
   end
 end
 
----@param path string The path to the field being validated
----@param tbl table The table to validate
----@param source table The original table that we're validating against
----@see vim.validate
+--- @param path string The path to the field being validated
+--- @param tbl table The table to validate
+--- @param source table The original table that we're validating against
+--- @see vim.validate
 function utils.validate(path, tbl, source)
   -- validate
-  local _, err = pcall(utils.fastValidate, tbl)
+  local _, err = pcall(utils._validate, tbl)
   if err then error(path .. '.' .. err) end
 
   -- check for erroneous fields

--- a/lua/blink/cmp/sources/luasnip.lua
+++ b/lua/blink/cmp/sources/luasnip.lua
@@ -17,7 +17,7 @@ local defaults_config = {
 
 function source.new(opts)
   local config = vim.tbl_deep_extend('keep', opts or {}, defaults_config)
-  vim.validate({
+  require("blink.cmp.config.utils").fastValidate({
     use_show_condition = { config.use_show_condition, 'boolean' },
     show_autosnippets = { config.show_autosnippets, 'boolean' },
   })

--- a/lua/blink/cmp/sources/luasnip.lua
+++ b/lua/blink/cmp/sources/luasnip.lua
@@ -17,10 +17,10 @@ local defaults_config = {
 
 function source.new(opts)
   local config = vim.tbl_deep_extend('keep', opts or {}, defaults_config)
-  require("blink.cmp.config.utils").fastValidate({
+  require('blink.cmp.config.utils').validate('sources.providers.luasnip', {
     use_show_condition = { config.use_show_condition, 'boolean' },
     show_autosnippets = { config.show_autosnippets, 'boolean' },
-  })
+  }, config)
 
   local self = setmetatable({}, { __index = source })
   self.config = config

--- a/lua/blink/cmp/sources/path/init.lua
+++ b/lua/blink/cmp/sources/path/init.lua
@@ -7,9 +7,8 @@
 --- @field get_cwd fun(context: blink.cmp.Context): string
 --- @field show_hidden_files_by_default boolean
 
-local regex = require('blink.cmp.sources.path.regex')
-
 --- @class blink.cmp.Source
+--- @field opts blink.cmp.PathOpts
 local path = {}
 
 function path.new(opts)
@@ -22,12 +21,12 @@ function path.new(opts)
     get_cwd = function(context) return vim.fn.expand(('#%d:p:h'):format(context.bufnr)) end,
     show_hidden_files_by_default = false,
   })
-  require("blink.cmp.config.utils").fastValidate({
+  require('blink.cmp.config.utils').validate('sources.providers.path', {
     trailing_slash = { opts.trailing_slash, 'boolean' },
     label_trailing_slash = { opts.label_trailing_slash, 'boolean' },
     get_cwd = { opts.get_cwd, 'function' },
     show_hidden_files_by_default = { opts.show_hidden_files_by_default, 'boolean' },
-  })
+  }, opts)
 
   self.opts = opts
   return self

--- a/lua/blink/cmp/sources/path/init.lua
+++ b/lua/blink/cmp/sources/path/init.lua
@@ -22,7 +22,7 @@ function path.new(opts)
     get_cwd = function(context) return vim.fn.expand(('#%d:p:h'):format(context.bufnr)) end,
     show_hidden_files_by_default = false,
   })
-  vim.validate({
+  require("blink.cmp.config.utils").fastValidate({
     trailing_slash = { opts.trailing_slash, 'boolean' },
     label_trailing_slash = { opts.label_trailing_slash, 'boolean' },
     get_cwd = { opts.get_cwd, 'function' },


### PR DESCRIPTION
this PR replaces vim.validate with it's new 0.11 implementation, that is ~36 000% faster, so it's as fast as no doing no validation at all ( [nvim core PR](https://github.com/neovim/neovim/pull/28977) )
This PR takes codes from an [indent-blankline PR](https://github.com/lukas-reineke/indent-blankline.nvim/pull/934/)
Do not merge this right now, since this is only for 0.11