### PR TITLE
feat: allow repeating the last completion with `.`

### DIFF
--- a/lua/blink/cmp/completion/accept/init.lua
+++ b/lua/blink/cmp/completion/accept/init.lua
@@ -70,16 +70,15 @@ local function accept(ctx, item, callback)
         -- so we empty the newText and apply
         local temp_text_edit = vim.deepcopy(item.textEdit)
         temp_text_edit.newText = ''
-        table.insert(all_text_edits, temp_text_edit)
-        return text_edits_lib.apply(all_text_edits):map(function()
+        return text_edits_lib.apply(all_text_edits, temp_text_edit):map(function()
           -- Expand the snippet
           require('blink.cmp.config').snippets.expand(item.textEdit.newText)
           return brackets_status
         end)
       else
         -- OR Normal: Apply the text edit and move the cursor
-        table.insert(all_text_edits, item.textEdit)
-        return text_edits_lib.apply(all_text_edits):map(function()
+        local main_text_edit = item.textEdit
+        return text_edits_lib.apply(all_text_edits, main_text_edit):map(function()
           -- TODO: should move the cursor only by the offset since text edit handles everything else?
           ctx.set_cursor({ ctx.get_cursor()[1], item.textEdit.range.start.character + #item.textEdit.newText + offset })
           return brackets_status

--- a/lua/blink/cmp/completion/accept/preview.lua
+++ b/lua/blink/cmp/completion/accept/preview.lua
@@ -18,18 +18,18 @@ local function preview(item)
     text_edit.range.start.character + #text_edit.newText,
   }
 
-  text_edits_lib.apply({ text_edit })
+  text_edits_lib.apply({ text_edit }):map(function()
+    local original_cursor = vim.api.nvim_win_get_cursor(0)
+    local cursor_moved = false
 
-  local original_cursor = vim.api.nvim_win_get_cursor(0)
-  local cursor_moved = false
+    -- TODO: remove when text_edits_lib.apply begins setting cursor position
+    if vim.api.nvim_get_mode().mode ~= 'c' then
+      vim.api.nvim_win_set_cursor(0, cursor_pos)
+      cursor_moved = true
+    end
 
-  -- TODO: remove when text_edits_lib.apply begins setting cursor position
-  if vim.api.nvim_get_mode().mode ~= 'c' then
-    vim.api.nvim_win_set_cursor(0, cursor_pos)
-    cursor_moved = true
-  end
-
-  return undo_text_edit, cursor_moved and original_cursor or nil
+    return undo_text_edit, cursor_moved and original_cursor or nil
+  end)
 end
 
 return preview

--- a/lua/blink/cmp/completion/list.lua
+++ b/lua/blink/cmp/completion/list.lua
@@ -218,11 +218,12 @@ end
 function list.undo_preview()
   if list.preview_undo == nil then return end
 
-  require('blink.cmp.lib.text_edits').apply({ list.preview_undo.text_edit })
-  if list.preview_undo.cursor then
-    require('blink.cmp.completion.trigger.context').set_cursor(list.preview_undo.cursor)
-  end
-  list.preview_undo = nil
+  require('blink.cmp.lib.text_edits').apply({ list.preview_undo.text_edit }):map(function()
+    if list.preview_undo.cursor then
+      require('blink.cmp.completion.trigger.context').set_cursor(list.preview_undo.cursor)
+    end
+    list.preview_undo = nil
+  end)
 end
 
 function list.apply_preview(item)
@@ -242,7 +243,7 @@ function list.accept(opts)
 
   list.undo_preview()
   local accept = require('blink.cmp.completion.accept')
-  accept(list.context, item, function()
+  local _ = accept(list.context, item, function()
     list.accept_emitter:emit({ item = item, context = list.context })
     if opts.callback then opts.callback() end
   end)

--- a/lua/blink/cmp/lib/feedkeys/feedkeys.lua
+++ b/lua/blink/cmp/lib/feedkeys/feedkeys.lua
@@ -1,0 +1,94 @@
+local feedkeys = {}
+
+feedkeys.call = setmetatable({
+  callbacks = {},
+}, {
+  __call = function(self, keys, mode, callback)
+    local is_insert = string.match(mode, 'i') ~= nil
+    local is_immediate = string.match(mode, 'x') ~= nil
+
+    local queue = {}
+    if #keys > 0 then
+      table.insert(queue, { feedkeys.t('<Cmd>setlocal lazyredraw<CR>'), 'n' })
+      table.insert(queue, { feedkeys.t('<Cmd>setlocal textwidth=0<CR>'), 'n' })
+      table.insert(queue, { feedkeys.t('<Cmd>setlocal backspace=nostop<CR>'), 'n' })
+      table.insert(queue, { keys, string.gsub(mode, '[itx]', ''), true })
+      table.insert(queue, { feedkeys.t('<Cmd>setlocal %slazyredraw<CR>'):format(vim.o.lazyredraw and '' or 'no'), 'n' })
+      table.insert(queue, { feedkeys.t('<Cmd>setlocal textwidth=%s<CR>'):format(vim.bo.textwidth or 0), 'n' })
+      table.insert(queue, { feedkeys.t('<Cmd>setlocal backspace=%s<CR>'):format(vim.go.backspace or 2), 'n' })
+    end
+
+    if callback then
+      -- since we run inserting keys in a queue, we need to run the callback in
+      -- a queue as well so it runs after the keys have been inserted
+      local id = feedkeys.id('blink.feedkeys.call')
+      self.callbacks[id] = callback
+      table.insert(
+        queue,
+        { feedkeys.t('<Cmd>lua require"blink.cmp.lib.feedkeys.feedkeys".run(%s)<CR>'):format(id), 'n', true }
+      )
+    end
+
+    if is_insert then
+      for i = #queue, 1, -1 do
+        vim.api.nvim_feedkeys(queue[i][1], queue[i][2] .. 'i', queue[i][3])
+      end
+    else
+      for i = 1, #queue do
+        vim.api.nvim_feedkeys(queue[i][1], queue[i][2], queue[i][3])
+      end
+    end
+
+    if is_immediate then vim.api.nvim_feedkeys('', 'x', true) end
+  end,
+})
+
+feedkeys.run = function(id)
+  if feedkeys.call.callbacks[id] then
+    local ok, err = pcall(feedkeys.call.callbacks[id])
+    if not ok then vim.notify(err, vim.log.levels.ERROR) end
+    feedkeys.call.callbacks[id] = nil
+  end
+  return ''
+end
+
+---Generate id for group name
+feedkeys.id = setmetatable({
+  group = {},
+}, {
+  __call = function(_, group)
+    feedkeys.id.group[group] = feedkeys.id.group[group] or 0
+    feedkeys.id.group[group] = feedkeys.id.group[group] + 1
+    return feedkeys.id.group[group]
+  end,
+})
+
+---Shortcut for nvim_replace_termcodes
+---@param keys string
+---@return string
+feedkeys.t = function(keys)
+  -- implementation copied from
+  -- https://github.com/hrsh7th/nvim-cmp/blob/b555203ce4bd7ff6192e759af3362f9d217e8c89/lua/cmp/utils/feedkeys.lua?plain=1#L7-L14
+  return (
+    string.gsub(
+      keys,
+      "(<[A-Za-z0-9\\%-%[%]%^@;,:_']->)",
+      function(match) return vim.api.nvim_eval(string.format([["\%s"]], match)) end
+    )
+  )
+end
+local t = feedkeys.t
+
+---Create backspace keys.
+---@param count string|integer
+---@return string
+---@nodiscard
+feedkeys.backspace = function(count)
+  if type(count) == 'string' then count = vim.fn.strchars(count, true) end
+  if count <= 0 then return '' end
+  local keys = {}
+  table.insert(keys, t(string.rep('<BS>', count)))
+  return table.concat(keys, '')
+end
+
+return feedkeys

--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -14,7 +14,6 @@ function text_edits.apply(edits)
   return async.task.new(function(resolve)
     local mode = context.get_mode()
     if mode == 'default' then
-      local fuzzy = require('blink.cmp.fuzzy')
       -- Fill the `.` register so that dot-repeat works. This also changes the
       -- text in the buffer - currently there is no way to do this in Neovim
       -- (only adding new text is supported, but we also want to replace the
@@ -24,7 +23,7 @@ function text_edits.apply(edits)
       -- only redoing the first edit is supported
       local edit = edits[1]
       local original_cursor = context.get_cursor()
-      local kwstart, kwend = fuzzy.get_keyword_range(context.get_line(), original_cursor[2], 'prefix')
+      local kwstart, kwend = edit.range.start.character, edit.range['end'].character
       local repeat_keys = {}
       local original_line = context.get_line()
       table.insert(repeat_keys, feedkeys.backspace(kwend - kwstart))
@@ -37,7 +36,7 @@ function text_edits.apply(edits)
       feedkeys.call_async(repeat_str, 'in'):map(function()
         local row = original_cursor[1]
         local end_col = kwstart + #edit.newText
-        local old_text = original_line:sub(1, end_col - 1)
+        local old_text = original_line:sub(1, end_col)
         vim.api.nvim_buf_set_text(context.bufnr, row, 0, row, end_col, { old_text })
         -- undo the changes to the buffer (but keep them in the `.` register for
         -- repeating)


### PR DESCRIPTION
This is a bit work in progress, but could implement dot-repeat (`.`) for simple completions. All cases might not work yet.

https://github.com/user-attachments/assets/b4f61768-8c55-4714-b9f9-259d85abb55c

The algorithm is basically the same as in nvim-cmp. The way it works here is the following:
- when a completion is selected, use the first text edit as the thing that can be repeated
- simulate pressing keys so that it's possible to write to the repeat register (`.`, dot). This register gets executed when the user presses the dot key later on. Note that neovim does not allow cleanly replacing text in a way that supports dot-repeat (https://github.com/neovim/neovim/issues/19806#issuecomment-2365146298)
- press backspace repeatedly to erase the current word
- add the new word
- undo these changes to the buffer so that all the text edits can be applied cleanly (this is the previous behaviour)
- allow the user to continue writing text (these are part of the repeating, as seen in the demo)

## next steps

- [ ] find out what cases need to be supported
- idea: could use async instead off callbacks
- idea: could eventually release this with an experimental (opt-in) status

Solves https://github.com/Saghen/blink.cmp/issues/182