### PR TITLE
feat: set default capabilities on 0.11

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -57,6 +57,9 @@
 }
 ```
 
+> [!IMPORTANT]
+> On Neovim 0.11+ and Blink.cmp 0.10+, you may skip this step
+
 Setting capabilities for `nvim-lspconfig`:
 
 ```lua

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -11,8 +11,7 @@ function cmp.setup(opts)
 
   opts = opts or {}
 
-  local version = vim.version()
-  if version.major == 0 and version.minor < 10 then
+  if vim.fn.has('nvim-0.10') == 0 then
     vim.notify('blink.cmp requires nvim 0.10 and newer', vim.log.levels.ERROR, { title = 'blink.cmp' })
     return
   end

--- a/plugin/blink-cmp.lua
+++ b/plugin/blink-cmp.lua
@@ -1,0 +1,5 @@
+if vim.fn.has('nvim-0.11') == 1 then
+  vim.lsp.config('*', {
+    capabilities = require('blink.cmp').get_lsp_capabilities(),
+  })
+end


### PR DESCRIPTION
See `:help vim.lsp.config` on nightly.

Changing `vim.version` to `vim.fn.has` improved the startup time by about 2-3 ms