### PR TITLE
fix(nix): use nix gcc and provide libiconv

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,13 +83,9 @@
           program = let
             buildScript = pkgs.writeShellApplication {
               name = "build-plugin";
-              runtimeInputs = with pkgs;
-                [
-                  fenix.minimal.toolchain
-                ]
-                # use the native gcc on macos, see #652
-                ++ lib.optionals (!pkgs.stdenv.isDarwin) [ gcc ];
+              runtimeInputs = with pkgs; [ fenix.minimal.toolchain gcc ];
               text = ''
+                export LIBRARY_PATH="${lib.makeLibraryPath [ pkgs.libiconv ]}";
                 cargo build --release
               '';
             };


### PR DESCRIPTION
Fixes iconv problems on darwin when using nix's gcc by removing an impurity from build.

Adding this is apparently a no-op for linux, because libiconv is included by default in libc for linux. This allows us to omit conditionals.

Before:
```sh
❯ otool -L libblink_cmp_fuzzy.dylib
libblink_cmp_fuzzy.dylib:
        /Users/konrad/Code/github.com/konradmalik/blink.cmp/target/release/deps/libblink_cmp_fuzzy.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
```

After:
```sh
❯ otool -L ./target/release/libblink_cmp_fuzzy.dylib
./target/release/libblink_cmp_fuzzy.dylib:
        /Users/konrad/Code/github.com/konradmalik/blink.cmp/target/release/deps/libblink_cmp_fuzzy.dylib (compatibility version 0.0.0, current version 0.0.0)
        /nix/store/v7ldx1ra3wrjaasap8bfradapkqi2w1r-libiconv-107/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
```

Improves #652 

Closes #899 