### PR TITLE
fix(cmdline): make completion work for <sid> and s: viml function

### DIFF
--- a/lua/blink/cmp/sources/cmdline/init.lua
+++ b/lua/blink/cmp/sources/cmdline/init.lua
@@ -39,11 +39,17 @@ function cmdline:get_completions(context, callback)
       end
 
       local completions = {}
-      local completion_type = vim.fn.getcmdcompltype()
+      local completion_args = vim.split(vim.fn.getcmdcompltype(), ',', { plain = true })
+      local completion_type = completion_args[1]
+      local completion_func = completion_args[2]
+
       -- Handle custom completions explicitly, since otherwise they won't work in input() mode (getcmdtype() == '@')
-      if vim.startswith(completion_type, 'custom,') or vim.startswith(completion_type, 'customlist,') then
-        local fun = completion_type:gsub('custom,', ''):gsub('customlist,', '')
-        completions = vim.fn.call(fun, { current_arg_prefix, vim.fn.getcmdline(), vim.fn.getcmdpos() })
+      if
+        vim.startswith(completion_type, 'custom')
+        and not vim.startswith(completion_func, 's:')
+        and not vim.startswith(completion_func, '<sid>')
+      then
+        completions = vim.fn.call(completion_func, { current_arg_prefix, vim.fn.getcmdline(), vim.fn.getcmdpos() })
         -- `custom,` type returns a string, delimited by newlines
         if type(completions) == 'string' then completions = vim.split(completions, '\n') end
       else

--- a/lua/blink/cmp/sources/cmdline/init.lua
+++ b/lua/blink/cmp/sources/cmdline/init.lua
@@ -44,6 +44,8 @@ function cmdline:get_completions(context, callback)
       local completion_func = completion_args[2]
 
       -- Handle custom completions explicitly, since otherwise they won't work in input() mode (getcmdtype() == '@')
+      -- TODO: however, we cannot handle s: and <sid> completions. is there a better solution here where we can get
+      -- completions in input() mode without calling ourselves?
       if
         vim.startswith(completion_type, 'custom')
         and not vim.startswith(completion_func, 's:')


### PR DESCRIPTION
This branch fixes completion issues with commands like `:Rename` in plugins such as [vim-eunuch](https://github.com/tpope/vim-eunuch). You can test it by running `:Rename`, and the completion should work without errors.

The issue was caused by `s:` and `<sid>` functions being scoped to their script, which led to errors like:

> Error while fetching completions: Vim:E120: Using <SID> not in a script context: s:RenameComplete

This fix ensures proper handling of these functions, resolving the issue.