### PR TITLE
Assert that the `vim.lsp.config` function exists before calling it

### DIFF
--- a/plugin/blink-cmp.lua
+++ b/plugin/blink-cmp.lua
@@ -1,4 +1,4 @@
-if vim.fn.has('nvim-0.11') == 1 then
+if vim.fn.has('nvim-0.11') == 1 and vim.lsp.config then
   vim.lsp.config('*', {
     capabilities = require('blink.cmp').get_lsp_capabilities(),
   })


### PR DESCRIPTION
The `plugin/blink-cmp.lua` script added in af1febb17f9ddc87cf73e69d3f61218cdc18ed85 currently doesn't check whether `vim.lsp.config` exists, which causes an error on startup if the Neovim nightly doesn't have this feature (ref. https://github.com/Saghen/blink.cmp/pull/897#issuecomment-2574628478). There is a broad range of development versions of Neovim 0.11 used in the wild, so solely checking for the `nvim-0.11` feature isn't enough.

I considered two alternative implementations for this:

1. _Skip the `vim.fn.has('nvim-0.11')` check entirely since it is not technically required._
    -> I left it on purpose because it has the merit of adding explicitness to the script.
1. _Use `pcall().`_
    -> Works equally well, but checking for the existence of the function is enough here.