### PR TITLE
Fix buildVimPlugin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734435836,
-        "narHash": "sha256-kMBQ5PRiFLagltK0sH+08aiNt3zGERC2297iB6vrvlU=",
+        "lastModified": 1736166416,
+        "narHash": "sha256-U47xeACNBpkSO6IcCm0XvahsVXpJXzjPIQG7TZlOToU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4989a246d7a390a859852baddb1013f825435cee",
+        "rev": "b30f97d8c32d804d2d832ee837d0f1ca0695faa5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -36,8 +36,9 @@
             ./rust-toolchain.toml
           ];
           # nvim source files
-          # all that are not nix, nor rust
-          nvimFs = fs.difference ./. (fs.union nixFs rustFs);
+          # all that are not nix, nor rust, nor other ignored files
+          nvimFs =
+            fs.difference ./. (fs.unions [ nixFs rustFs ./docs ./repro.lua ]);
           version = "0.9.3";
         in {
           blink-fuzzy-lib = let


### PR DESCRIPTION
After https://github.com/NixOS/nixpkgs/pull/352277 when we update nixpkgs in this repo - the plugin build fails with:
```
       > Require check failed for the following modules:
       >   - repro
```
See: https://github.com/Saghen/blink.cmp/actions/runs/12654863130/job/35263764079?pr=933

Since this file is not needed for any release, we should simply ignore it from nvim sources instead of providing explicit require checks.

What we have here is:
- update flake
- ignore repro.lua from nvimFs (also ignore docs folder because it's quite large and not used at all in vimPlugin)

The "update" step is optional, I just wanted to confirm that the build will fail and that this will fix it. If updating now is not preferred, we can remove that commit.

Note - we could also use `nvimSkipModule` to ignore `repro` but I think we can just exclude it from source. However I'm open to suggestions.