### PR TITLE
fix(ghost_text): ensure multiline indent is correct

### DIFF
--- a/lua/blink/cmp/completion/windows/ghost_text.lua
+++ b/lua/blink/cmp/completion/windows/ghost_text.lua
@@ -71,7 +71,8 @@ function ghost_text.draw_preview(bufnr)
 
   if ghost_text.selected_item.insertTextFormat == vim.lsp.protocol.InsertTextFormat.Snippet then
     local expanded_snippet = snippets_utils.safe_parse(text_edit.newText)
-    text_edit.newText = expanded_snippet and tostring(expanded_snippet) or text_edit.newText
+    text_edit.newText = expanded_snippet and snippets_utils.add_identation(tostring(expanded_snippet))
+      or text_edit.newText
   end
 
   local display_lines = vim.split(get_still_untyped_text(text_edit), '\n', { plain = true }) or {}

--- a/lua/blink/cmp/completion/windows/ghost_text.lua
+++ b/lua/blink/cmp/completion/windows/ghost_text.lua
@@ -71,7 +71,7 @@ function ghost_text.draw_preview(bufnr)
 
   if ghost_text.selected_item.insertTextFormat == vim.lsp.protocol.InsertTextFormat.Snippet then
     local expanded_snippet = snippets_utils.safe_parse(text_edit.newText)
-    text_edit.newText = expanded_snippet and snippets_utils.add_identation(tostring(expanded_snippet))
+    text_edit.newText = expanded_snippet and snippets_utils.add_current_line_indentation(tostring(expanded_snippet))
       or text_edit.newText
   end
 

--- a/lua/blink/cmp/sources/snippets/utils.lua
+++ b/lua/blink/cmp/sources/snippets/utils.lua
@@ -65,6 +65,37 @@ function utils.read_snippet(snippet, fallback)
   return snippets
 end
 
+local function text_to_lines(text)
+  text = type(text) == 'string' and { text } or text
+  --- @cast text string[]
+  return vim.split(table.concat(text), '\n', { plain = true })
+end
+
+-- Add the current line's identation for a snippet raw text,
+-- which is abtained by calling tostring(snippet).
+---@param text string
+function utils.add_identation(text)
+  local base_indent = vim.api.nvim_get_current_line():match('^%s*') or ''
+  local snippet_lines = text_to_lines(text)
+
+  local shiftwidth = vim.fn.shiftwidth()
+  local curbuf = vim.api.nvim_get_current_buf()
+  local expandtab = vim.bo[curbuf].expandtab
+
+  local lines = {} --- @type string[]
+  for i, line in ipairs(snippet_lines) do
+    -- Replace tabs by spaces.
+    if expandtab then
+      line = line:gsub('\t', (' '):rep(shiftwidth)) --- @type string
+    end
+    -- Add the base indentation.
+    if i > 1 then line = base_indent .. line end
+    lines[#lines + 1] = line
+  end
+
+  return table.concat(lines, '\n')
+end
+
 function utils.get_tab_stops(snippet)
   local expanded_snippet = require('blink.cmp.sources.snippets.utils').safe_parse(snippet)
   if not expanded_snippet then return end

--- a/lua/blink/cmp/sources/snippets/utils.lua
+++ b/lua/blink/cmp/sources/snippets/utils.lua
@@ -65,18 +65,12 @@ function utils.read_snippet(snippet, fallback)
   return snippets
 end
 
-local function text_to_lines(text)
-  text = type(text) == 'string' and { text } or text
-  --- @cast text string[]
-  return vim.split(table.concat(text), '\n', { plain = true })
-end
-
--- Add the current line's identation for a snippet raw text,
--- which is abtained by calling tostring(snippet).
+-- Add the current line's identation to all but the first line of
+-- the provided text
 ---@param text string
-function utils.add_identation(text)
+function utils.add_current_line_indentation(text)
   local base_indent = vim.api.nvim_get_current_line():match('^%s*') or ''
-  local snippet_lines = text_to_lines(text)
+  local snippet_lines = vim.split(text, '\n', { plain = true })
 
   local shiftwidth = vim.fn.shiftwidth()
   local curbuf = vim.api.nvim_get_current_buf()
@@ -84,11 +78,11 @@ function utils.add_identation(text)
 
   local lines = {} --- @type string[]
   for i, line in ipairs(snippet_lines) do
-    -- Replace tabs by spaces.
+    -- Replace tabs with spaces
     if expandtab then
       line = line:gsub('\t', (' '):rep(shiftwidth)) --- @type string
     end
-    -- Add the base indentation.
+    -- Add the base indentation
     if i > 1 then line = base_indent .. line end
     lines[#lines + 1] = line
   end


### PR DESCRIPTION
This pr includes a util function `to_static_text` that correctly transforms
multiline snippets with regards of current line indent. This function is nearly
a copy of `vim.snippet.expand` but without really expanding it, to solely get
the yet-to-inserted text.

before:
<img width="760" alt="image" src="https://github.com/user-attachments/assets/406779ab-7153-4bf7-8e1c-8966e1e505c1" />

after:
<img width="758" alt="image" src="https://github.com/user-attachments/assets/aa8e2b3f-f35d-48ae-b2d8-81bf4aead2e6" />
