### PR TITLE
fix(auto-insert): restore content of context instead of undo

### DIFF
--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -91,7 +91,7 @@ end
 function cmp.cancel(opts)
   if not cmp.is_visible() then return end
   vim.schedule(function()
-    require('blink.cmp.completion.list').undo_preview()
+    require('blink.cmp.completion.list').restore_content()
     require('blink.cmp.completion.trigger').hide()
     if opts and opts.callback then opts.callback() end
   end)


### PR DESCRIPTION
fix https://github.com/Saghen/blink.cmp/issues/942
fix https://github.com/Saghen/blink.cmp/issues/810

Described in https://github.com/Saghen/blink.cmp/issues/942#issuecomment-2578065112, this pr removes the `preview_undo` field and make the auto_insert stateless.