### PR TITLE
refactor(fuzzy): misc cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,7 @@ dependencies = [
  "mlua",
  "regex",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -670,6 +671,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ac7f54ca534db81081ef1c1e7f6ea8a3ef428d2fc069097c079443d24124d3"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9465d30713b56a37ede7185763c3492a91be2f5fa68d958c44e41ab9248beb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,6 @@ version = "0.1.0"
 dependencies = [
  "frizbee",
  "heed",
- "lazy_static",
  "mlua",
  "regex",
  "serde",
@@ -65,9 +64,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.11"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf"
+checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
 dependencies = [
  "shlex",
 ]
@@ -131,7 +130,7 @@ dependencies = [
 [[package]]
 name = "frizbee"
 version = "0.1.0"
-source = "git+https://github.com/saghen/frizbee#a535bd75abc6bfe76f532dbb5c374ea0a38e88fd"
+source = "git+https://github.com/saghen/frizbee#75c9dc534f459580dba8a45847bfae2e384f1a54"
 dependencies = [
  "memchr",
 ]
@@ -318,12 +317,6 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -650,9 +643,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.97"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dabd04e3b9a8c3c03d5e743f5ef5e1207befc9de704d477f7198cc28049763e"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ frizbee = { git = "https://github.com/saghen/frizbee" }
 serde = { version = "1.0.216", features = ["derive"] }
 heed = "0.21.0"
 mlua = { version = "0.10.2", features = ["module", "luajit"] }
+thiserror = "2.0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 regex = "1.11.1"
-lazy_static = "1.5.0"
 frizbee = { git = "https://github.com/saghen/frizbee" }
 serde = { version = "1.0.216", features = ["derive"] }
 heed = "0.21.0"

--- a/lua/blink/cmp/fuzzy/error.rs
+++ b/lua/blink/cmp/fuzzy/error.rs
@@ -1,0 +1,44 @@
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    #[error("Failed to acquire lock for frecency")]
+    AcquireFrecencyLock,
+
+    #[error("Failed to acquire lock for items by provider")]
+    AcquireItemLock,
+
+    #[error("Attempted to use frencecy before initialization")]
+    UseFrecencyBeforeInit,
+
+    #[error(
+        "Attempted to fuzzy match for provider {provider_id} before setting the provider's items"
+    )]
+    FuzzyBeforeSetItems { provider_id: String },
+
+    #[error("Failed to create frecency database directory: {0}")]
+    CreateDir(#[source] std::io::Error),
+    #[error("Failed to open frecency database env: {0}")]
+    EnvOpen(#[source] heed::Error),
+    #[error("Failed to create frecency database: {0}")]
+    DbCreate(#[source] heed::Error),
+    #[error("Failed to clear stale readers for frecency database: {0}")]
+    DbClearStaleReaders(#[source] heed::Error),
+
+    #[error("Failed to start read transaction for frecency database: {0}")]
+    DbStartReadTxn(#[source] heed::Error),
+    #[error("Failed to start write transaction for frecency database: {0}")]
+    DbStartWriteTxn(#[source] heed::Error),
+
+    #[error("Failed to read from frecency database: {0}")]
+    DbRead(#[source] heed::Error),
+    #[error("Failed to write to frecency database: {0}")]
+    DbWrite(#[source] heed::Error),
+    #[error("Failed to commit write transaction to frecency database: {0}")]
+    DbCommit(#[source] heed::Error),
+}
+
+impl From<Error> for mlua::Error {
+    fn from(value: Error) -> Self {
+        mlua::Error::RuntimeError(value.to_string())
+    }
+}

--- a/lua/blink/cmp/fuzzy/keyword.rs
+++ b/lua/blink/cmp/fuzzy/keyword.rs
@@ -1,10 +1,10 @@
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
+
 use regex::Regex;
 
-lazy_static! {
-    static ref BACKWARD_REGEX: Regex = Regex::new(r"[\p{L}0-9_][\p{L}0-9_\\-]*$").unwrap();
-    static ref FORWARD_REGEX: Regex = Regex::new(r"^[\p{L}0-9_\\-]+").unwrap();
-}
+static BACKWARD_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[\p{L}0-9_][\p{L}0-9_\\-]*$").unwrap());
+static FORWARD_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[\p{L}0-9_\\-]+").unwrap());
 
 /// Given a line and cursor position, returns the start and end indices of the keyword
 pub fn get_keyword_range(line: &str, col: usize, match_suffix: bool) -> (usize, usize) {

--- a/lua/blink/cmp/fuzzy/lib.rs
+++ b/lua/blink/cmp/fuzzy/lib.rs
@@ -67,10 +67,10 @@ pub fn fuzzy(
     _lua: &Lua,
     (line, cursor_col, provider_id, opts): (mlua::String, usize, String, FuzzyOptions),
 ) -> LuaResult<(Vec<i32>, Vec<u32>)> {
-    let mut frecency_handle = FRECENCY.write().map_err(|_| {
+    let frecency_handle = FRECENCY.read().map_err(|_| {
         mlua::Error::RuntimeError("Failed to acquire lock for frecency".to_string())
     })?;
-    let frecency = frecency_handle.as_mut().ok_or_else(|| {
+    let frecency = frecency_handle.as_ref().ok_or_else(|| {
         mlua::Error::RuntimeError("Attempted to use frencecy before initialization".to_string())
     })?;
 

--- a/lua/blink/cmp/fuzzy/lib.rs
+++ b/lua/blink/cmp/fuzzy/lib.rs
@@ -1,23 +1,20 @@
 use crate::frecency::FrecencyTracker;
 use crate::fuzzy::FuzzyOptions;
 use crate::lsp_item::LspItem;
-use lazy_static::lazy_static;
 use mlua::prelude::*;
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
-use std::sync::RwLock;
+use std::sync::{LazyLock, RwLock};
 
 mod frecency;
 mod fuzzy;
 mod keyword;
 mod lsp_item;
 
-lazy_static! {
-    static ref REGEX: Regex = Regex::new(r"[\p{L}_][\p{L}0-9_\\-]{2,}").unwrap();
-    static ref FRECENCY: RwLock<Option<FrecencyTracker>> = RwLock::new(None);
-    static ref HAYSTACKS_BY_PROVIDER: RwLock<HashMap<String, Vec<LspItem>>> =
-        RwLock::new(HashMap::new());
-}
+static REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\p{L}_[\p{L}0-9_\\-]{2,}").unwrap());
+static FRECENCY: LazyLock<RwLock<Option<FrecencyTracker>>> = LazyLock::new(|| RwLock::new(None));
+static HAYSTACKS_BY_PROVIDER: LazyLock<RwLock<HashMap<String, Vec<LspItem>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
 
 pub fn init_db(_: &Lua, (db_path, use_unsafe_no_lock): (String, bool)) -> LuaResult<bool> {
     let mut frecency = FRECENCY.write().map_err(|_| {


### PR DESCRIPTION
- remove lazy_static in favor of std LazyLock
- `lib::fuzzy()` only reads the db, so don't acquire a write lock
-  introduce an error type, to avoid including the error descriptions inline. Also decouples fuzzy implementation from mlua.