### PR TITLE
feat: spellchecking with typos-cli

### DIFF
--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -4,6 +4,9 @@ permissions:
   contents: read
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 env:

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -1,0 +1,22 @@
+name: Spelling
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+
+env:
+  CLICOLOR: 1
+
+jobs:
+  spelling:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Spell Check Repo
+        uses: crate-ci/typos@685eb3d55be2f85191e8c84acb9f44d7756f84ab # v1.29.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -596,7 +596,7 @@ You may now use `nvim-cmp` sources within `blink.cmp` using @stefanboca's compat
 * add missing select_and_accept keymap to config ([d2140dc](https://github.com/Saghen/blink.cmp/commit/d2140dc7615991ea88fa1fd75dd4fccb53a73e25))
 * always hide window on accept ([7f5a3d9](https://github.com/Saghen/blink.cmp/commit/7f5a3d9a820125e7da0a1816efaddb84d47a7f18))
 * auto insert breaking on single line text edit ([78ac56e](https://github.com/Saghen/blink.cmp/commit/78ac56e96144ed7475bb6d11981d3c8154bfd366)), closes [#169](https://github.com/Saghen/blink.cmp/issues/169)
-* check if item contains brackets before defering to semantic token ([e5f543d](https://github.com/Saghen/blink.cmp/commit/e5f543da2a0ce91c8720b67f0ea6cfa941dc26d6))
+* check if item contains brackets before deferring to semantic token ([e5f543d](https://github.com/Saghen/blink.cmp/commit/e5f543da2a0ce91c8720b67f0ea6cfa941dc26d6))
 * **config:** set correct type def for blink.cmp.WindowBorderChar ([516190b](https://github.com/Saghen/blink.cmp/commit/516190bcdafa387d417cfb235cbcd7385e902089))
 * don't show completions when trigger context is nil ([5b39d83](https://github.com/Saghen/blink.cmp/commit/5b39d83ac4fed46c57d8db987ea56cb1c0e68b0e))
 * drop prints ([89259f9](https://github.com/Saghen/blink.cmp/commit/89259f936e413e0a324b2ea369eb8ccefc05a14f)), closes [#179](https://github.com/Saghen/blink.cmp/issues/179)

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,15 @@
+[files]
+extend-exclude = []
+
+[default.extend-words]
+noice = "noice"
+
+[default]
+extend-ignore-re = [
+  # git commit hashes in CHANGELOG.md
+  "\\[[0-9a-f]{7}\\]",
+  # Line ignore with trailing # spellchecker:disable-line
+  "(?Rm)^.*(#|--|//)\\s*spellchecker:disable-line$",
+  # Line block with # spellchecker:<on|off>
+  "(?s)(#|--|//|)\\s*spellchecker:off.*?\\n\\s*(#|--|//)\\s*spellchecker:on",
+]

--- a/lua/blink/cmp/completion/trigger/init.lua
+++ b/lua/blink/cmp/completion/trigger/init.lua
@@ -87,7 +87,7 @@ function trigger.activate()
     local is_on_trigger_for_show = trigger.is_trigger_character(char_under_cursor)
 
     -- TODO: doesn't handle `a` where the cursor moves immediately after
-    -- Reproducable with `example.|a` and pressing `a`, should not show the menu
+    -- Reproducible with `example.|a` and pressing `a`, should not show the menu
     local insert_enter_on_trigger_character = config.show_on_trigger_character
       and config.show_on_insert_on_trigger_character
       and event == 'InsertEnter'

--- a/lua/blink/cmp/sources/cmdline/constants.lua
+++ b/lua/blink/cmp/sources/cmdline/constants.lua
@@ -1,3 +1,4 @@
+-- spellchecker:off
 return {
   help_commands = {
     'help',
@@ -38,3 +39,4 @@ return {
     'make',
   },
 }
+-- spellchecker:on

--- a/lua/blink/cmp/sources/snippets/utils.lua
+++ b/lua/blink/cmp/sources/snippets/utils.lua
@@ -65,7 +65,7 @@ function utils.read_snippet(snippet, fallback)
   return snippets
 end
 
--- Add the current line's identation to all but the first line of
+-- Add the current line's indentation to all but the first line of
 -- the provided text
 ---@param text string
 function utils.add_current_line_indentation(text)


### PR DESCRIPTION
- fix all current typos using [typos-cli](https://github.com/crate-ci/typos)
- add a `_typos.toml`
- add a github action to check pull requests for spelling errors using [typos](https://github.com/crate-ci/typos)