### PR TITLE
fix(ci): don't persist credentials in actions/checkout

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -15,6 +15,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         run: |
@@ -116,6 +118,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
 
       - name: Build


### PR DESCRIPTION
Identified with [zizmor](https://woodruffw.github.io/zizmor/). It's also possible to [run zizmore in ci](https://woodruffw.github.io/zizmor/usage/#use-in-github-actions), but I didn't implement this because it requires a GITHUB_TOKEN secret.