### PR TITLE
feat(snippets.default): filter_snippets function for disabling certain snippet files

### DIFF
--- a/lua/blink/cmp/sources/snippets/default/init.lua
+++ b/lua/blink/cmp/sources/snippets/default/init.lua
@@ -5,6 +5,7 @@
 --- @field extended_filetypes? table<string, string[]>
 --- @field ignored_filetypes? string[]
 --- @field get_filetype? fun(context: blink.cmp.Context): string
+--- @field filter_snippets? fun(filetype: string, file: string): boolean
 --- @field clipboard_register? string
 
 local snippets = {}

--- a/lua/blink/cmp/sources/snippets/default/init.lua
+++ b/lua/blink/cmp/sources/snippets/default/init.lua
@@ -3,7 +3,6 @@
 --- @field search_paths? string[]
 --- @field global_snippets? string[]
 --- @field extended_filetypes? table<string, string[]>
---- @field ignored_filetypes? string[]
 --- @field get_filetype? fun(context: blink.cmp.Context): string
 --- @field filter_snippets? fun(filetype: string, file: string): boolean
 --- @field clipboard_register? string
@@ -23,7 +22,6 @@ end
 
 function snippets:get_completions(context, callback)
   local filetype = self.get_filetype(context)
-  if vim.tbl_contains(self.registry.config.ignored_filetypes, filetype) then return callback() end
 
   if not self.cache[filetype] then
     local global_snippets = self.registry:get_global_snippets()

--- a/lua/blink/cmp/sources/snippets/default/registry.lua
+++ b/lua/blink/cmp/sources/snippets/default/registry.lua
@@ -17,7 +17,6 @@ local default_config = {
   search_paths = { vim.fn.stdpath('config') .. '/snippets' },
   global_snippets = { 'all' },
   extended_filetypes = {},
-  ignored_filetypes = {},
   --- @type string?
   clipboard_register = nil,
 }

--- a/lua/blink/cmp/sources/snippets/default/registry.lua
+++ b/lua/blink/cmp/sources/snippets/default/registry.lua
@@ -35,6 +35,18 @@ function registry.new(config)
   end
   self.registry = require('blink.cmp.sources.snippets.default.scan').register_snippets(self.config.search_paths)
 
+  if self.config.filter_snippets then
+    local filtered_registry = {}
+    for ft, files in pairs(self.registry) do
+      filtered_registry[ft] = {}
+      for _, file in ipairs(files) do
+        if self.config.filter_snippets(ft, file) then table.insert(filtered_registry[ft], file) end
+      end
+    end
+
+    self.registry = filtered_registry
+  end
+
   return self
 end
 


### PR DESCRIPTION
This can be used with eg.
```lua
filter_snippets = function(ft, file)
  return not (string.match(file, "friendly.snippets") and string.match(file, "framework"))
end,
```
to disable friendly-snippets frameworks.

Closes https://github.com/Saghen/blink.cmp/issues/291

Also removes the `ignored_filetypes` option, which is redundant now that users can filter snippets with more control.