### PR TITLE
fix: add proxy for downloading libblink_cmp_fuzzy

### DIFF
--- a/lua/blink/cmp/config/fuzzy.lua
+++ b/lua/blink/cmp/config/fuzzy.lua
@@ -11,9 +11,12 @@
 --- @field ignore_version_mismatch boolean Ignores mismatched version between the built binary and the current git sha, when building locally
 --- @field force_version? string When downloading a prebuilt binary, force the downloader to resolve this version. If this is unset then the downloader will attempt to infer the version from the checked out git tag (if any). WARN: Beware that `main` may be incompatible with the version you select
 --- @field force_system_triple? string When downloading a prebuilt binary, force the downloader to use this system triple. If this is unset then the downloader will attempt to infer the system triple from `jit.os` and `jit.arch`. Check the latest release for all available system triples. WARN: Beware that `main` may be incompatible with the version you select
---- @field use_system_proxy boolean When downloading a prebuilt binary, use the system proxy settings. This will load the HTTPS_PROXY environment variable by default
---- @field system_proxy_url? string When downloading a prebuilt binary, use this proxy URL. This will override the system proxy settings
 --- @field extra_curl_args string[] Extra arguments that will be passed to curl like { 'curl', ..extra_curl_args, ..built_in_args }
+--- @field proxy blink.cmp.PrebuiltBinariesProxyConfig
+
+--- @class (exact) blink.cmp.PrebuiltBinariesProxyConfig
+--- @field from_env boolean When downloading a prebuilt binary, use the HTTPS_PROXY environment variable
+--- @field url? string When downloading a prebuilt binary, use this proxy URL. This will ignore the HTTPS_PROXY environment variable
 
 --- @alias blink.cmp.SortFunction fun(a: blink.cmp.CompletionItem, b: blink.cmp.CompletionItem): boolean | nil
 
@@ -31,9 +34,11 @@ local fuzzy = {
       ignore_version_mismatch = false,
       force_version = nil,
       force_system_triple = nil,
-      use_system_proxy = true,
-      system_proxy_url = nil,
       extra_curl_args = {},
+      proxy = {
+        from_env = true,
+        url = nil,
+      },
     },
   },
 }
@@ -58,13 +63,20 @@ function fuzzy.validate(config)
     },
     prebuilt_binaries = { config.prebuilt_binaries, 'table' },
   }, config)
+
   validate('fuzzy.prebuilt_binaries', {
     download = { config.prebuilt_binaries.download, 'boolean' },
     ignore_version_mismatch = { config.prebuilt_binaries.ignore_version_mismatch, 'boolean' },
     force_version = { config.prebuilt_binaries.force_version, { 'string', 'nil' } },
     force_system_triple = { config.prebuilt_binaries.force_system_triple, { 'string', 'nil' } },
     extra_curl_args = { config.prebuilt_binaries.extra_curl_args, { 'table' } },
+    proxy = { config.prebuilt_binaries.proxy, 'table' },
   }, config.prebuilt_binaries)
+
+  validate('fuzzy.prebuilt_binaries.proxy', {
+    from_env = { config.prebuilt_binaries.proxy.from_env, 'boolean' },
+    url = { config.prebuilt_binaries.proxy.url, { 'string', 'nil' } },
+  }, config.prebuilt_binaries.proxy)
 end
 
 return fuzzy

--- a/lua/blink/cmp/config/fuzzy.lua
+++ b/lua/blink/cmp/config/fuzzy.lua
@@ -11,6 +11,8 @@
 --- @field ignore_version_mismatch boolean Ignores mismatched version between the built binary and the current git sha, when building locally
 --- @field force_version? string When downloading a prebuilt binary, force the downloader to resolve this version. If this is unset then the downloader will attempt to infer the version from the checked out git tag (if any). WARN: Beware that `main` may be incompatible with the version you select
 --- @field force_system_triple? string When downloading a prebuilt binary, force the downloader to use this system triple. If this is unset then the downloader will attempt to infer the system triple from `jit.os` and `jit.arch`. Check the latest release for all available system triples. WARN: Beware that `main` may be incompatible with the version you select
+--- @field use_system_proxy boolean When downloading a prebuilt binary, use the system proxy settings. This will load the HTTPS_PROXY environment variable by default
+--- @field system_proxy_url? string When downloading a prebuilt binary, use this proxy URL. This will override the system proxy settings
 --- @field extra_curl_args string[] Extra arguments that will be passed to curl like { 'curl', ..extra_curl_args, ..built_in_args }
 
 --- @alias blink.cmp.SortFunction fun(a: blink.cmp.CompletionItem, b: blink.cmp.CompletionItem): boolean | nil
@@ -29,6 +31,8 @@ local fuzzy = {
       ignore_version_mismatch = false,
       force_version = nil,
       force_system_triple = nil,
+      use_system_proxy = true,
+      system_proxy_url = nil,
       extra_curl_args = {},
     },
   },

--- a/lua/blink/cmp/config/types_partial.lua
+++ b/lua/blink/cmp/config/types_partial.lua
@@ -59,6 +59,9 @@
 --- @field prebuilt_binaries? blink.cmp.PrebuiltBinariesConfigPartial
 
 --- @class (exact) blink.cmp.PrebuiltBinariesConfigPartial : blink.cmp.PrebuiltBinariesConfig, {}
+--- @field proxy? blink.cmp.PrebuiltBinariesProxyConfigPartial
+
+--- @class (exact) blink.cmp.PrebuiltBinariesProxyConfigPartial : blink.cmp.PrebuiltBinariesProxyConfig, {}
 
 --- @class blink.cmp.SourceConfigPartial : blink.cmp.SourceConfig, {}
 --- @field providers? table<string, blink.cmp.SourceProviderConfigPartial>

--- a/lua/blink/cmp/fuzzy/download/init.lua
+++ b/lua/blink/cmp/fuzzy/download/init.lua
@@ -145,6 +145,13 @@ end
 function download.download_file(url, filename)
   return async.task.new(function(resolve, reject)
     local args = { 'curl' }
+
+    -- Load https_proxy if available
+    if download_config.use_system_proxy then
+      local proxy_url = download_config.system_proxy_url or os.getenv('HTTPS_PROXY') or os.getenv('https_proxy')
+      vim.list_extend(args, { '--proxy', proxy_url })
+    end
+
     vim.list_extend(args, download_config.extra_curl_args)
     vim.list_extend(args, {
       '--fail', -- Fail on 4xx/5xx

--- a/lua/blink/cmp/fuzzy/download/init.lua
+++ b/lua/blink/cmp/fuzzy/download/init.lua
@@ -146,10 +146,12 @@ function download.download_file(url, filename)
   return async.task.new(function(resolve, reject)
     local args = { 'curl' }
 
-    -- Load https_proxy if available
-    if download_config.use_system_proxy then
-      local proxy_url = download_config.system_proxy_url or os.getenv('HTTPS_PROXY') or os.getenv('https_proxy')
-      vim.list_extend(args, { '--proxy', proxy_url })
+    -- Use https proxy if available
+    if download_config.proxy.url ~= nil then
+      vim.list_extend(args, { '--proxy', download_config.proxy.url })
+    elseif download_config.proxy.from_env then
+      local proxy_url = os.getenv('HTTPS_PROXY')
+      if proxy_url ~= nil then vim.list_extend(args, { '--proxy', proxy_url }) end
     end
 
     vim.list_extend(args, download_config.extra_curl_args)


### PR DESCRIPTION
The Curl command itself does not use system proxies, so use environment variables to avoid not being able to download the blink libraries in some regions.