### PR TITLE
feat(keymap): add Up/Down keymaps to default preset

### DIFF
--- a/docs/configuration/keymap.md
+++ b/docs/configuration/keymap.md
@@ -86,6 +86,8 @@ Set the preset to `none` to disable the presets
 ['<C-e>'] = { 'hide' },
 ['<C-y>'] = { 'select_and_accept' },
 
+['<Up>'] = { 'select_prev', 'fallback' },
+['<Down>'] = { 'select_next', 'fallback' },
 ['<C-p>'] = { 'select_prev', 'fallback' },
 ['<C-n>'] = { 'select_next', 'fallback' },
 

--- a/lua/blink/cmp/config/keymap.lua
+++ b/lua/blink/cmp/config/keymap.lua
@@ -25,6 +25,8 @@
 ---   ['<C-e>'] = { 'cancel', 'fallback' },
 ---   ['<C-y>'] = { 'select_and_accept' },
 ---
+---   ['<Up>'] = { 'select_prev', 'fallback' },
+---   ['<Down>'] = { 'select_next', 'fallback' },
 ---   ['<C-p>'] = { 'select_prev', 'fallback' },
 ---   ['<C-n>'] = { 'select_next', 'fallback' },
 ---

--- a/lua/blink/cmp/keymap/presets.lua
+++ b/lua/blink/cmp/keymap/presets.lua
@@ -6,6 +6,8 @@ local presets = {
     ['<C-e>'] = { 'cancel', 'fallback' },
     ['<C-y>'] = { 'select_and_accept' },
 
+    ['<Up>'] = { 'select_prev', 'fallback' },
+    ['<Down>'] = { 'select_next', 'fallback' },
     ['<C-p>'] = { 'select_prev', 'fallback' },
     ['<C-n>'] = { 'select_next', 'fallback' },
 


### PR DESCRIPTION
The default preset seems to be the only one without the Up/Down keymaps.
This PR adds them.