### PR TITLE
feat: support dot-repeat via `vim.fn.complete`

### DIFF
--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -116,6 +116,8 @@ completion.list = {
 
 ```lua
 completion.accept = {
+  -- Write completions to the `.` register
+  dot_repeat = true,
   -- Create an undo point when accepting a completion item
   create_undo_point = true,
   -- How long to wait for the LSP to resolve the item with additional information before continuing as-is

--- a/lua/blink/cmp/completion/accept/init.lua
+++ b/lua/blink/cmp/completion/accept/init.lua
@@ -75,8 +75,7 @@ local function accept(ctx, item, callback)
         -- so we empty the newText and apply
         local temp_text_edit = vim.deepcopy(item.textEdit)
         temp_text_edit.newText = ''
-        table.insert(all_text_edits, temp_text_edit)
-        text_edits_lib.apply(all_text_edits)
+        text_edits_lib.apply(temp_text_edit, all_text_edits)
 
         -- Expand the snippet
         require('blink.cmp.config').snippets.expand(item.textEdit.newText)
@@ -86,12 +85,14 @@ local function accept(ctx, item, callback)
         local new_cursor = text_edits_lib.get_apply_end_position(item.textEdit, all_text_edits)
         new_cursor[2] = new_cursor[2] + offset
 
-        table.insert(all_text_edits, item.textEdit)
-        text_edits_lib.apply(all_text_edits)
+        text_edits_lib.apply(item.textEdit, all_text_edits)
 
         if ctx.get_mode() ~= 'term' then ctx.set_cursor(new_cursor) end
       end
 
+      return brackets_status
+    end)
+    :map(function(brackets_status)
       -- Let the source execute the item itself
       sources.execute(ctx, item):map(function()
         -- Check semantic tokens for brackets, if needed, and apply additional text edits

--- a/lua/blink/cmp/completion/accept/preview.lua
+++ b/lua/blink/cmp/completion/accept/preview.lua
@@ -28,7 +28,7 @@ local function preview(item)
     cursor_moved = true
   end
 
-  return { text_edit = undo_text_edit, cursor = cursor_moved and original_cursor or nil }
+  return undo_text_edit, cursor_moved and original_cursor or nil
 end
 
 return preview

--- a/lua/blink/cmp/completion/accept/preview.lua
+++ b/lua/blink/cmp/completion/accept/preview.lua
@@ -1,6 +1,5 @@
 --- @param item blink.cmp.CompletionItem
---- @return lsp.TextEdit undo_text_edit, integer[]? undo_cursor_pos The text edit to apply and the original cursor
---- position to move to when undoing the preview,
+--- @return { text_edit: lsp.TextEdit, cursor?: integer[] } undo_text_edit, integer[]? undo_cursor_pos The text edit to apply and the original cursor
 local function preview(item)
   local text_edits_lib = require('blink.cmp.lib.text_edits')
   local text_edit = text_edits_lib.get_from_item(item)
@@ -19,7 +18,7 @@ local function preview(item)
   }
 
   local undo_text_edit = text_edits_lib.get_undo_text_edit(text_edit)
-  text_edits_lib.apply({ text_edit })
+  text_edits_lib.apply(text_edit)
 
   local cursor_moved = false
 
@@ -29,7 +28,7 @@ local function preview(item)
     cursor_moved = true
   end
 
-  return undo_text_edit, cursor_moved and original_cursor or nil
+  return { text_edit = undo_text_edit, cursor = cursor_moved and original_cursor or nil }
 end
 
 return preview

--- a/lua/blink/cmp/completion/list.lua
+++ b/lua/blink/cmp/completion/list.lua
@@ -229,7 +229,7 @@ function list.undo_preview()
   local new_cursor_col = context.get_cursor()[2]
   text_edit = text_edits_lib.compensate_for_cursor_movement(text_edit, old_cursor_col, new_cursor_col)
 
-  require('blink.cmp.lib.text_edits').apply({ text_edit })
+  require('blink.cmp.lib.text_edits').apply(text_edit)
   if list.preview_undo.cursor_before ~= nil then
     require('blink.cmp.completion.trigger.context').set_cursor(list.preview_undo.cursor_before)
   end
@@ -258,8 +258,7 @@ function list.accept(opts)
   if item == nil then return false end
 
   list.undo_preview()
-  local accept = require('blink.cmp.completion.accept')
-  accept(list.context, item, function()
+  require('blink.cmp.completion.accept')(list.context, item, function()
     list.accept_emitter:emit({ item = item, context = list.context })
     if opts.callback then opts.callback() end
   end)

--- a/lua/blink/cmp/config/completion/accept.lua
+++ b/lua/blink/cmp/config/completion/accept.lua
@@ -1,4 +1,5 @@
 --- @class (exact) blink.cmp.CompletionAcceptConfig
+--- @field dot_repeat boolean Write completions to the `.` register
 --- @field create_undo_point boolean Create an undo point when accepting a completion item
 --- @field resolve_timeout_ms number How long to wait for the LSP to resolve the item with additional information before continuing as-is
 --- @field auto_brackets blink.cmp.AutoBracketsConfig
@@ -25,6 +26,7 @@ local validate = require('blink.cmp.config.utils').validate
 local accept = {
   --- @type blink.cmp.CompletionAcceptConfig
   default = {
+    dot_repeat = true,
     create_undo_point = true,
     resolve_timeout_ms = 100,
     auto_brackets = {
@@ -48,6 +50,7 @@ local accept = {
 
 function accept.validate(config)
   validate('completion.accept', {
+    dot_repeat = { config.dot_repeat, 'boolean' },
     create_undo_point = { config.create_undo_point, 'boolean' },
     resolve_timeout_ms = { config.resolve_timeout_ms, 'number' },
     auto_brackets = { config.auto_brackets, 'table' },

--- a/lua/blink/cmp/lib/buffer_events.lua
+++ b/lua/blink/cmp/lib/buffer_events.lua
@@ -89,7 +89,8 @@ local function make_insert_leave(self, on_insert_leave)
     -- so we schedule to ignore the intermediary modes
     -- TODO: deduplicate requests
     vim.schedule(function()
-      if not vim.tbl_contains({ 'i', 's' }, vim.api.nvim_get_mode().mode) then on_insert_leave() end
+      local mode = vim.api.nvim_get_mode().mode
+      if not mode:match('i') and not mode:match('s') then on_insert_leave() end
     end)
   end
 end
@@ -159,9 +160,9 @@ function buffer_events:suppress_events_for_callback(cb)
   local cursor_after = vim.api.nvim_win_get_cursor(0)
   local changed_tick_after = vim.api.nvim_buf_get_changedtick(0)
 
-  local is_insert_mode = vim.api.nvim_get_mode().mode == 'i'
+  local is_insert_mode = vim.api.nvim_get_mode().mode:sub(1, 1) == 'i'
 
-  self.ignore_next_text_changed = changed_tick_after ~= changed_tick_before and is_insert_mode
+  self.ignore_next_text_changed = changed_tick_before ~= changed_tick_after and is_insert_mode
 
   -- HACK: the cursor may move from position (1, 1) to (1, 0) and back to (1, 1) during the callback
   -- This will trigger a CursorMovedI event, but we can't detect it simply by checking the cursor position

--- a/lua/blink/cmp/lib/term_events.lua
+++ b/lua/blink/cmp/lib/term_events.lua
@@ -62,7 +62,8 @@ function term_events:listen(opts)
   })
 
   -- definitely leaving the context
-  vim.api.nvim_create_autocmd({ 'ModeChanged', 'TermLeave' }, {
+  -- HACK: we don't handle mode changed here because the buffer events handles it
+  vim.api.nvim_create_autocmd('TermLeave', {
     callback = function()
       last_char = ''
       vim.schedule(function() opts.on_term_leave() end)

--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -1,39 +1,46 @@
 local config = require('blink.cmp.config')
+local utils = require('blink.cmp.lib.utils')
 local context = require('blink.cmp.completion.trigger.context')
 
 local text_edits = {}
 
 --- Applies one or more text edits to the current buffer, assuming utf-8 encoding
---- @param edits lsp.TextEdit[]
-function text_edits.apply(edits)
+--- @param text_edit lsp.TextEdit # the main text edit (at the cursor). Can be repeated.
+--- @param additional_text_edits? lsp.TextEdit[] # additional text edits that can e.g. add import statements.
+function text_edits.apply(text_edit, additional_text_edits)
   local mode = context.get_mode()
-  if mode == 'default' then return vim.lsp.util.apply_text_edits(edits, vim.api.nvim_get_current_buf(), 'utf-8') end
+  assert(mode == 'default' or mode == 'cmdline' or mode == 'term', 'Unsupported mode for text edits: ' .. mode)
 
-  assert(mode == 'cmdline' or mode == 'term', 'Unsupported mode for text edits: ' .. mode)
+  if mode == 'default' then
+    text_edits.write_to_dot_repeat(text_edit)
 
-  if mode == 'cmdline' then
-    assert(#edits == 1, 'Cmdline mode only supports one text edit. Contributions welcome!')
-
-    local edit = edits[1]
-    local line = context.get_line()
-    local edited_line = line:sub(1, edit.range.start.character)
-      .. edit.newText
-      .. line:sub(edit.range['end'].character + 1)
-    -- FIXME: for some reason, we have to set the cursor here, instead of later,
-    -- because this will override the cursor position set later
-    vim.fn.setcmdline(edited_line, edit.range.start.character + #edit.newText + 1)
+    local all_edits = utils.shallow_copy(additional_text_edits or {})
+    table.insert(all_edits, 1, text_edit)
+    vim.lsp.util.apply_text_edits(all_edits, vim.api.nvim_get_current_buf(), 'utf-8')
   end
 
+  if mode == 'cmdline' then
+    assert(#additional_text_edits == 0, 'Cmdline mode only supports one text edit. Contributions welcome!')
+
+    local line = context.get_line()
+    local edited_line = line:sub(1, text_edit.range.start.character)
+      .. text_edit.newText
+      .. line:sub(text_edit.range['end'].character + 1)
+    -- FIXME: for some reason, we have to set the cursor here, instead of later,
+    -- because this will override the cursor position set later
+    vim.fn.setcmdline(edited_line, text_edit.range.start.character + #text_edit.newText + 1)
+  end
+
+  -- TODO: apply dot repeat
   if mode == 'term' then
-    assert(#edits == 1, 'Terminal mode only supports one text edit. Contributions welcome!')
+    assert(#additional_text_edits == 0, 'Terminal mode only supports one text edit. Contributions welcome!')
 
     if vim.bo.channel and vim.bo.channel ~= 0 then
-      local edit = edits[1]
       local cur_col = vim.api.nvim_win_get_cursor(0)[2]
-      local n_replaced = cur_col - edit.range.start.character
+      local n_replaced = cur_col - text_edit.range.start.character
       local backspace_keycode = '\8'
 
-      vim.fn.chansend(vim.bo.channel, backspace_keycode:rep(n_replaced) .. edit.newText)
+      vim.fn.chansend(vim.bo.channel, backspace_keycode:rep(n_replaced) .. text_edit.newText)
     end
   end
 end
@@ -278,6 +285,34 @@ function text_edits.get_apply_end_position(text_edit, additional_text_edits)
 
   -- Convert from 0-indexed to (1, 0)-indexed to match nvim cursor api
   return { end_line + 1, end_col }
+end
+
+----- Dot repeat -----
+
+--- @param text_edit lsp.TextEdit
+function text_edits.write_to_dot_repeat(text_edit)
+  -- Fill the `.` register so that dot-repeat works. This also changes the
+  -- text in the buffer - currently there is no way to do this in Neovim
+  -- (only adding new text is supported, but we also want to replace the
+  -- current word). See the tracking issue for this feature at
+  -- https://github.com/neovim/neovim/issues/19806#issuecomment-2365146298
+  local row = vim.api.nvim_win_get_cursor(0)[1]
+  local old_line = vim.api.nvim_get_current_line()
+
+  -- emulate builtin completion (dot repeat)
+  local saved_completeopt = vim.opt.completeopt
+  local saved_shortmess = vim.o.shortmess
+  vim.opt.completeopt = ''
+  if not vim.o.shortmess:match('c') then vim.o.shortmess = vim.o.shortmess .. 'c' end
+  vim.fn.complete(text_edit.range.start.character + 1, { text_edit.newText })
+  vim.opt.completeopt = saved_completeopt
+  vim.o.shortmess = saved_shortmess
+
+  -- exit completion mode
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<C-x><C-z>', true, true, true), 'in', false)
+
+  -- restore old content
+  vim.api.nvim_buf_set_lines(0, row - 1, row, false, { old_line })
 end
 
 return text_edits

--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -14,7 +14,7 @@ function text_edits.apply(text_edit, additional_text_edits)
   assert(mode == 'default' or mode == 'cmdline' or mode == 'term', 'Unsupported mode for text edits: ' .. mode)
 
   if mode == 'default' then
-    text_edits.write_to_dot_repeat(text_edit)
+    if config.completion.accept.dot_repeat then text_edits.write_to_dot_repeat(text_edit) end
 
     local all_edits = utils.shallow_copy(additional_text_edits)
     table.insert(all_edits, 1, text_edit)

--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -149,4 +149,18 @@ function utils.reverse(arr)
   return reversed
 end
 
+--- Disables all autocmds for the duration of the callback
+--- @param cb fun()
+function utils.with_no_autocmds(cb)
+  local original_eventignore = vim.opt.eventignore
+  vim.opt.eventignore = 'all'
+
+  local success, result_or_err = pcall(cb)
+
+  vim.opt.eventignore = original_eventignore
+
+  if not success then error(result_or_err) end
+  return result_or_err
+end
+
 return utils

--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -137,4 +137,16 @@ function utils.get_char_at_cursor()
   return line:sub(start_col, end_col)
 end
 
+--- Reverses an array
+--- @generic T
+--- @param arr T[]
+--- @return T[]
+function utils.reverse(arr)
+  local reversed = {}
+  for i = #arr, 1, -1 do
+    reversed[#reversed + 1] = arr[i]
+  end
+  return reversed
+end
+
 return utils


### PR DESCRIPTION
See #870 for previous work

The main issue atm is with `completion.list.selection.auto_insert = true`, any selected items will be included in the dot repeat, so we should skip the `vim.fn.complete` in that case. If the context changes or we hide, we should then add it to the dot complete. Perhaps we should have a generic "write to dot repeat" function