### PR TITLE
fix: Outdated completion item with mini.snippets

### DIFF
--- a/lua/blink/cmp/config/snippets.lua
+++ b/lua/blink/cmp/config/snippets.lua
@@ -25,6 +25,7 @@ local snippets = {
         if not _G.MiniSnippets then error('mini.snippets has not been setup') end
         local insert = MiniSnippets.config.expand.insert or MiniSnippets.default_insert
         insert({ body = snippet })
+        require('blink.cmp').resubscribe()
       end,
     }),
     active = by_preset({

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -250,6 +250,12 @@ function cmp.snippet_backward()
   return true
 end
 
+--- Ensures that blink.cmp will be notified last when a user adds a character
+function cmp.resubscribe()
+  local trigger = require('blink.cmp.completion.trigger')
+  trigger.resubscribe()
+end
+
 --- Tells the sources to reload a specific provider or all providers (when nil)
 --- @param provider? string
 function cmp.reload(provider) require('blink.cmp.sources.lib').reload(provider) end

--- a/lua/blink/cmp/lib/buffer_events.lua
+++ b/lua/blink/cmp/lib/buffer_events.lua
@@ -7,9 +7,12 @@
 --- @field show_in_snippet boolean
 --- @field ignore_next_text_changed boolean
 --- @field ignore_next_cursor_moved boolean
+--- @field last_char string
+--- @field textchangedi_id number
 ---
 --- @field new fun(opts: blink.cmp.BufferEventsOptions): blink.cmp.BufferEvents
 --- @field listen fun(self: blink.cmp.BufferEvents, opts: blink.cmp.BufferEventsListener)
+--- @field resubscribe fun(self: blink.cmp.BufferEvents, opts: blink.cmp.BufferEventsListener)
 --- @field suppress_events_for_callback fun(self: blink.cmp.BufferEvents, cb: fun())
 
 --- @class blink.cmp.BufferEventsOptions
@@ -31,77 +34,90 @@ function buffer_events.new(opts)
     show_in_snippet = opts.show_in_snippet,
     ignore_next_text_changed = false,
     ignore_next_cursor_moved = false,
+    last_char = '',
+    textchangedi_id = -1,
   }, { __index = buffer_events })
+end
+
+local function make_char_added(self, snippet, on_char_added)
+  return function()
+    if not require('blink.cmp.config').enabled() then return end
+    if snippet.active() and not self.show_in_snippet and not self.has_context() then return end
+
+    local is_ignored = self.ignore_next_text_changed
+    self.ignore_next_text_changed = false
+
+    -- no characters added so let cursormoved handle it
+    if self.last_char == '' then return end
+
+    on_char_added(self.last_char, is_ignored)
+
+    self.last_char = ''
+  end
+end
+
+local function make_cursor_moved(self, snippet, on_cursor_moved)
+  return function(ev)
+    -- only fire a CursorMoved event (notable not CursorMovedI)
+    -- when jumping between tab stops in a snippet while showing the menu
+    if
+      ev.event == 'CursorMoved'
+      and (vim.api.nvim_get_mode().mode ~= 'v' or not self.has_context() or not snippet.active())
+    then
+      return
+    end
+
+    local is_cursor_moved = ev.event == 'CursorMoved' or ev.event == 'CursorMovedI'
+
+    local is_ignored = is_cursor_moved and self.ignore_next_cursor_moved
+    if is_cursor_moved then self.ignore_next_cursor_moved = false end
+
+    -- characters added so let textchanged handle it
+    if self.last_char ~= '' then return end
+
+    if not require('blink.cmp.config').enabled() then return end
+    if not self.show_in_snippet and not self.has_context() and snippet.active() then return end
+
+    on_cursor_moved(is_cursor_moved and 'CursorMoved' or ev.event, is_ignored)
+  end
+end
+
+local function make_insert_leave(self, on_insert_leave)
+  return function()
+    self.last_char = ''
+    -- HACK: when using vim.snippet.expand, the mode switches from insert -> normal -> visual -> select
+    -- so we schedule to ignore the intermediary modes
+    -- TODO: deduplicate requests
+    vim.schedule(function()
+      if not vim.tbl_contains({ 'i', 's' }, vim.api.nvim_get_mode().mode) then on_insert_leave() end
+    end)
+  end
 end
 
 --- Normalizes the autocmds + ctrl+c into a common api and handles ignored events
 function buffer_events:listen(opts)
   local snippet = require('blink.cmp.config').snippets
 
-  local last_char = ''
   vim.api.nvim_create_autocmd('InsertCharPre', {
     callback = function()
       if snippet.active() and not self.show_in_snippet and not self.has_context() then return end
       -- FIXME: vim.v.char can be an escape code such as <95> in the case of <F2>. This breaks downstream
       -- since this isn't a valid utf-8 string. How can we identify and ignore these?
-      last_char = vim.v.char
+      self.last_char = vim.v.char
     end,
   })
 
-  vim.api.nvim_create_autocmd('TextChangedI', {
-    callback = function()
-      if not require('blink.cmp.config').enabled() then return end
-      if snippet.active() and not self.show_in_snippet and not self.has_context() then return end
-
-      local is_ignored = self.ignore_next_text_changed
-      self.ignore_next_text_changed = false
-
-      -- no characters added so let cursormoved handle it
-      if last_char == '' then return end
-
-      opts.on_char_added(last_char, is_ignored)
-
-      last_char = ''
-    end,
+  self.textchangedi_id = vim.api.nvim_create_autocmd('TextChangedI', {
+    callback = make_char_added(self, snippet, opts.on_char_added),
   })
 
   vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI', 'InsertEnter' }, {
-    callback = function(ev)
-      -- only fire a CursorMoved event (notable not CursorMovedI)
-      -- when jumping between tab stops in a snippet while showing the menu
-      if
-        ev.event == 'CursorMoved'
-        and (vim.api.nvim_get_mode().mode ~= 'v' or not self.has_context() or not snippet.active())
-      then
-        return
-      end
-
-      local is_cursor_moved = ev.event == 'CursorMoved' or ev.event == 'CursorMovedI'
-
-      local is_ignored = is_cursor_moved and self.ignore_next_cursor_moved
-      if is_cursor_moved then self.ignore_next_cursor_moved = false end
-
-      -- characters added so let textchanged handle it
-      if last_char ~= '' then return end
-
-      if not require('blink.cmp.config').enabled() then return end
-      if not self.show_in_snippet and not self.has_context() and snippet.active() then return end
-
-      opts.on_cursor_moved(is_cursor_moved and 'CursorMoved' or ev.event, is_ignored)
-    end,
+    callback = make_cursor_moved(self, snippet, opts.on_cursor_moved),
   })
 
   -- definitely leaving the context
   vim.api.nvim_create_autocmd({ 'ModeChanged', 'BufLeave' }, {
-    callback = function()
-      last_char = ''
-      -- HACK: when using vim.snippet.expand, the mode switches from insert -> normal -> visual -> select
-      -- so we schedule to ignore the intermediary modes
-      -- TODO: deduplicate requests
-      vim.schedule(function()
-        if not vim.tbl_contains({ 'i', 's' }, vim.api.nvim_get_mode().mode) then opts.on_insert_leave() end
-      end)
-    end,
+    callback = make_insert_leave(self, opts.on_insert_leave),
   })
 
   -- ctrl+c doesn't trigger InsertLeave so handle it separately
@@ -111,12 +127,22 @@ function buffer_events:listen(opts)
       vim.schedule(function()
         local mode = vim.api.nvim_get_mode().mode
         if mode ~= 'i' then
-          last_char = ''
+          self.last_char = ''
           opts.on_insert_leave()
         end
       end)
     end
   end)
+end
+
+function buffer_events:resubscribe(opts)
+  if self.textchangedi_id == -1 then return end
+
+  local snippet = require('blink.cmp.config').snippets
+  vim.api.nvim_del_autocmd(self.textchangedi_id)
+  self.textchangedi_id = vim.api.nvim_create_autocmd('TextChangedI', {
+    callback = make_char_added(self, snippet, opts.on_char_added),
+  })
 end
 
 --- Suppresses autocmd events for the duration of the callback


### PR DESCRIPTION
Hello @Saghen,

I recently [fixed](https://github.com/hrsh7th/nvim-cmp/pull/2126) this [issue](https://github.com/hrsh7th/nvim-cmp/issues/2119) in `nvim-cmp`.

The problem also occurs in `blink`, and the fix is very similar.

Are there any drawbacks to the following approach?

`.../completion/init.lua`:

```lua
  -- trigger -> sources: request completion items from the sources on show
  trigger.show_emitter:on(function(event)
    vim.schedule(function()
      -- schedule to avoid outdated completion items
      sources.request_completions(event.context)
    end)
  end)
```