### PR TITLE
Typo in Documentation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -96,7 +96,7 @@ Setting capabilities for `nvim-lspconfig`:
     local capabilities = require('blink.cmp').get_lsp_capabilities()
     local lspconfig = require('lspconfig')
 
-    lspconfig['lua-ls'].setup({ capabilities = capabilities })
+    lspconfig['lua_ls'].setup({ capabilities = capabilities })
   end
 }
 ```


### PR DESCRIPTION
Changed 'lua-ls' to 'lua_ls' in line 99 so it wont return an error.