### PR TITLE
feat(menu.draw): columns can be function

### DIFF
--- a/lua/blink/cmp/completion/windows/menu.lua
+++ b/lua/blink/cmp/completion/windows/menu.lua
@@ -51,8 +51,8 @@ function menu.open_with_items(context, items)
   menu.items = items
   menu.selected_item_idx = menu.selected_item_idx ~= nil and math.min(menu.selected_item_idx, #items) or nil
 
-  if not menu.renderer then menu.renderer = require('blink.cmp.completion.windows.render').new(config.draw) end
-  menu.renderer:draw(context, menu.win:get_buf(), items)
+  if not menu.renderer then menu.renderer = require('blink.cmp.completion.windows.render').new(context, config.draw) end
+  menu.renderer:draw(context, menu.win:get_buf(), items, config.draw)
 
   local auto_show = menu.auto_show
   if type(auto_show) == 'function' then auto_show = auto_show(context, items) end

--- a/lua/blink/cmp/completion/windows/render/column.lua
+++ b/lua/blink/cmp/completion/windows/render/column.lua
@@ -6,7 +6,7 @@
 --- @field ctxs blink.cmp.DrawItemContext[]
 ---
 --- @field new fun(components: blink.cmp.DrawComponent[], gap: number): blink.cmp.DrawColumn
---- @field render fun(self: blink.cmp.DrawColumn, ctxs: blink.cmp.DrawItemContext[])
+--- @field render fun(self: blink.cmp.DrawColumn,context: blink.cmp.Context, ctxs: blink.cmp.DrawItemContext[])
 --- @field get_line_text fun(self: blink.cmp.DrawColumn, line_idx: number): string
 --- @field get_line_highlights fun(self: blink.cmp.DrawColumn, line_idx: number): blink.cmp.DrawHighlight[]
 
@@ -26,7 +26,7 @@ function column.new(components, gap)
   return self
 end
 
-function column:render(ctxs)
+function column:render(context, ctxs)
   --- render text and get the max widths of each component
   --- @type string[][]
   local lines = {}
@@ -35,7 +35,7 @@ function column:render(ctxs)
     --- @type string[]
     local line = {}
     for component_idx, component in ipairs(self.components) do
-      local text = text_lib.apply_component_width(component.text(ctx) or '', component)
+      local text = text_lib.apply_component_width(context, component.text(ctx) or '', component)
       table.insert(line, text)
       max_component_widths[component_idx] =
         math.max(max_component_widths[component_idx] or 0, vim.api.nvim_strwidth(text))

--- a/lua/blink/cmp/completion/windows/render/text.lua
+++ b/lua/blink/cmp/completion/windows/render/text.lua
@@ -2,14 +2,17 @@ local config = require('blink.cmp.config')
 local text_lib = {}
 
 --- Applies the component width settings to the text
+--- @param context blink.cmp.Context
 --- @param text string
 --- @param component blink.cmp.DrawComponent
 --- @return string text
-function text_lib.apply_component_width(text, component)
+function text_lib.apply_component_width(context, text, component)
   local width = component.width or {}
   if width.fixed ~= nil then return text_lib.set_width(text, width.fixed, component) end
   if width.min ~= nil then text = text_lib.pad(text, width.min) end
-  if width.max ~= nil then text = text_lib.truncate(text, width.max, component.ellipsis) end
+  local max_width = width.max
+  if type(width.max) == 'function' then max_width = width.max(context) end
+  if max_width ~= nil then text = text_lib.truncate(text, max_width, component.ellipsis) end
   return text
 end
 

--- a/lua/blink/cmp/config/completion/menu.lua
+++ b/lua/blink/cmp/config/completion/menu.lua
@@ -164,6 +164,7 @@ function window.validate(config)
     align_to = {
       config.draw.align_to,
       function(align)
+        if type(config.draw.columns) == 'function' then return true end
         if align == 'none' or align == 'cursor' then return true end
         for _, column in ipairs(config.draw.columns) do
           for _, component in ipairs(column) do
@@ -193,7 +194,7 @@ function window.validate(config)
       config.draw.columns,
       function(columns)
         local available_components = vim.tbl_keys(config.draw.components)
-
+        if type(columns) == 'function' then return true end
         if type(columns) ~= 'table' or #columns == 0 then return false end
         for _, column in ipairs(columns) do
           if #column == 0 then return false end


### PR DESCRIPTION
https://github.com/Saghen/blink.cmp/issues/820 may be closed

# what i did:
- `menu.draw.columns` can receive an function with `ctx` args;
- `draw.components._.width.max` can receive an function with `ctx` args (this is needed for set seperate max_width for cmdline);

# example

```lua
menu.draw.columns = function(ctx)
    if ctx.mode == "cmdline" then
        return { { "kind_icon" }, { "label" } }
    else
        return { { "kind_icon" }, { "label", "label_description", gap = 1 } }
    end
end

draw.components.label.width.max = function(ctx)
    return ctx.mode == "cmdline" and 20 or 60
end
```

# need to do:
- docs
- config check should be more detailed.

feel free to change anything to what you want :)