### PR TITLE
Update recipes.md

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -233,7 +233,7 @@ sources = {
 
 ### Path completion from `cwd` instead of current buffer's directory
 
-It's common to run code from the root of your repository, in which case relative paths will start from that directory. In that case, you may want path completions to be relative to your current working directory rather than the default, which is the current buffer's directory.
+It's common to run code from the root of your repository, in which case relative paths will start from that directory. In that case, you may want path completions to be relative to your current working directory rather than the default, which is the current buffer's parent directory.
 
 ```lua
 sources = {

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -231,6 +231,26 @@ sources = {
 }
 ```
 
+### Path completion from `cwd` instead of current buffer's directory
+
+It's common to run code from the root of your repository, in which case relative paths will start from that directory. In that case, you may want path completions to be relative to your current working directory rather than the default, which is the current buffer's directory.
+
+```lua
+sources = {
+  providers = {
+    path = {
+      opts = {
+        get_cwd = function(_)
+          return vim.fn.getcwd()
+        end,
+      },
+    },
+  },
+},
+```
+
+This also makes it easy to `:cwd` to the desired base directory for path completion.
+
 ## For writers
 
 When writing prose, you may want significantly different behavior than typical LSP completions. If you find any interesting configurations, please open a PR adding it here!


### PR DESCRIPTION
Includes example for making path completion relative to `cwd` rather than buffer's parent dir.