### PR TITLE
chore: add <C-k> to default keymap doc

### DIFF
--- a/lua/blink/cmp/config/keymap.lua
+++ b/lua/blink/cmp/config/keymap.lua
@@ -37,6 +37,8 @@
 ---
 ---   ['<Tab>'] = { 'snippet_forward', 'fallback' },
 ---   ['<S-Tab>'] = { 'snippet_backward', 'fallback' },
+---  
+---   ['<C-k>'] = { 'show_signature', 'hide_signature', 'fallback' },
 --- }
 --- ```
 --- | 'default'


### PR DESCRIPTION
The `<C-k>` was previously missing in the doc on the `default` keymap which lead to confusion when this keymap was added since it was not shown in the cmp documentation.