### PR TITLE
Apply lsp commands

### DIFF
--- a/docs/development/lsp-tracker.md
+++ b/docs/development/lsp-tracker.md
@@ -65,5 +65,5 @@
 - [x] `textEditText`
 - [x] `additionalTextEdits` <- known issue where applying the main text edit will cause this to be wrong if the additional text edit comes after since the indices will be offset
 - [ ] `commitCharacters`
-- [ ] `command`
+- [x] `command`
 - [x] `data` <- Don't think there's anything special to do here

--- a/lua/blink/cmp/sources/lib/provider/init.lua
+++ b/lua/blink/cmp/sources/lib/provider/init.lua
@@ -158,7 +158,7 @@ function source:execute(context, item)
   if self.module.execute == nil then
     return async.task.new(function(resolve) resolve() end)
   end
-  return async.task.new(function(resolve) self.module:execute(context, item, resolve) end)
+  return async.task.new(function(resolve) return self.module:execute(context, item, resolve) end)
 end
 
 --- Signature help ---

--- a/lua/blink/cmp/sources/lsp/init.lua
+++ b/lua/blink/cmp/sources/lsp/init.lua
@@ -149,10 +149,13 @@ end
 
 --- Execute ---
 
-function lsp:execute(_, item)
+function lsp:execute(_, item, callback)
   local client = vim.lsp.get_client_by_id(item.client_id)
-  if client and item.command then client.request('workspace/executeCommand', item.command) end
-  return function() end
+  if client and item.command then
+    client.request('workspace/executeCommand', item.command, function() callback() end)
+  else
+    callback()
+  end
 end
 
 return lsp

--- a/lua/blink/cmp/sources/lsp/init.lua
+++ b/lua/blink/cmp/sources/lsp/init.lua
@@ -147,4 +147,12 @@ function lsp:get_signature_help(context, callback)
   end)
 end
 
+--- Execute ---
+
+function lsp:execute(_, item)
+  local client = vim.lsp.get_client_by_id(item.client_id)
+  if client and item.command then client.request('workspace/executeCommand', item.command) end
+  return function() end
+end
+
 return lsp


### PR DESCRIPTION
If the lsp returns commands to run on completion, we now execute them. This is helpful for the Haskell language server which uses commands to implement auto-importing.