### PR TITLE
docs: add `blink-cmp-env` community source

### DIFF
--- a/docs/configuration/sources.md
+++ b/docs/configuration/sources.md
@@ -74,3 +74,4 @@ The command `:BlinkCmp status` can be used to view which sources providers are e
 - [blink-cmp-git](https://github.com/Kaiser-Yang/blink-cmp-git)
 - [blink-cmp-spell](https://github.com/ribru17/blink-cmp-spell.git)
 - [css-vars.nvim](https://github.com/jdrupal-dev/css-vars.nvim)
+- [blink-cmp-env](https://github.com/bydlw98/blink-cmp-env)


### PR DESCRIPTION
Hi. This adds [blink-cmp-env](https://github.com/bydlw98/blink-cmp-env) to the list of community sources.