### PR TITLE
fix: path completion in Windows using backward slash

### DIFF
--- a/lua/blink/cmp/sources/path/init.lua
+++ b/lua/blink/cmp/sources/path/init.lua
@@ -32,7 +32,7 @@ function path.new(opts)
   return self
 end
 
-function path:get_trigger_characters() return { '/', '.' } end
+function path:get_trigger_characters() return { '/', '.', '\\' } end
 
 function path:get_completions(context, callback)
   -- we use libuv, but the rest of the library expects to be synchronous

--- a/lua/blink/cmp/sources/path/regex.lua
+++ b/lua/blink/cmp/sources/path/regex.lua
@@ -5,13 +5,26 @@
 -- Not allowed: ~/example foo
 local NAME_WITH_SPACE_REGEX = '\\%([^/\\\\:\\*?<>\'"`\\|]\\)'
 local NAME_REGEX = '\\%([^/\\\\:\\*?<>\'"`\\| ]\\)'
-local PATH_REGEX = assert(
-  vim.regex(
-    ([[\%(\%(/PAT1*[^/\\\\:\\*?<>\'"`\\| .~]\)\|\%(/\.\.\)\)*/\zePAT2*$]])
-      :gsub('PAT1', NAME_WITH_SPACE_REGEX)
-      :gsub('PAT2', NAME_REGEX)
+local IS_WIN = vim.uv.os_uname().sysname == 'Windows_NT'
+local PATH_REGEX
+
+if IS_WIN then
+  PATH_REGEX = assert(
+    vim.regex(
+      ([[\%(\%([/\\]PAT1*[^/\\\\:\\*?<>\'"`\\| .~]\)\|\%(/\.\.\)\)*[/\\]\zePAT2*$]])
+        :gsub('PAT1', NAME_WITH_SPACE_REGEX)
+        :gsub('PAT2', NAME_REGEX)
+    )
   )
-)
+else
+  PATH_REGEX = assert(
+    vim.regex(
+      ([[\%(\%(/PAT1*[^/\\\\:\\*?<>\'"`\\| .~]\)\|\%(/\.\.\)\)*/\zePAT2*$]])
+        :gsub('PAT1', NAME_WITH_SPACE_REGEX)
+        :gsub('PAT2', NAME_REGEX)
+    )
+  )
+end
 
 return {
   --- Lua pattern for matching file names


### PR DESCRIPTION
Fixes #1151 by doing the following:
1. Ensure that `\` is allowed as a trigger character.
2. Fix the path regex to handle Windows correctly.

The implementation for the path regex was taken directly from [async_path](https://codeberg.org/FelipeLema/cmp-async-path/src/branch/main/lua/cmp_async_path/init.lua). I've already tested this on Windows and can confirm that it correctly handles both `C:/` and `C:\` paths.