### PR TITLE
fix(luadoc): KeymapCommand alias broken

### DIFF
--- a/lua/blink/cmp/config/keymap.lua
+++ b/lua/blink/cmp/config/keymap.lua
@@ -1,5 +1,4 @@
 --- @alias blink.cmp.KeymapCommand
-
 --- | 'fallback' Fallback to the built-in behavior
 --- | 'show' Show the completion window
 --- | 'show_and_insert' Show the completion window and select the first item


### PR DESCRIPTION
Hey there!

I was thrown of that my languageserver told me my keymappings are wrongly typed, so I took a quick look around and I think the blank line that I removed breaks the typedoc.
At least without it my languageserver is happier than before :D