### PR TITLE
docs(recipes.md): add Disable completion in only shell command mode

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -16,19 +16,19 @@ end,
 
 ### Disable completion in *only* shell command mode
 
-Some pc's, especially windows running git bash, hang with cmp in shell commands. This disables blink cmp only when running shell commands ( i.e. [ ':!' , ':%!' ] ), but still allows completion in other command modes ( i.e. [ ':' , ':help', '/' , '?' ] etc ).
+Windows when inside of git bash or WSL may cause a hang with shell commands. This disables cmdline completions only when running shell commands ( i.e. [ ':!' , ':%!' ] ), but still allows completion in other command modes ( i.e. [ ':' , ':help', '/' , '?' ] etc ).
+
 ```lua
-    enabled = function()
-      -- check if command mode is a shell cmd (i.e. [ ":!" , ":%!" ]) to disable cmp for proformance
-      local function not_shellcmd()
-        if vim.fn.getcmdtype() ~= ':' then -- speed optimization for searches
-          return true
-        else
-          return not vim.fn.getcmdline():match("^[%%0-9,'<>%-]*!")
-          end
+sources = {
+  providers = {
+    cmdline = {
+      -- ignores cmdline completions when executing shell commands
+      enabled = function()
+        return vim.fn.getcmdtype() ~= ':' or not vim.fn.getcmdline():match("^[%%0-9,'<>%-]*!")
       end
-      return not_shellcmd()
-    end,
+    }
+  }
+}
 ```
 
 ### Border

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -14,6 +14,23 @@ enabled = function()
 end,
 ```
 
+### Disable completion in *only* shell command mode
+
+Some pc's, especially windows running git bash, hang with cmp in shell commands. This disables blink cmp only when running shell commands ( i.e. [ ':!' , ':%!' ] ), but still allows completion in other command modes ( i.e. [ ':' , ':help', '/' , '?' ] etc ).
+```lua
+    enabled = function()
+      -- check if command mode is a shell cmd (i.e. [ ":!" , ":%!" ]) to disable cmp for proformance
+      local function not_shellcmd()
+        if vim.fn.getcmdtype() ~= ':' then -- speed optimization for searches
+          return true
+        else
+          return not vim.fn.getcmdline():match("^[%%0-9,'<>%-]*!")
+          end
+      end
+      return not_shellcmd()
+    end,
+```
+
 ### Border
 
 ```lua


### PR DESCRIPTION
Addresses #795 by adding recipe to disable command completion in certain scenarios like the following:

disables blink cmp only when running shell commands ( i.e. [ ':!' , ':%!' ] ), but still allows completion in other command modes ( i.e. [ ':' , ':help', '/' , '?' ] etc ).

---
context

on my nvim config running inside windows > wezterm > using git bash shell if i leave cmp on for shell commands nvim hangs as it indexes (i think?) the shell completions. So i put the code from this recipe in my config, thought others might benefit from it aswell!