### PR TITLE
ci(docs): do not run deploy-docs job in forks

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy-docs:
+    if: github.repository == 'Saghen/blink.cmp'
     name: Deploy docs
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
When syncing changes to the forked repository, the deploy-docs job will always run and fail.

With this commit, the deploy-docs job will check if the current github repository is the original "upstream" repository before running the job.