### PR TITLE
feat: format lua files using stylua

### DIFF
--- a/.github/workflows/stylua.yaml
+++ b/.github/workflows/stylua.yaml
@@ -1,0 +1,28 @@
+name: Stylua
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  CLICOLOR: 1
+
+jobs:
+  stylua:
+    name: Check lua files using Stylua
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Stylua Check Repo
+        uses: JohnnyMorganz/stylua-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --color=always --check lua

--- a/.github/workflows/stylua.yaml
+++ b/.github/workflows/stylua.yaml
@@ -25,4 +25,5 @@ jobs:
         uses: JohnnyMorganz/stylua-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
           args: --color=always --check lua

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,3 +1,4 @@
+syntax = "LuaJIT"
 column_width = 120
 line_endings = "Unix"
 indent_type = "Spaces"

--- a/lua/blink-cmp.lua
+++ b/lua/blink-cmp.lua
@@ -1,2 +1,1 @@
 return require('blink.cmp')
-

--- a/lua/blink/cmp/config/keymap.lua
+++ b/lua/blink/cmp/config/keymap.lua
@@ -38,7 +38,7 @@
 ---
 ---   ['<Tab>'] = { 'snippet_forward', 'fallback' },
 ---   ['<S-Tab>'] = { 'snippet_backward', 'fallback' },
----  
+---
 ---   ['<C-k>'] = { 'show_signature', 'hide_signature', 'fallback' },
 --- }
 --- ```

--- a/lua/blink/cmp/keymap/init.lua
+++ b/lua/blink/cmp/keymap/init.lua
@@ -70,7 +70,6 @@ function keymap.setup()
     require('blink.cmp.keymap.apply').cmdline_keymaps(cmdline_mappings)
   end
 
-
   -- Apply term keymaps
   local term_sources = require('blink.cmp.config').sources.term
   if type(term_sources) ~= 'table' or #term_sources > 0 then

--- a/lua/blink/cmp/lib/term_events.lua
+++ b/lua/blink/cmp/lib/term_events.lua
@@ -36,13 +36,13 @@ function term_events:listen(opts)
   vim.api.nvim_create_autocmd('TermEnter', {
     callback = function()
       vim.on_key(function(k) last_char = k end, term_on_key_ns)
-    end
+    end,
   })
   vim.api.nvim_create_autocmd('TermLeave', {
     callback = function()
       vim.on_key(nil, term_on_key_ns)
       last_char = ''
-    end
+    end,
   })
 
   vim.api.nvim_create_autocmd('TextChangedT', {
@@ -86,7 +86,7 @@ function term_events:suppress_events_for_callback(cb)
   self.ignore_next_text_changed = changed_tick_after ~= changed_tick_before and is_term_mode
   -- TODO: does this guarantee that the CursorMovedI event will fire?
   self.ignore_next_cursor_moved = (cursor_after[1] ~= cursor_before[1] or cursor_after[2] ~= cursor_before[2])
-  and is_term_mode
+    and is_term_mode
 end
 
 return term_events

--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -17,8 +17,8 @@ function text_edits.apply(edits)
     local edit = edits[1]
     local line = context.get_line()
     local edited_line = line:sub(1, edit.range.start.character)
-    .. edit.newText
-    .. line:sub(edit.range['end'].character + 1)
+      .. edit.newText
+      .. line:sub(edit.range['end'].character + 1)
     -- FIXME: for some reason, we have to set the cursor here, instead of later,
     -- because this will override the cursor position set later
     vim.fn.setcmdline(edited_line, edit.range.start.character + #edit.newText + 1)
@@ -33,10 +33,7 @@ function text_edits.apply(edits)
       local n_replaced = cur_col - edit.range.start.character
       local backspace_keycode = '\8'
 
-      vim.fn.chansend(
-        vim.bo.channel,
-        backspace_keycode:rep(n_replaced) .. edit.newText
-      )
+      vim.fn.chansend(vim.bo.channel, backspace_keycode:rep(n_replaced) .. edit.newText)
     end
   end
 end

--- a/lua/blink/cmp/sources/lib/provider/override.lua
+++ b/lua/blink/cmp/sources/lib/provider/override.lua
@@ -8,7 +8,9 @@ function override.new(module, override_config)
 
   return setmetatable({}, {
     __index = function(_, key)
-      if override_config[key] ~= nil then return function(_, ...) return override_config[key](module, ...) end end
+      if override_config[key] ~= nil then
+        return function(_, ...) return override_config[key](module, ...) end
+      end
       return module[key]
     end,
   })


### PR DESCRIPTION
This commit fixs formatting in lua files using stylua and updates ".stylua.toml" to use LuaJIT syntax.

A workflow is also added to check whether lua files are formatted using stylua. This workflow runs on pushes to the "main" branch and on pull requests.