### PR TITLE
feat!: mode-specific config

### DIFF
--- a/docs/configuration/completion.md
+++ b/docs/configuration/completion.md
@@ -32,6 +32,9 @@ Shows after typing a trigger character, defined by the sources. For example for 
 
 ```lua
 completion.trigger.show_on_trigger_character = true
+-- Optionally, set a list of characters that will not trigger the completion window,
+-- even when sources request it. The following are the defaults:
+completion.trigger.show_on_blocked_trigger_characters = { ' ', '\n', '\t' }
 ```
 
 <video src="https://github.com/user-attachments/assets/b4ee0069-2de8-44e7-b3ca-51b10bc4cb4a" muted autoplay loop />
@@ -41,6 +44,9 @@ Shows after entering insert mode on top of a trigger character.
 
 ```lua
 completion.trigger.show_on_insert_on_trigger_character = true
+-- Optionally, set a list of characters that will not trigger the completion window,
+-- even when sources request it. The following are the defaults:
+completion.trigger.show_on_x_blocked_trigger_characters = { "'", '"', '(', '{', '[' }
 ```
 
 <video src="https://github.com/user-attachments/assets/9e7aa3c2-4756-4a5e-a0e8-303d3ae0fda9" muted autoplay loop />
@@ -50,6 +56,9 @@ Shows after accepting a completion item, where the cursor ends up on top of a tr
 
 ```lua
 completion.trigger.show_on_accept_on_trigger_character = true
+-- Optionally, set a list of characters that will not trigger the completion window,
+-- even when sources request it. The following are the defaults:
+completion.trigger.show_on_x_blocked_trigger_characters = { "'", '"', '(', '{', '[' }
 ```
 
 TODO: Find a case where this actually fires : )

--- a/docs/configuration/keymap.md
+++ b/docs/configuration/keymap.md
@@ -73,25 +73,21 @@ keymap = {
 
 ## Cmdline and Terminal
 
-You may set a separate keymap for cmdline by defining `keymap.cmdline`, with an identical structure to `keymap`.
+You may set a separate keymap for cmdline by defining `cmdline.keymap`, with an identical structure to `keymap`. The same applies for terminal keymaps, under `term.keymap`.
 
 ```lua
-keymap = {
-  preset = 'default',
+cmdline.keymap = {
+  preset = 'enter',
+
+  -- OPTIONAL: sets <CR> to accept the item and run the command immediately
+  -- use `select_accept_and_enter` to accept the item or the first item if none are selected
+  ['<CR>'] = { 'accept_and_enter', 'fallback' },
+
   ...
-  cmdline = {
-    preset = 'enter',
-
-    -- OPTIONAL: sets <CR> to accept the item and run the command immediately
-    -- use `select_accept_and_enter` to accept the item or the first item if none are selected
-    ['<CR>'] = { 'accept_and_enter', 'fallback' },
-
-    ...
-  },
-  term = {
-    preset = 'super-tab',
-    ...
-  }
+},
+term.keymap = {
+  preset = 'super-tab',
+  ...
 }
 ```
 

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -2,6 +2,7 @@
 
 > [!IMPORTANT]
 > Do not copy the default configuration! Only include options you want to change in your configuration
+
 ```lua
 -- Enables keymaps, completions and signature help when true
 enabled = function() return vim.bo.buftype ~= "prompt" and vim.b.completion ~= false end,
@@ -55,16 +56,7 @@ completion.trigger = {
   -- LSPs can indicate when to show the completion window via trigger characters
   -- however, some LSPs (i.e. tsserver) return characters that would essentially
   -- always show the window. We block these by default.
-  show_on_blocked_trigger_characters = function()
-    if vim.api.nvim_get_mode().mode == 'c' then return {} end
-
-    -- you can also block per filetype, for example:
-    -- if vim.bo.filetype == 'markdown' then
-    --   return { ' ', '\n', '\t', '.', '/', '(', '[' }
-    -- end
-
-    return { ' ', '\n', '\t' }
-  end,
+  show_on_blocked_trigger_characters = { ' ', '\n', '\t' },
 
   -- When both this and show_on_trigger_character are true, will show the completion window
   -- when the cursor comes after a trigger character after accepting an item
@@ -385,6 +377,8 @@ fuzzy = {
 
 ## Sources
 
+See the [mode specific configurations](#mode-specific) for setting sources for `cmdline` and `term`.
+
 ```lua
 sources = {
   -- Static list of providers to enable, or a function to dynamically enable/disable providers based on the context
@@ -394,21 +388,6 @@ sources = {
   per_filetype = {
     -- lua = { 'lsp', 'path' },
   },
-
-  -- By default, we choose providers for the cmdline based on the current cmdtype
-  -- You may disable cmdline completions by replacing this with an empty table
-  cmdline = function()
-    local type = vim.fn.getcmdtype()
-    -- Search forward and backward
-    if type == '/' or type == '?' then return { 'buffer' } end
-    -- Commands
-    if type == ':' or type == '@' then return { 'cmdline' } end
-    return {}
-  end,
-
-  -- By default, we don't enable any terminal sources, but you may try `path` or others
-  -- NOTE: Nightly only! Known bugs in v0.10
-  term = {},
 
   -- Function to use when transforming the items before they're returned for all providers
   -- The default will lower the score for snippets to sort them lower in the list
@@ -568,3 +547,62 @@ appearance = {
   },
 }
 ```
+
+## Mode specific
+
+You may set configurations which will override the default configuration, specifically for that mode. Only properties in the top level config that support `fun()` may be overridden, as well as `sources` and `keymap`.
+
+### Cmdline
+
+```lua
+cmdline = {
+  enabled = true,
+  keymap = nil, -- Inherits from top level `keymap` config when not set
+  sources = {
+    per_cmdtype = {
+      ['/'] = { 'buffer' },
+      ['?'] = { 'buffer' },
+      [':'] = { 'cmdline' },
+      ['@'] = { 'cmdline' },
+    },
+  },
+  completion = {
+    trigger = {
+      show_on_blocked_trigger_characters = {},
+      show_on_x_blocked_trigger_characters = nil, -- Inherits from top level `completion.trigger.show_on_blocked_trigger_characters` config when not set
+    },
+    menu = {
+      auto_show = nil, -- Inherits from top level `completion.menu.auto_show` config when not set
+      draw = {
+        columns = { { 'label', 'label_description', gap = 1 } },
+      },
+    }
+  }
+}
+```
+
+### Terminal
+
+> [!NOTE]
+> Terminal completions are nightly only! Known bugs in v0.10
+
+```lua
+term = {
+  enabled = false,
+  keymap = nil, -- Inherits from top level `keymap` config when not set
+  sources = {
+    default = {},
+  },
+  completion = {
+    trigger = {
+      show_on_blocked_trigger_characters = {},
+      show_on_x_blocked_trigger_characters = nil, -- Inherits from top level `completion.trigger.show_on_blocked_trigger_characters` config when not set
+    },
+    menu = {
+      auto_show = nil, -- Inherits from top level `completion.menu.auto_show` config when not set
+      draw = {
+        columns = { { 'label', 'label_description', gap = 1 } },
+      },
+    }
+  }
+}

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -558,14 +558,14 @@ You may set configurations which will override the default configuration, specif
 cmdline = {
   enabled = true,
   keymap = nil, -- Inherits from top level `keymap` config when not set
-  sources = {
-    per_cmdtype = {
-      ['/'] = { 'buffer' },
-      ['?'] = { 'buffer' },
-      [':'] = { 'cmdline' },
-      ['@'] = { 'cmdline' },
-    },
-  },
+  sources = function()
+    local type = vim.fn.getcmdtype()
+    -- Search forward and backward
+    if type == '/' or type == '?' then return { 'buffer' } end
+    -- Commands
+    if type == ':' or type == '@' then return { 'cmdline' } end
+    return {}
+  end,
   completion = {
     trigger = {
       show_on_blocked_trigger_characters = {},
@@ -590,9 +590,7 @@ cmdline = {
 term = {
   enabled = false,
   keymap = nil, -- Inherits from top level `keymap` config when not set
-  sources = {
-    default = {},
-  },
+  sources = {},
   completion = {
     trigger = {
       show_on_blocked_trigger_characters = {},

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -57,6 +57,11 @@ completion.trigger = {
   -- however, some LSPs (i.e. tsserver) return characters that would essentially
   -- always show the window. We block these by default.
   show_on_blocked_trigger_characters = { ' ', '\n', '\t' },
+  -- You can also block per filetype with a function:
+  -- show_on_blocked_trigger_characters = function(ctx)
+  --   if vim.bo.filetype == 'markdown' then return { ' ', '\n', '\t', '.', '/', '(', '[' } end
+  --   return { ' ', '\n', '\t' }
+  -- end,
 
   -- When both this and show_on_trigger_character are true, will show the completion window
   -- when the cursor comes after a trigger character after accepting an item

--- a/docs/configuration/sources.md
+++ b/docs/configuration/sources.md
@@ -56,7 +56,7 @@ sources.providers.lsp = {
 > [!NOTE]
 > Terminal completions are nightly only! Known bugs in v0.10. Cmdline completions are supported on all versions
 
-You may use `cmdline` and `term` sources via the `sources.cmdline` and `sources.term` tables. You may see the defaults in the [reference](./reference.md#sources). There's no source for shell completions at the moment, [contributions welcome](https://github.com/Saghen/blink.cmp/issues/1149)! 
+You may use `cmdline` and `term` sources via the `cmdline.sources.per_cmdtype` and `term.sources.default` tables. You may see the defaults in the [reference](./reference.md#mode-specific). There's no source for shell completions at the moment, [contributions welcome](https://github.com/Saghen/blink.cmp/issues/1149)! 
 
 ## Using `nvim-cmp` sources
 

--- a/docs/configuration/sources.md
+++ b/docs/configuration/sources.md
@@ -56,7 +56,7 @@ sources.providers.lsp = {
 > [!NOTE]
 > Terminal completions are nightly only! Known bugs in v0.10. Cmdline completions are supported on all versions
 
-You may use `cmdline` and `term` sources via the `cmdline.sources.per_cmdtype` and `term.sources.default` tables. You may see the defaults in the [reference](./reference.md#mode-specific). There's no source for shell completions at the moment, [contributions welcome](https://github.com/Saghen/blink.cmp/issues/1149)! 
+You may use `cmdline` and `term` sources via the `cmdline.sources` and `term.sources` tables. You may see the defaults in the [reference](./reference.md#mode-specific). There's no source for shell completions at the moment, [contributions welcome](https://github.com/Saghen/blink.cmp/issues/1149)! 
 
 ## Using `nvim-cmp` sources
 

--- a/lua/blink/cmp/config/completion/documentation.lua
+++ b/lua/blink/cmp/config/completion/documentation.lua
@@ -3,7 +3,7 @@
 --- @field auto_show_delay_ms number Delay before showing the documentation window
 --- @field update_delay_ms number Delay before updating the documentation window when selecting a new item, while an existing item is still visible
 --- @field treesitter_highlighting boolean Whether to use treesitter highlighting, disable if you run into performance issues
---- @field draw fun(opts: blink.cmp.CompletionDocumentationDrawOpts): nil Renders the item in the documentation window, by default using an internal treessitter based implementation
+--- @field draw fun(opts: blink.cmp.CompletionDocumentationDrawOpts): nil Renders the item in the documentation window, by default using an internal treesitter based implementation
 --- @field window blink.cmp.CompletionDocumentationWindowConfig
 
 --- @class (exact) blink.cmp.CompletionDocumentationWindowConfig

--- a/lua/blink/cmp/config/completion/trigger.lua
+++ b/lua/blink/cmp/config/completion/trigger.lua
@@ -16,10 +16,7 @@ local trigger = {
     show_in_snippet = true,
     show_on_keyword = true,
     show_on_trigger_character = true,
-    show_on_blocked_trigger_characters = function()
-      if vim.api.nvim_get_mode().mode == 'c' then return {} end
-      return { ' ', '\n', '\t' }
-    end,
+    show_on_blocked_trigger_characters = { ' ', '\n', '\t' },
     show_on_accept_on_trigger_character = true,
     show_on_insert_on_trigger_character = true,
     show_on_x_blocked_trigger_characters = { "'", '"', '(', '{', '[' },

--- a/lua/blink/cmp/config/init.lua
+++ b/lua/blink/cmp/config/init.lua
@@ -7,6 +7,8 @@
 --- @field signature blink.cmp.SignatureConfig
 --- @field snippets blink.cmp.SnippetsConfig
 --- @field appearance blink.cmp.AppearanceConfig
+--- @field cmdline blink.cmp.CmdlineConfig
+--- @field term blink.cmp.TermConfig
 
 local validate = require('blink.cmp.config.utils').validate
 --- @type blink.cmp.ConfigStrict
@@ -19,6 +21,10 @@ local config = {
   signature = require('blink.cmp.config.signature').default,
   snippets = require('blink.cmp.config.snippets').default,
   appearance = require('blink.cmp.config.appearance').default,
+
+  -- mode specific configs
+  cmdline = require('blink.cmp.config.modes.cmdline').default,
+  term = require('blink.cmp.config.modes.term').default,
 }
 
 --- @type blink.cmp.ConfigStrict
@@ -36,7 +42,12 @@ function M.validate(cfg)
     signature = { cfg.signature, 'table' },
     snippets = { cfg.snippets, 'table' },
     appearance = { cfg.appearance, 'table' },
+
+    -- mode specific configs
+    cmdline = { cfg.cmdline, 'table' },
+    term = { cfg.term, 'table' },
   }, cfg)
+
   require('blink.cmp.config.keymap').validate(cfg.keymap)
   require('blink.cmp.config.completion').validate(cfg.completion)
   require('blink.cmp.config.fuzzy').validate(cfg.fuzzy)
@@ -44,12 +55,63 @@ function M.validate(cfg)
   require('blink.cmp.config.signature').validate(cfg.signature)
   require('blink.cmp.config.snippets').validate(cfg.snippets)
   require('blink.cmp.config.appearance').validate(cfg.appearance)
+
+  -- mode specific configs
+  require('blink.cmp.config.modes.cmdline').validate(cfg.cmdline)
+  require('blink.cmp.config.modes.term').validate(cfg.term)
+end
+
+--- @param cfg blink.cmp.ConfigStrict
+function M.apply_mode_specific(cfg)
+  local call_or_return = function(f, ...)
+    if type(f) == 'function' then return f(...) end
+    return f
+  end
+
+  local get_at_path = function(path)
+    local t = cfg
+    for _, p in ipairs(path) do
+      if t == nil then return end
+      t = t[p]
+    end
+    return t
+  end
+
+  local set_at_path = function(path, value)
+    local t = cfg
+    for i = 1, #path - 1 do
+      t = t[path[i]]
+    end
+    t[path[#path]] = value
+  end
+
+  --- @param path string[]
+  local apply_mode_specific_at_path = function(path)
+    local default = get_at_path(path)
+    local cmdline = get_at_path({ 'cmdline', unpack(path) })
+    local term = get_at_path({ 'term', unpack(path) })
+
+    if cmdline == nil and term == nil then return end
+
+    set_at_path(path, function(...)
+      local mode = vim.api.nvim_get_mode().mode
+      if mode == 'c' and cmdline ~= nil then return call_or_return(cmdline, ...) end
+      if mode == 't' and term ~= nil then return call_or_return(term, ...) end
+      return call_or_return(default, ...)
+    end)
+  end
+
+  apply_mode_specific_at_path({ 'completion', 'trigger', 'show_on_blocked_trigger_characters' })
+  apply_mode_specific_at_path({ 'completion', 'trigger', 'show_on_x_blocked_trigger_characters' })
+  apply_mode_specific_at_path({ 'completion', 'menu', 'auto_show' })
+  apply_mode_specific_at_path({ 'completion', 'menu', 'draw', 'columns' })
 end
 
 --- @param user_config blink.cmp.Config
 function M.merge_with(user_config)
   config = vim.tbl_deep_extend('force', config, user_config)
   M.validate(config)
+  M.apply_mode_specific(config)
 end
 
 return setmetatable(M, {

--- a/lua/blink/cmp/config/keymap.lua
+++ b/lua/blink/cmp/config/keymap.lua
@@ -120,13 +120,9 @@
 --- ```
 ---
 --- When defining your own keymaps without a preset, no keybinds will be assigned automatically.
---- @class (exact) blink.cmp.BaseKeymapConfig
+--- @class (exact) blink.cmp.KeymapConfig
 --- @field preset? blink.cmp.KeymapPreset
 --- @field [string] blink.cmp.KeymapCommand[] Table of keys => commands[]
-
---- @class (exact) blink.cmp.KeymapConfig : blink.cmp.BaseKeymapConfig
---- @field cmdline? blink.cmp.BaseKeymapConfig Optionally, define a separate keymap for cmdline
---- @field term? blink.cmp.BaseKeymapConfig Optionally, define a separate keymap for cmdline
 
 local keymap = {
   --- @type blink.cmp.KeymapConfig
@@ -162,12 +158,8 @@ function keymap.validate(config)
 
   local validation_schema = {}
   for key, value in pairs(config) do
-    -- nested cmdline/term keymap
-    if key == 'cmdline' or key == 'term' then
-      keymap.validate(value)
-
     -- preset
-    elseif key == 'preset' then
+    if key == 'preset' then
       validation_schema[key] = {
         value,
         function(preset) return vim.tbl_contains(presets, preset) end,

--- a/lua/blink/cmp/config/modes/cmdline.lua
+++ b/lua/blink/cmp/config/modes/cmdline.lua
@@ -1,0 +1,86 @@
+--- @class blink.cmp.CmdlineConfig : blink.cmp.ModeConfig
+--- @field sources blink.cmp.CmdlineSourceConfig
+
+--- @class blink.cmp.CmdlineSourceConfig
+--- @field per_cmdtype table<string, string[] | fun(): string[]>
+
+local validate = require('blink.cmp.config.utils').validate
+local cmdline = {
+  --- @type blink.cmp.CmdlineConfig
+  default = {
+    enabled = true,
+    sources = {
+      per_cmdtype = {
+        ['/'] = { 'buffer' },
+        ['?'] = { 'buffer' },
+        [':'] = { 'cmdline' },
+        ['@'] = { 'cmdline' },
+      },
+    },
+    completion = {
+      trigger = {
+        show_on_blocked_trigger_characters = {},
+      },
+      menu = {
+        draw = {
+          columns = { { 'label', 'label_description', gap = 1 } },
+        },
+      },
+    },
+  },
+}
+
+--- @param config blink.cmp.CmdlineConfig
+function cmdline.validate(config)
+  validate('cmdline', {
+    enabled = { config.enabled, 'boolean' },
+    keymap = { config.keymap, 'table', true },
+    sources = { config.sources, 'table' },
+    completion = { config.completion, 'table', true },
+  }, config)
+
+  if config.keymap ~= nil then require('blink.cmp.config.keymap').validate(config.keymap) end
+
+  if config.sources ~= nil then
+    validate('cmdline.sources', {
+      per_cmdtype = { config.sources.per_cmdtype, 'table' },
+    }, config.sources)
+  end
+
+  if config.completion ~= nil then
+    validate('cmdline.completion', {
+      trigger = { config.completion.trigger, 'table', true },
+      menu = { config.completion.menu, 'table', true },
+    }, config.completion)
+
+    if config.completion.trigger ~= nil then
+      validate('cmdline.completion.trigger', {
+        show_on_blocked_trigger_characters = {
+          config.completion.trigger.show_on_blocked_trigger_characters,
+          { 'function', 'table' },
+          true,
+        },
+        show_on_x_blocked_trigger_characters = {
+          config.completion.trigger.show_on_x_blocked_trigger_characters,
+          { 'function', 'table' },
+          true,
+        },
+      }, config.completion.trigger)
+    end
+
+    if config.completion.menu ~= nil then
+      validate('cmdline.completion.menu', {
+        auto_show = { config.completion.menu.auto_show, { 'boolean', 'function' }, true },
+        draw = { config.completion.menu.draw, 'table', true },
+      }, config.completion.menu)
+
+      if config.completion.menu.draw ~= nil then
+        validate('cmdline.completion.menu.draw', {
+          columns = { config.completion.menu.draw.columns, { 'function', 'table' }, true },
+        }, config.completion.menu.draw)
+      end
+    end
+  end
+end
+
+return cmdline

--- a/lua/blink/cmp/config/modes/term.lua
+++ b/lua/blink/cmp/config/modes/term.lua
@@ -1,0 +1,79 @@
+--- @class blink.cmp.TermConfig : blink.cmp.ModeConfig
+--- @field sources blink.cmp.TermSourceConfig
+
+--- @class blink.cmp.TermSourceConfig
+--- @field default table<string, string[] | fun(): string[]>
+
+local validate = require('blink.cmp.config.utils').validate
+local term = {
+  --- @type blink.cmp.TermConfig
+  default = {
+    enabled = false,
+    sources = { default = {} },
+    completion = {
+      trigger = {
+        show_on_blocked_trigger_characters = {},
+      },
+      menu = {
+        draw = {
+          columns = { { 'label', 'label_description', gap = 1 } },
+        },
+      },
+    },
+  },
+}
+
+--- @param config blink.cmp.TermConfig
+function term.validate(config)
+  validate('term', {
+    enabled = { config.enabled, 'boolean' },
+    keymap = { config.keymap, 'table', true },
+    sources = { config.sources, 'table' },
+    completion = { config.completion, 'table', true },
+  }, config)
+
+  if config.keymap ~= nil then require('blink.cmp.config.keymap').validate(config.keymap) end
+
+  if config.sources ~= nil then
+    validate('term.sources', {
+      default = { config.sources.default, 'table' },
+    }, config.sources)
+  end
+
+  if config.completion ~= nil then
+    validate('term.completion', {
+      trigger = { config.completion.trigger, 'table', true },
+      menu = { config.completion.menu, 'table', true },
+    }, config.completion)
+
+    if config.completion.trigger ~= nil then
+      validate('term.completion.trigger', {
+        show_on_blocked_trigger_characters = {
+          config.completion.trigger.show_on_blocked_trigger_characters,
+          { 'function', 'table' },
+          true,
+        },
+        show_on_x_blocked_trigger_characters = {
+          config.completion.trigger.show_on_x_blocked_trigger_characters,
+          { 'function', 'table' },
+          true,
+        },
+      }, config.completion.trigger)
+    end
+
+    if config.completion.menu ~= nil then
+      validate('term.completion.menu', {
+        auto_show = { config.completion.menu.auto_show, { 'boolean', 'function' }, true },
+        draw = { config.completion.menu.draw, 'table', true },
+      }, config.completion.menu)
+
+      if config.completion.menu.draw ~= nil then
+        validate('term.completion.menu.draw', {
+          columns = { config.completion.menu.draw.columns, { 'function', 'table' }, true },
+        }, config.completion.menu.draw)
+      end
+    end
+  end
+end
+
+return term

--- a/lua/blink/cmp/config/modes/term.lua
+++ b/lua/blink/cmp/config/modes/term.lua
@@ -1,15 +1,12 @@
 --- @class blink.cmp.TermConfig : blink.cmp.ModeConfig
---- @field sources blink.cmp.TermSourceConfig
-
---- @class blink.cmp.TermSourceConfig
---- @field default table<string, string[] | fun(): string[]>
+--- @field sources string[] | fun(): string[]
 
 local validate = require('blink.cmp.config.utils').validate
 local term = {
   --- @type blink.cmp.TermConfig
   default = {
     enabled = false,
-    sources = { default = {} },
+    sources = {},
     completion = {
       trigger = {
         show_on_blocked_trigger_characters = {},
@@ -28,17 +25,11 @@ function term.validate(config)
   validate('term', {
     enabled = { config.enabled, 'boolean' },
     keymap = { config.keymap, 'table', true },
-    sources = { config.sources, 'table' },
+    sources = { config.sources, { 'function', 'table' } },
     completion = { config.completion, 'table', true },
   }, config)
 
   if config.keymap ~= nil then require('blink.cmp.config.keymap').validate(config.keymap) end
-
-  if config.sources ~= nil then
-    validate('term.sources', {
-      default = { config.sources.default, 'table' },
-    }, config.sources)
-  end
 
   if config.completion ~= nil then
     validate('term.completion', {

--- a/lua/blink/cmp/config/modes/types.lua
+++ b/lua/blink/cmp/config/modes/types.lua
@@ -1,0 +1,19 @@
+--- @class blink.cmp.ModeConfig
+--- @field enabled? boolean
+--- @field keymap? blink.cmp.KeymapConfig
+--- @field completion? blink.cmp.ModeCompletionConfig
+
+--- @class blink.cmp.ModeCompletionConfig
+--- @field trigger? blink.cmp.ModeCompletionTriggerConfig
+--- @field menu? blink.cmp.ModeCompletionMenuConfig
+
+--- @class blink.cmp.ModeCompletionTriggerConfig
+--- @field show_on_blocked_trigger_characters? string[] | (fun(): string[]) LSPs can indicate when to show the completion window via trigger characters. However, some LSPs (i.e. tsserver) return characters that would essentially always show the window. We block these by default.
+--- @field show_on_x_blocked_trigger_characters? string[] | (fun(): string[]) List of trigger characters (on top of `show_on_blocked_trigger_characters`) that won't trigger the completion window when the cursor comes after a trigger character when entering insert mode/accepting an item
+
+--- @class blink.cmp.ModeCompletionMenuConfig
+--- @field auto_show? boolean | fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): boolean Whether to automatically show the window when new completion items are available
+--- @field draw? blink.cmp.ModeDraw Controls how the completion items are rendered on the popup window
+
+--- @class blink.cmp.ModeDraw
+--- @field columns? blink.cmp.DrawColumnDefinition[] | fun(context: blink.cmp.Context): blink.cmp.DrawColumnDefinition[] Components to render, grouped by column

--- a/lua/blink/cmp/config/sources.lua
+++ b/lua/blink/cmp/config/sources.lua
@@ -16,8 +16,6 @@
 --- ```
 --- @field default string[] | fun(): string[]
 --- @field per_filetype table<string, string[] | fun(): string[]>
---- @field cmdline string[] | fun(): string[]
---- @field term string[] | fun(): string[]
 ---
 --- @field transform_items fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): blink.cmp.CompletionItem[] Function to transform the items before they're returned
 --- @field min_keyword_length number | fun(ctx: blink.cmp.Context): number Minimum number of characters in the keyword to trigger
@@ -46,15 +44,6 @@ local sources = {
   default = {
     default = { 'lsp', 'path', 'snippets', 'buffer' },
     per_filetype = {},
-    cmdline = function()
-      local type = vim.fn.getcmdtype()
-      -- Search forward and backward
-      if type == '/' or type == '?' then return { 'buffer' } end
-      -- Commands
-      if type == ':' or type == '@' then return { 'cmdline' } end
-      return {}
-    end,
-    term = {},
 
     transform_items = function(_, items) return items end,
     min_keyword_length = 0,
@@ -123,8 +112,6 @@ function sources.validate(config)
   validate('sources', {
     default = { config.default, { 'function', 'table' } },
     per_filetype = { config.per_filetype, 'table' },
-    cmdline = { config.cmdline, { 'function', 'table' } },
-    term = { config.term, { 'function', 'table' } },
 
     transform_items = { config.transform_items, 'function' },
     min_keyword_length = { config.min_keyword_length, { 'number', 'function' } },

--- a/lua/blink/cmp/config/types_partial.lua
+++ b/lua/blink/cmp/config/types_partial.lua
@@ -7,6 +7,8 @@
 --- @field signature? blink.cmp.SignatureConfigPartial
 --- @field snippets? blink.cmp.SnippetsConfigPartial
 --- @field appearance? blink.cmp.AppearanceConfigPartial
+--- @field cmdline? blink.cmp.CmdlineConfigPartial
+--- @field term? blink.cmp.TermConfigPartial
 
 --- @class (exact) blink.cmp.CompletionConfigPartial : blink.cmp.CompletionConfig
 --- @field keyword? blink.cmp.CompletionKeywordConfigPartial
@@ -79,3 +81,13 @@
 --- @class (exact) blink.cmp.SnippetsConfigPartial : blink.cmp.SnippetsConfig, {}
 
 --- @class (exact) blink.cmp.AppearanceConfigPartial : blink.cmp.AppearanceConfig, {}
+
+--- @class (exact) blink.cmp.CmdlineConfigPartial : blink.cmp.CmdlineConfig, {}
+--- @field sources? blink.cmp.CmdlineSourceConfigPartial
+
+--- @class (exact) blink.cmp.CmdlineSourceConfigPartial : blink.cmp.CmdlineSourceConfig, {}
+
+--- @class (exact) blink.cmp.TermConfigPartial : blink.cmp.TermConfig, {}
+--- @field sources? blink.cmp.TermSourceConfigPartial
+
+--- @class (exact) blink.cmp.TermSourceConfigPartial : blink.cmp.TermSourceConfig, {}

--- a/lua/blink/cmp/config/utils.lua
+++ b/lua/blink/cmp/config/utils.lua
@@ -9,13 +9,14 @@ local utils = {}
 --- NOTE: We disable some Lua diagnostics here since lua_ls isn't smart enough to
 --- realize that we're using an overloaded function.
 function utils._validate(spec)
-  if vim.fn.has('nvim-0.11') == 0 then return vim.validate(spec) end
-  for key, key_spec in pairs(spec) do
-    local message = type(key_spec[3]) == 'string' and key_spec[3] or nil --[[@as string?]]
-    local optional = type(key_spec[3]) == 'boolean' and key_spec[3] or nil --[[@as boolean?]]
-    ---@diagnostic disable-next-line:param-type-mismatch, redundant-parameter
-    vim.validate(key, key_spec[1], key_spec[2], optional, message)
-  end
+  return vim.validate(spec)
+  -- if vim.fn.has('nvim-0.11') == 0 then return vim.validate(spec) end
+  -- for key, key_spec in pairs(spec) do
+  --   local message = type(key_spec[3]) == 'string' and key_spec[3] or nil --[[@as string?]]
+  --   local optional = type(key_spec[3]) == 'boolean' and key_spec[3] or nil --[[@as boolean?]]
+  --   ---@diagnostic disable-next-line:param-type-mismatch, redundant-parameter
+  --   vim.validate(key, key_spec[1], key_spec[2], optional, message)
+  -- end
 end
 
 --- @param path string The path to the field being validated
@@ -24,7 +25,7 @@ end
 --- @see vim.validate
 function utils.validate(path, tbl, source)
   -- validate
-  local _, err = pcall(utils._validate, tbl)
+  local _, err = pcall(vim.validate, tbl)
   if err then error(path .. '.' .. err) end
 
   -- check for erroneous fields

--- a/lua/blink/cmp/keymap/init.lua
+++ b/lua/blink/cmp/keymap/init.lua
@@ -26,7 +26,7 @@ function keymap.merge_mappings(existing_mappings, new_mappings)
   return merged_mappings
 end
 
----@param keymap_config blink.cmp.BaseKeymapConfig
+---@param keymap_config blink.cmp.KeymapConfig
 function keymap.get_mappings(keymap_config)
   local mappings = vim.deepcopy(keymap_config)
 
@@ -63,17 +63,15 @@ function keymap.setup()
     require('blink.cmp.keymap.apply').keymap_to_current_buffer(mappings)
   end
 
-  -- Apply cmdline keymaps since they're global, if any sources are defined
-  local cmdline_sources = require('blink.cmp.config').sources.cmdline
-  if type(cmdline_sources) ~= 'table' or #cmdline_sources > 0 then
-    local cmdline_mappings = keymap.get_mappings(config.keymap.cmdline or config.keymap)
+  -- Apply cmdline keymaps
+  if config.cmdline.enabled then
+    local cmdline_mappings = keymap.get_mappings(config.cmdline.keymap or config.keymap)
     require('blink.cmp.keymap.apply').cmdline_keymaps(cmdline_mappings)
   end
 
   -- Apply term keymaps
-  local term_sources = require('blink.cmp.config').sources.term
-  if type(term_sources) ~= 'table' or #term_sources > 0 then
-    local term_mappings = keymap.get_mappings(config.keymap.term or config.keymap)
+  if config.term.enabled then
+    local term_mappings = keymap.get_mappings(config.term.keymap or config.keymap)
     require('blink.cmp.keymap.apply').term_keymaps(term_mappings)
   end
 end

--- a/lua/blink/cmp/sources/lib/init.lua
+++ b/lua/blink/cmp/sources/lib/init.lua
@@ -50,8 +50,8 @@ function sources.get_all_providers()
 end
 
 function sources.get_enabled_provider_ids(mode)
-  local enabled_providers = mode == 'cmdline' and (config.cmdline.sources.per_cmdtype[vim.fn.getcmdtype()] or {})
-    or mode == 'term' and config.term.sources.default
+  local enabled_providers = mode == 'cmdline' and config.cmdline.sources
+    or mode == 'term' and config.term.sources
     or config.sources.per_filetype[vim.bo.filetype]
     or config.sources.default
 

--- a/lua/blink/cmp/sources/lib/init.lua
+++ b/lua/blink/cmp/sources/lib/init.lua
@@ -50,9 +50,11 @@ function sources.get_all_providers()
 end
 
 function sources.get_enabled_provider_ids(mode)
-  local enabled_providers = mode ~= 'default' and config.sources[mode]
+  local enabled_providers = mode == 'cmdline' and (config.cmdline.sources.per_cmdtype[vim.fn.getcmdtype()] or {})
+    or mode == 'term' and config.term.sources.default
     or config.sources.per_filetype[vim.bo.filetype]
     or config.sources.default
+
   if type(enabled_providers) == 'function' then return enabled_providers() end
   --- @cast enabled_providers string[]
   return enabled_providers


### PR DESCRIPTION
Moves the `cmdline` and `term` configs to a separate top level `cmdline = {}` and `term = {}`. This should be the last breaking change to the config before 1.0