### PR TITLE
docs(receipt): Don't accept suggestion if cursor previous char is whitespace

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -159,29 +159,6 @@ fuzzy = {
 }
 ```
 
-### Use `<Tab>` key for both accept suggestions and jump to next snippet placeholder
-
-You may want to use `<Tab>` key for both accept suggestions and jump to next snippet placeholder. And use `<S-Tab>` to jump to previous snippet placeholder. This is similar to the vscode's completion behavior.
-
-```lua
-keymap = {
-  -- Use <Tab> to accept if there are suggestions, or jump to next placeholder if already in an expanded snippet.
-  ["<Tab>"] = {
-    function(cmp)
-      if cmp.snippet_active() then
-        return cmp.accept()
-      else
-        return cmp.select_and_accept()
-      end
-    end,
-    "snippet_forward",
-    "fallback",
-  },
-  -- Use <S-Tab> to jump to previous placeholder if already in an expanded snippet.
-  ["<S-Tab>"] = { "snippet_backward", "fallback" },
-}
-```
-
 ### Don't accept suggestion if cursor previous char is whitespace
 
 When using `<Tab>` key for both accept suggestions and navigate to next snippet placeholder, you may want to only accept when cursor's previous char (on the left side) is a non-whitespace character, and fallback to a `tab` character if previous char is whtiespace.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -159,7 +159,30 @@ fuzzy = {
 }
 ```
 
-### Don't accept suggestion if cursor previous char is whitespace (similar to coc.nvim)
+### Use `<Tab>` key for both accept suggestions and jump to next snippet placeholder
+
+You may want to use `<Tab>` key for both accept suggestions and jump to next snippet placeholder. And use `<S-Tab>` to jump to previous snippet placeholder. This is similar to the vscode's completion behavior.
+
+```lua
+keymap = {
+  -- Use <Tab> to accept if there are suggestions, or jump to next placeholder if already in an expanded snippet.
+  ["<Tab>"] = {
+    function(cmp)
+      if cmp.snippet_active() then
+        return cmp.accept()
+      else
+        return cmp.select_and_accept()
+      end
+    end,
+    "snippet_forward",
+    "fallback",
+  },
+  -- Use <S-Tab> to jump to previous placeholder if already in an expanded snippet.
+  ["<S-Tab>"] = { "snippet_backward", "fallback" },
+}
+```
+
+### Don't accept suggestion if cursor previous char is whitespace
 
 When using `<Tab>` key for both accept suggestions and navigate to next snippet placeholder, you may want to only accept when cursor's previous char (on the left side) is a non-whitespace character, and fallback to a `tab` character if previous char is whtiespace.
 


### PR DESCRIPTION
This PR adds 1 receipt for configuring the `<Tab>` key in `keymap`.

### Don't accept suggestion if cursor previous char is whitespace

When using `<Tab>` key for both accept suggestions and navigate to next snippet placeholder, you may want to:

1. Accept the suggestion only when cursor's previous char (on the left side) is a non-whitespace character.
2. (Fallback) input a normal `tab` character if previous char is whitespace.

This is because there's an editing scenario, that user wants to keep pressing the `<Tab>` key and input continously `tab` chars. And for most other editing scenarios, user only input a few characters as prefix/hints, then let `blink.cmp` completes the rest part for user. For example, user input `re`, then `blink.cmp` give the whole `return` word as suggestion.

This is similar to the behavior in [coc.nvim example configuration](https://github.com/neoclide/coc.nvim?#example-vim-configuration), implemented by the `CheckBackspace` function.