### PR TITLE
feat: resolve tags lazily

### DIFF
--- a/lua/blink/cmp/sources/lib/init.lua
+++ b/lua/blink/cmp/sources/lib/init.lua
@@ -276,6 +276,7 @@ function sources.get_lsp_capabilities(override, include_nvim_defaults)
               'additionalTextEdits',
               'command',
               'data',
+              'tags',
               -- todo: support more properties? should test if it improves latency
             },
           },


### PR DESCRIPTION
added `tags` to `resolveSupport`, so that it can be lazily added through `completionItem/resolve`
