### PR TITLE
fix: check if mode-specific configs are enabled before adding sources

### DIFF
--- a/lua/blink/cmp/sources/lib/init.lua
+++ b/lua/blink/cmp/sources/lib/init.lua
@@ -50,6 +50,10 @@ function sources.get_all_providers()
 end
 
 function sources.get_enabled_provider_ids(mode)
+  if (mode == 'cmdline' and not config.cmdline.enabled) or (mode == 'term' and not config.term.enabled) then
+    return {}
+  end
+
   local enabled_providers = mode == 'cmdline' and config.cmdline.sources
     or mode == 'term' and config.term.sources
     or config.sources.per_filetype[vim.bo.filetype]


### PR DESCRIPTION
Fixes https://github.com/Saghen/blink.cmp/issues/1228