### PR TITLE
typo fix on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - Works out of the box with no additional configuration
 - Updates on every keystroke (0.5-4ms async, single core)
 - [Typo resistant fuzzy](https://github.com/saghen/frizbee) with frecency and proximity bonus
-- Extensive LSP support ([tracker](./docs/development/lsp-tracker.md))
+- Extensive LSP support ([tracker](./doc/development/lsp-tracker.md))
 - [Snippet support](https://cmp.saghen.dev/configuration/snippets.html): native `vim.snippet` (including `friendly-snippets`), `LuaSnip` and `mini.snippets`
 - External sources support ([community sources](https://cmp.saghen.dev/configuration/sources.html#community-sources) and [compatibility layer for `nvim-cmp` sources](https://github.com/saghen/blink.compat))
 - Auto-bracket support based on semantic tokens


### PR DESCRIPTION
lsp-tracker link had "docs" instead of "doc", leading to a 404 when clicking