### PR TITLE
feat: support ghost text with noice

### DIFF
--- a/doc/configuration/reference.md
+++ b/doc/configuration/reference.md
@@ -589,7 +589,8 @@ cmdline = {
       draw = {
         columns = { { 'label', 'label_description', gap = 1 } },
       },
-    }
+    },
+    ghost_text = { enabled = nil }
   }
 }
 ```
@@ -615,6 +616,7 @@ term = {
       draw = {
         columns = { { 'label', 'label_description', gap = 1 } },
       },
-    }
+    },
+    ghost_text = { enabled = nil }
   }
 }

--- a/lua/blink/cmp/completion/windows/ghost_text/init.lua
+++ b/lua/blink/cmp/completion/windows/ghost_text/init.lua
@@ -31,6 +31,11 @@ menu.close_emitter:on(function()
   ghost_text.draw_preview()
 end)
 
+function ghost_text.enabled()
+  if type(config.enabled) == 'function' then return config.enabled() end
+  return config.enabled
+end
+
 function ghost_text.is_open() return ghost_text.extmark_id ~= nil end
 
 --- Shows the ghost text preview and sets up the state to automatically
@@ -76,7 +81,7 @@ function ghost_text.draw_preview()
   -- check if we should be showing
   local menu_open = require('blink.cmp.completion.windows.menu').win:is_open()
   if
-    not config.enabled
+    not ghost_text.enabled()
     or (not config.show_with_menu and menu_open)
     or (not config.show_without_menu and not menu_open)
   then

--- a/lua/blink/cmp/completion/windows/ghost_text/utils.lua
+++ b/lua/blink/cmp/completion/windows/ghost_text/utils.lua
@@ -9,6 +9,10 @@ end
 function utils.is_cmdline() return vim.api.nvim_get_mode().mode == 'c' end
 function utils.is_noice() return utils.is_cmdline() and package.loaded['noice'] and vim.g.ui_cmdline_pos ~= nil end
 
+function utils.redraw_if_needed()
+  if utils.is_cmdline() then vim.api.nvim__redraw({ buf = utils.get_buf(), flush = true }) end
+end
+
 --- Gets the buffer to use for ghost text
 --- @return integer
 function utils.get_buf()

--- a/lua/blink/cmp/completion/windows/ghost_text/utils.lua
+++ b/lua/blink/cmp/completion/windows/ghost_text/utils.lua
@@ -1,0 +1,28 @@
+local utils = {}
+
+--- @param text_edit lsp.TextEdit
+function utils.get_still_untyped_text(text_edit)
+  local type_text_length = text_edit.range['end'].character - text_edit.range.start.character
+  return text_edit.newText:sub(type_text_length + 1)
+end
+
+function utils.is_cmdline() return vim.api.nvim_get_mode().mode == 'c' end
+function utils.is_noice() return utils.is_cmdline() and package.loaded['noice'] and vim.g.ui_cmdline_pos ~= nil end
+
+--- Gets the buffer to use for ghost text
+--- @return integer
+function utils.get_buf()
+  if vim.api.nvim_get_mode().mode == 'c' then return require('noice.ui.cmdline').position.buf end
+  return vim.api.nvim_get_current_buf()
+end
+
+--- Gets the offset from the cursor, primarily used for noice cmdline
+--- @return integer
+function utils.get_offset()
+  if vim.api.nvim_get_mode().mode == 'c' then
+    return require('noice.ui.cmdline').position.cursor - (vim.fn.getcmdpos() - 1)
+  end
+  return 0
+end
+
+return utils

--- a/lua/blink/cmp/config/completion/ghost_text.lua
+++ b/lua/blink/cmp/config/completion/ghost_text.lua
@@ -1,6 +1,6 @@
 --- Displays a preview of the selected item on the current line
 --- @class (exact) blink.cmp.CompletionGhostTextConfig
---- @field enabled boolean
+--- @field enabled boolean | fun(): boolean
 --- @field show_with_selection boolean Show the ghost text when an item has been selected
 --- @field show_without_selection boolean Show the ghost text when no item has been selected, defaulting to the first item
 --- @field show_with_menu boolean Show the ghost text when the menu is open
@@ -20,7 +20,7 @@ local ghost_text = {
 
 function ghost_text.validate(config)
   validate('completion.ghost_text', {
-    enabled = { config.enabled, 'boolean' },
+    enabled = { config.enabled, { 'boolean', 'function' } },
     show_with_selection = { config.show_with_selection, 'boolean' },
     show_without_selection = { config.show_without_selection, 'boolean' },
     show_without_menu = { config.show_without_menu, 'boolean' },

--- a/lua/blink/cmp/config/init.lua
+++ b/lua/blink/cmp/config/init.lua
@@ -105,6 +105,7 @@ function M.apply_mode_specific(cfg)
   apply_mode_specific_at_path({ 'completion', 'trigger', 'show_on_x_blocked_trigger_characters' })
   apply_mode_specific_at_path({ 'completion', 'menu', 'auto_show' })
   apply_mode_specific_at_path({ 'completion', 'menu', 'draw', 'columns' })
+  apply_mode_specific_at_path({ 'completion', 'ghost_text', 'enabled' })
 end
 
 --- @param user_config blink.cmp.Config

--- a/lua/blink/cmp/config/modes/cmdline.lua
+++ b/lua/blink/cmp/config/modes/cmdline.lua
@@ -37,6 +37,7 @@ function cmdline.validate(config)
     validate('cmdline.completion', {
       trigger = { config.completion.trigger, 'table', true },
       menu = { config.completion.menu, 'table', true },
+      ghost_text = { config.completion.ghost_text, 'table', true },
     }, config.completion)
 
     if config.completion.trigger ~= nil then
@@ -65,6 +66,12 @@ function cmdline.validate(config)
           columns = { config.completion.menu.draw.columns, { 'function', 'table' }, true },
         }, config.completion.menu.draw)
       end
+    end
+
+    if config.completion.ghost_text ~= nil then
+      validate('cmdline.completion.ghost_text', {
+        enabled = { config.completion.ghost_text.enabled, { 'boolean', 'function' }, true },
+      }, config.completion.ghost_text)
     end
   end
 end

--- a/lua/blink/cmp/config/modes/term.lua
+++ b/lua/blink/cmp/config/modes/term.lua
@@ -35,6 +35,7 @@ function term.validate(config)
     validate('term.completion', {
       trigger = { config.completion.trigger, 'table', true },
       menu = { config.completion.menu, 'table', true },
+      ghost_text = { config.completion.ghost_text, 'table', true },
     }, config.completion)
 
     if config.completion.trigger ~= nil then
@@ -63,6 +64,12 @@ function term.validate(config)
           columns = { config.completion.menu.draw.columns, { 'function', 'table' }, true },
         }, config.completion.menu.draw)
       end
+    end
+
+    if config.completion.ghost_text ~= nil then
+      validate('cmdline.completion.ghost_text', {
+        enabled = { config.completion.ghost_text.enabled, { 'boolean', 'function' }, true },
+      }, config.completion.ghost_text)
     end
   end
 end

--- a/lua/blink/cmp/config/modes/types.lua
+++ b/lua/blink/cmp/config/modes/types.lua
@@ -6,6 +6,7 @@
 --- @class blink.cmp.ModeCompletionConfig
 --- @field trigger? blink.cmp.ModeCompletionTriggerConfig
 --- @field menu? blink.cmp.ModeCompletionMenuConfig
+--- @field ghost_text? blink.cmp.ModeCompletionGhostTextConfig
 
 --- @class blink.cmp.ModeCompletionTriggerConfig
 --- @field show_on_blocked_trigger_characters? string[] | (fun(): string[]) LSPs can indicate when to show the completion window via trigger characters. However, some LSPs (i.e. tsserver) return characters that would essentially always show the window. We block these by default.
@@ -17,3 +18,6 @@
 
 --- @class blink.cmp.ModeDraw
 --- @field columns? blink.cmp.DrawColumnDefinition[] | fun(context: blink.cmp.Context): blink.cmp.DrawColumnDefinition[] Components to render, grouped by column
+
+--- @class blink.cmp.ModeCompletionGhostTextConfig
+--- @field enabled? boolean | fun(): boolean

--- a/lua/blink/cmp/lib/cmdline_events.lua
+++ b/lua/blink/cmp/lib/cmdline_events.lua
@@ -52,36 +52,51 @@ function cmdline_events:listen(opts)
   end)
 
   -- CursorMoved
-  local previous_cmdline = ''
-  vim.api.nvim_create_autocmd('CmdlineEnter', {
-    callback = function() previous_cmdline = '' end,
-  })
+  if vim.fn.has('nvim-0.11') == 1 then
+    vim.api.nvim_create_autocmd('CursorMovedC', {
+      callback = function()
+        if vim.api.nvim_get_mode().mode ~= 'c' then return end
+        if is_change_queued then return end
+
+        local is_ignored = self.ignore_next_cursor_moved
+        self.ignore_next_cursor_moved = false
+
+        opts.on_cursor_moved('CursorMoved', is_ignored)
+      end,
+    })
 
   -- TODO: switch to CursorMovedC when nvim 0.11 is released
   -- HACK: check every 16ms (60 times/second) to see if the cursor moved
   -- for neovim < 0.11
-  local timer = vim.uv.new_timer()
-  local previous_cursor
-  local callback
-  callback = vim.schedule_wrap(function()
+  else
+    local previous_cmdline = ''
+    vim.api.nvim_create_autocmd('CmdlineEnter', {
+      callback = function() previous_cmdline = '' end,
+    })
+
+    local timer = vim.uv.new_timer()
+    local previous_cursor
+    local callback
+    callback = vim.schedule_wrap(function()
+      timer:start(1, 0, callback)
+      if vim.api.nvim_get_mode().mode ~= 'c' then return end
+
+      local cmdline_equal = vim.fn.getcmdline() == previous_cmdline
+      local cursor_equal = vim.fn.getcmdpos() == previous_cursor
+
+      previous_cmdline = vim.fn.getcmdline()
+      previous_cursor = vim.fn.getcmdpos()
+
+      if cursor_equal or (not cmdline_equal and not did_backspace) then return end
+      did_backspace = false
+
+      local is_ignored = self.ignore_next_cursor_moved
+      self.ignore_next_cursor_moved = false
+
+      opts.on_cursor_moved('CursorMoved', is_ignored)
+    end)
     timer:start(16, 0, callback)
-    if vim.api.nvim_get_mode().mode ~= 'c' then return end
-
-    local cmdline_equal = vim.fn.getcmdline() == previous_cmdline
-    local cursor_equal = vim.fn.getcmdpos() == previous_cursor
-
-    previous_cmdline = vim.fn.getcmdline()
-    previous_cursor = vim.fn.getcmdpos()
-
-    if cursor_equal or (not cmdline_equal and not did_backspace) then return end
-    did_backspace = false
-
-    local is_ignored = self.ignore_next_cursor_moved
-    self.ignore_next_cursor_moved = false
-
-    opts.on_cursor_moved('CursorMoved', is_ignored)
-  end)
-  timer:start(16, 0, callback)
+  end
 
   vim.api.nvim_create_autocmd('CmdlineLeave', {
     callback = function() opts.on_leave() end,


### PR DESCRIPTION
Closes #939

@folke Curious on your thoughts on this, I've used an internal API (`require('noice.ui.cmdline').position`) but the result is quite promising! Perhaps this internal API could be made official? I've started using this with:

```lua
cmdline = {
  keymap = { 
    ['<Tab>'] = { 'accept' },
    ['<C-Space>'] = { 'show_and_insert' }
  },
  completion = {
    menu = { auto_show = false },
    ghost_text = { enabled = true },
  },
}
```

![image](https://github.com/user-attachments/assets/33265386-259e-426d-b91e-574c919d8726)
