### PR TITLE
docs(sources): add blink-cmp-conventional-commits to community sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+doc/tags
 target/
 .archive.lua
 _*.lua

--- a/doc/configuration/sources.md
+++ b/doc/configuration/sources.md
@@ -84,3 +84,4 @@ The command `:BlinkCmp status` can be used to view which sources providers are e
 - [blink-cmp-spell](https://github.com/ribru17/blink-cmp-spell.git)
 - [css-vars.nvim](https://github.com/jdrupal-dev/css-vars.nvim)
 - [blink-cmp-env](https://github.com/bydlw98/blink-cmp-env)
+- [blink-cmp-conventional-commits](disrupted/blink-cmp-conventional-commits)

--- a/doc/configuration/sources.md
+++ b/doc/configuration/sources.md
@@ -84,4 +84,4 @@ The command `:BlinkCmp status` can be used to view which sources providers are e
 - [blink-cmp-spell](https://github.com/ribru17/blink-cmp-spell.git)
 - [css-vars.nvim](https://github.com/jdrupal-dev/css-vars.nvim)
 - [blink-cmp-env](https://github.com/bydlw98/blink-cmp-env)
-- [blink-cmp-conventional-commits](disrupted/blink-cmp-conventional-commits)
+- [blink-cmp-conventional-commits](https://github.com/disrupted/blink-cmp-conventional-commits)


### PR DESCRIPTION
Made a tiny completion source for [Conventional Commits](https://www.conventionalcommits.org) types
