### PR TITLE
completion.ghost_text.enabled can be a function or boolean

### DIFF
--- a/lua/blink/cmp/completion/windows/ghost_text.lua
+++ b/lua/blink/cmp/completion/windows/ghost_text.lua
@@ -84,9 +84,15 @@ end
 
 function ghost_text.draw_preview()
   -- check if we should be showing
+  local enabled
+  if type(config.enabled) == "function" then
+    enabled = config.enabled("foo")
+  else
+    enabled = config.enabled
+  end
   local menu_open = require('blink.cmp.completion.windows.menu').win:is_open()
   if
-    not config.enabled
+    not enabled
     or (not config.show_with_menu and menu_open)
     or (not config.show_without_menu and not menu_open)
   then

--- a/lua/blink/cmp/completion/windows/ghost_text.lua
+++ b/lua/blink/cmp/completion/windows/ghost_text.lua
@@ -86,7 +86,7 @@ function ghost_text.draw_preview()
   -- check if we should be showing
   local enabled
   if type(config.enabled) == "function" then
-    enabled = config.enabled("foo")
+    enabled = config.enabled()
   else
     enabled = config.enabled
   end

--- a/lua/blink/cmp/config/completion/ghost_text.lua
+++ b/lua/blink/cmp/config/completion/ghost_text.lua
@@ -20,7 +20,7 @@ local ghost_text = {
 
 function ghost_text.validate(config)
   validate('completion.ghost_text', {
-    enabled = { config.enabled, 'boolean' },
+    enabled = { config.enabled, { 'boolean', 'function' } },
     show_with_selection = { config.show_with_selection, 'boolean' },
     show_without_selection = { config.show_without_selection, 'boolean' },
     show_without_menu = { config.show_without_menu, 'boolean' },


### PR DESCRIPTION
This allows to enable or disable the ghost text feature without changing the blink.cmp configuration. Similar to what can be done with `completion.menu.auto_show`.