### PR TITLE
feat!: set `BlinkCmpSource` highlight to `PmenuExtra`

### DIFF
--- a/lua/blink/cmp/highlights.lua
+++ b/lua/blink/cmp/highlights.lua
@@ -18,8 +18,8 @@ function highlights.setup()
   set_hl('BlinkCmpLabelDeprecated', { link = use_nvim_cmp and 'CmpItemAbbrDeprecated' or 'PmenuExtra' })
   set_hl('BlinkCmpLabelDetail', { link = use_nvim_cmp and 'CmpItemMenu' or 'PmenuExtra' })
   set_hl('BlinkCmpLabelDescription', { link = use_nvim_cmp and 'CmpItemMenu' or 'PmenuExtra' })
+  set_hl('BlinkCmpSource', { link = use_nvim_cmp and 'CmpItemMenu' or 'PmenuExtra' })
   set_hl('BlinkCmpKind', { link = use_nvim_cmp and 'CmpItemKind' or 'PmenuKind' })
-  set_hl('BlinkCmpSource', { link = use_nvim_cmp and 'CmpItemMenu' or 'NonText' })
   for _, kind in ipairs(require('blink.cmp.types').CompletionItemKind) do
     set_hl('BlinkCmpKind' .. kind, { link = use_nvim_cmp and 'CmpItemKind' .. kind or 'BlinkCmpKind' })
   end


### PR DESCRIPTION
The completion item source is extra metadata, the same as detail / description / deprecated, so it should use the same highlight for consistency.