### PR TITLE
fix: cmdline completion replace behavior when using `:=`

### DIFF
--- a/lua/blink/cmp/sources/cmdline/init.lua
+++ b/lua/blink/cmp/sources/cmdline/init.lua
@@ -25,6 +25,7 @@ function cmdline:get_completions(context, callback)
   local text_before_argument = table.concat(require('blink.cmp.lib.utils').slice(arguments, 1, arg_number - 1), ' ')
     .. (arg_number > 1 and ' ' or '')
 
+  local is_first_arg = arg_number == 1 and not vim.startswith(context.line, '=')
   local current_arg = arguments[arg_number]
   local keyword_config = require('blink.cmp.config').completion.keyword
   local keyword = context.get_bounds(keyword_config.range)
@@ -110,7 +111,6 @@ function cmdline:get_completions(context, callback)
 
       local completion_type = vim.fn.getcmdcompltype()
       local is_file_completion = completion_type == 'file' or completion_type == 'buffer'
-      local is_first_arg = arg_number == 1
 
       local items = {}
       for _, completion in ipairs(completions) do


### PR DESCRIPTION
cmdline completion treat every completion as the first argument when using `:=`. If we type `:=vim.api.` and accept the "nvim_create_autocmd" completion, the whole line would be "nvim_create_autocmd". This works just fine when using `:lua vim.api.` or add the optional space `:= vim.api.`.