### PR TITLE
fix(dot_repeat): move cursor for auto brackets only when `dot_repeat` is enabled

### DIFF
--- a/lua/blink/cmp/completion/accept/init.lua
+++ b/lua/blink/cmp/completion/accept/init.lua
@@ -88,7 +88,7 @@ local function accept(ctx, item, callback)
         text_edits_lib.apply(item.textEdit, all_text_edits)
 
         if ctx.get_mode() ~= 'term' then ctx.set_cursor(new_cursor) end
-        text_edits_lib.move_cursor_in_dot_repeat(offset)
+        if config.dot_repeat then text_edits_lib.move_cursor_in_dot_repeat(offset) end
       end
 
       -- Let the source execute the item itself


### PR DESCRIPTION
Hi, appreciate the work you've put into it! 🔥

There is a missing check for `config.dot_repeat` here.
It was causing some issues in my neovim configuration.