### PR TITLE
feat!: match built-in cmdline behavior by default

### DIFF
--- a/doc/.vitepress/config.mts
+++ b/doc/.vitepress/config.mts
@@ -39,6 +39,13 @@ export default defineConfig({
         ],
       },
       {
+        text: 'Modes',
+        items: [
+          { text: 'Cmdline', link: '/modes/cmdline' },
+          { text: 'Terminal', link: '/modes/term' },
+        ],
+      },
+      {
         text: 'Development',
         items: [
           { text: 'Architecture', link: '/development/architecture' },

--- a/doc/configuration/fuzzy.md
+++ b/doc/configuration/fuzzy.md
@@ -6,7 +6,7 @@ Blink uses a SIMD fuzzy matcher called [frizbee](https://github.com/saghen/frizb
 
 ### Prebuilt binaries (default on a release tag)
 
-By default, Blink will download a prebuilt binary from the latest release, when you're on a release tag (via `version = '*'` on `lazy.nvim` for example). If you're not on a release tag, you may force a specific version via `fuzzy.prebuilt_binaries.force_version`. See [the latest release](https://github.com/saghen/blink.cmp/releases/latest) for supported systems. See `prebuilt_binaries` section of the [reference configuration](./reference.md#prebuilt-binaries) for more options.
+By default, Blink will download a prebuilt binary from the latest release, when you're on a release tag (via `version = '*'` on `lazy.nvim` for example). If you're not on a release tag, you may force a specific version via `fuzzy.prebuilt_binaries.force_version`. See [the latest release](https://github.com/saghen/blink.cmp/releases/latest) for supported systems. See `prebuilt_binaries` section of the [reference configuration](./reference.md#fuzzy) for more options.
 
 You may instead install the prebuilt binaries manually by downloading the appropriate binary from the [latest release](https://github.com/saghen/blink.cmp/releases/latest) and placing it at `$data/lazy/blink.cmp/target/release/libblink_cmp_fuzzy.$ext`. Get the `$data` path via `:echo stdpath('data')`. Use `.so` for linux, `.dylib` for mac, and `.dll` for windows. If you're unsure whether you want `-musl` or `-gnu` for linux, you very likely want `-gnu`.
 
@@ -24,6 +24,8 @@ You may instead install the prebuilt binaries manually by downloading the approp
 ### Build from source (recommended for `main`)
 
 When on `main`, it's highly recommended to build from source via `cargo build --release` (via `build = '...'` on `lazy.nvim` for example). This requires a nightly rust toolchain, which will be automatically downloaded when using `rustup`.
+
+You may also build with nix via `nix run .#build-plugin`.
 
 ## Configuration
 

--- a/doc/configuration/keymap.md
+++ b/doc/configuration/keymap.md
@@ -159,3 +159,7 @@ You may want to set `completion.list.selection.preselect = false`. See more info
 
 ['<C-k>'] = { 'show_signature', 'hide_signature', 'fallback' },
 ```
+
+### `cmdline`
+
+See the [cmdline documentation](../modes/cmdline.md)

--- a/doc/configuration/reference.md
+++ b/doc/configuration/reference.md
@@ -570,7 +570,7 @@ You may set configurations which will override the default configuration, specif
 ```lua
 cmdline = {
   enabled = true,
-  keymap = nil, -- Inherits from top level `keymap` config when not set
+  keymap = { preset = 'cmdline' },
   sources = function()
     local type = vim.fn.getcmdtype()
     -- Search forward and backward
@@ -582,15 +582,20 @@ cmdline = {
   completion = {
     trigger = {
       show_on_blocked_trigger_characters = {},
-      show_on_x_blocked_trigger_characters = nil, -- Inherits from top level `completion.trigger.show_on_blocked_trigger_characters` config when not set
+      show_on_x_blocked_trigger_characters = {},
     },
-    menu = {
-      auto_show = nil, -- Inherits from top level `completion.menu.auto_show` config when not set
-      draw = {
-        columns = { { 'label', 'label_description', gap = 1 } },
+    list = {
+      selection = {
+        -- When `true`, will automatically select the first item in the completion list
+        preselect = true,
+        -- When `true`, inserts the completion item automatically when selecting it
+        auto_insert = true,
       },
     },
-    ghost_text = { enabled = nil }
+    -- Whether to automatically show the window when new completion items are available
+    menu = { auto_show = false },
+    -- Displays a preview of the selected item on the current line
+    ghost_text = { enabled = true }
   }
 }
 ```
@@ -611,12 +616,18 @@ term = {
       show_on_blocked_trigger_characters = {},
       show_on_x_blocked_trigger_characters = nil, -- Inherits from top level `completion.trigger.show_on_blocked_trigger_characters` config when not set
     },
-    menu = {
-      auto_show = nil, -- Inherits from top level `completion.menu.auto_show` config when not set
-      draw = {
-        columns = { { 'label', 'label_description', gap = 1 } },
+    -- Inherits from top level config options when not set
+    list = {
+      selection = {
+        -- When `true`, will automatically select the first item in the completion list
+        preselect = nil,
+        -- When `true`, inserts the completion item automatically when selecting it
+        auto_insert = nil,
       },
     },
+    -- Whether to automatically show the window when new completion items are available
+    menu = { auto_show = nil },
+    -- Displays a preview of the selected item on the current line
     ghost_text = { enabled = nil }
   }
 }

--- a/doc/modes/cmdline.md
+++ b/doc/modes/cmdline.md
@@ -1,0 +1,108 @@
+# Command line (cmdline)
+
+By default, blink.cmp matches the behavior of the built-in `cmdline` completion:
+
+- Menu will not show automatically (`cmdline.completion.menu.auto_show = false`)
+- Pressing `<Tab>` will show the completion menu and insert the first item
+  - Subsequent presses will select the next item, `<S-Tab>` for previous item.
+- `<C-n>` and `<C-p>` will select the next and previous item respectively
+- `<C-y>` accepts the current item, `<C-e>` cancels the completion
+- When [noice.nvim](https://github.com/folke/noice.nvim) is detected, ghost text will be shown, see the [ghost text](#ghost-text) section below
+
+See the [reference configuration](../configuration/reference.md#cmdline) for the complete list of options.
+
+## Keymap preset
+
+Set via `cmdline.keymap.preset = 'cmdline'`, which is the default.
+
+```lua
+{
+  ['<Tab>'] = {
+    function(cmp)
+      if cmp.is_ghost_text_visible() and not cmp.is_menu_visible() then return cmp.accept() end
+    end,
+    'show_and_insert',
+    'select_next',
+  },
+  ['<S-Tab>'] = { 'show_and_insert', 'select_prev' },
+
+  ['<C-n>'] = { 'select_next' },
+  ['<C-p>'] = { 'select_prev' },
+
+  ['<C-y>'] = { 'select_and_accept' },
+  ['<C-e>'] = { 'cancel' },
+}
+```
+
+
+## Ghost text
+
+When [noice.nvim](https://github.com/folke/noice.nvim) is detected, ghost text will be shown, likely similar to your terminal shell completions. Pressing `<Tab>` while ghost text is visible will accept the completion. When not visible, `<Tab>` will open the menu and insert the first item as per usual.
+
+<img src="https://github.com/user-attachments/assets/b2fa6f41-4937-47bf-86b3-d82e9ec86b12">
+
+```lua
+cmdline = { completion = { ghost_text = { enabled = true } } }
+```
+
+## Show menu automatically
+
+By default, the completion menu will not be shown automatically. You may set `cmdline.completion.menu.auto_show = true` to have it appear automatically.
+
+```lua
+cmdline = {
+  keymap = {
+    -- recommended, as the default keymap will only show and select the next item
+    ['<Tab>'] = { 'show', 'accept' },
+  },
+  completion = { menu = { auto_show = true } },
+}
+```
+
+However, you may want to only show the menu only when writing commands, and not when searching or using other input menus.
+
+```lua
+cmdline = {
+  keymap = {
+    -- recommended, as the default keymap will only show and select the next item
+    ['<Tab>'] = { 'show', 'accept' },
+  },
+  completion = {
+    menu = {
+      auto_show = function(ctx)
+        return vim.fn.getcmdtype() == ':'
+        -- enable for inputs as well, with:
+        -- or vim.fn.getcmdtype() == '@'
+      end,
+    },
+  }
+}
+```
+
+## Enter keymap
+
+When using `<Enter>` (`<CR>`) to accept the current item, you may want to immediately execute the command as well. However, this results in awkward behavior when running abbreviations like `:wq`. You may disable the completions when the keyword, for the argument, is less than 2 characters.
+
+```lua
+cmdline = {
+  keymap = {
+    -- (optionally) disable built-in keymaps
+    -- preset = 'none',
+
+    ['<CR>'] = { 'accept_and_enter', 'fallback' },
+  },
+  -- (optionally) automatically show the menu
+  completion = { menu = { auto_show = true } }
+},
+sources = {
+  providers = {
+    cmdline = {
+      min_keyword_length = function(ctx)
+        -- only apply when typing a command, don't apply to arguments
+        if ctx.mode == 'cmdline' and string.find(ctx.line, ' ') == nil then return 2 end
+        return 0
+      end
+    }
+  }
+}
+```

--- a/doc/modes/term.md
+++ b/doc/modes/term.md
@@ -1,0 +1,5 @@
+# Terminal (term)
+
+See the [reference configuration](../configuration/reference.md#term) for the complete list of options.
+
+TODO

--- a/doc/recipes.md
+++ b/doc/recipes.md
@@ -299,20 +299,6 @@ sources.min_keyword_length = function()
 end
 ```
 
-### Set minimum keyword length for command only in cmdline
-
-If you'd prefer the menu doesn't popup when typing abbreviations like `wq`, you may set the minimum keyword length to 2 when typing the command.
-
-```lua
-sources = {
-  min_keyword_length = function(ctx)
-    -- only applies when typing a command, doesn't apply to arguments
-    if ctx.mode == 'cmdline' and string.find(ctx.line, ' ') == nil then return 2 end
-    return 0
-  end
-}
-```
-
 ### Path completion from `cwd` instead of current buffer's directory
 
 It's common to run code from the root of your repository, in which case relative paths will start from that directory. In that case, you may want path completions to be relative to your current working directory rather than the default, which is the current buffer's parent directory.

--- a/lua/blink/cmp/config/init.lua
+++ b/lua/blink/cmp/config/init.lua
@@ -103,6 +103,8 @@ function M.apply_mode_specific(cfg)
 
   apply_mode_specific_at_path({ 'completion', 'trigger', 'show_on_blocked_trigger_characters' })
   apply_mode_specific_at_path({ 'completion', 'trigger', 'show_on_x_blocked_trigger_characters' })
+  apply_mode_specific_at_path({ 'completion', 'list', 'selection', 'preselect' })
+  apply_mode_specific_at_path({ 'completion', 'list', 'selection', 'auto_insert' })
   apply_mode_specific_at_path({ 'completion', 'menu', 'auto_show' })
   apply_mode_specific_at_path({ 'completion', 'menu', 'draw', 'columns' })
   apply_mode_specific_at_path({ 'completion', 'ghost_text', 'enabled' })

--- a/lua/blink/cmp/config/keymap.lua
+++ b/lua/blink/cmp/config/keymap.lua
@@ -42,8 +42,29 @@
 ---
 ---   ['<C-k>'] = { 'show_signature', 'hide_signature', 'fallback' },
 --- }
+---
 --- ```
 --- | 'default'
+--- Mappings similar to the built-in completion in cmdline mode:
+--- ```lua
+--- {
+---   ['<Tab>'] = {
+---     function(cmp)
+---       if cmp.is_ghost_text_visible() and not cmp.is_menu_visible() then return cmp.accept() end
+---     end,
+---     'show_and_insert',
+---     'select_next',
+---   },
+---   ['<S-Tab>'] = { 'show_and_insert', 'select_prev' },
+---
+---   ['<C-n>'] = { 'select_next' },
+---   ['<C-p>'] = { 'select_prev' },
+---
+---   ['<C-y>'] = { 'select_and_accept' },
+---   ['<C-e>'] = { 'cancel' },
+--- }
+--- ```
+--- | 'cmdline'
 --- Mappings similar to VSCode.
 --- You may want to set `completion.trigger.show_in_snippet = false` or use `completion.list.selection.preselect = function(ctx) return not require('blink.cmp').snippet_active({ direction = 1 }) end` when using this mapping:
 --- ```lua
@@ -162,7 +183,7 @@ function keymap.validate(config)
     'snippet_forward',
     'snippet_backward',
   }
-  local presets = { 'default', 'super-tab', 'enter', 'none' }
+  local presets = { 'default', 'cmdline', 'super-tab', 'enter', 'none' }
 
   local validation_schema = {}
   for key, value in pairs(config) do

--- a/lua/blink/cmp/config/modes/cmdline.lua
+++ b/lua/blink/cmp/config/modes/cmdline.lua
@@ -1,11 +1,10 @@
 --- @class blink.cmp.CmdlineConfig : blink.cmp.ModeConfig
---- @field sources string[] | fun(): string[]
 
-local validate = require('blink.cmp.config.utils').validate
 local cmdline = {
   --- @type blink.cmp.CmdlineConfig
   default = {
     enabled = true,
+    keymap = { preset = 'cmdline' },
     sources = function()
       local type = vim.fn.getcmdtype()
       -- Search forward and backward
@@ -15,65 +14,15 @@ local cmdline = {
       return {}
     end,
     completion = {
-      trigger = {
-        show_on_blocked_trigger_characters = {},
-      },
+      trigger = { show_on_blocked_trigger_characters = {}, show_on_x_blocked_trigger_characters = {} },
+      list = { selection = { preselect = true, auto_insert = true } },
+      menu = { auto_show = false },
+      ghost_text = { enabled = true },
     },
   },
 }
 
 --- @param config blink.cmp.CmdlineConfig
-function cmdline.validate(config)
-  validate('cmdline', {
-    enabled = { config.enabled, 'boolean' },
-    keymap = { config.keymap, 'table', true },
-    sources = { config.sources, { 'function', 'table' } },
-    completion = { config.completion, 'table', true },
-  }, config)
-
-  if config.keymap ~= nil then require('blink.cmp.config.keymap').validate(config.keymap) end
-
-  if config.completion ~= nil then
-    validate('cmdline.completion', {
-      trigger = { config.completion.trigger, 'table', true },
-      menu = { config.completion.menu, 'table', true },
-      ghost_text = { config.completion.ghost_text, 'table', true },
-    }, config.completion)
-
-    if config.completion.trigger ~= nil then
-      validate('cmdline.completion.trigger', {
-        show_on_blocked_trigger_characters = {
-          config.completion.trigger.show_on_blocked_trigger_characters,
-          { 'function', 'table' },
-          true,
-        },
-        show_on_x_blocked_trigger_characters = {
-          config.completion.trigger.show_on_x_blocked_trigger_characters,
-          { 'function', 'table' },
-          true,
-        },
-      }, config.completion.trigger)
-    end
-
-    if config.completion.menu ~= nil then
-      validate('cmdline.completion.menu', {
-        auto_show = { config.completion.menu.auto_show, { 'boolean', 'function' }, true },
-        draw = { config.completion.menu.draw, 'table', true },
-      }, config.completion.menu)
-
-      if config.completion.menu.draw ~= nil then
-        validate('cmdline.completion.menu.draw', {
-          columns = { config.completion.menu.draw.columns, { 'function', 'table' }, true },
-        }, config.completion.menu.draw)
-      end
-    end
-
-    if config.completion.ghost_text ~= nil then
-      validate('cmdline.completion.ghost_text', {
-        enabled = { config.completion.ghost_text.enabled, { 'boolean', 'function' }, true },
-      }, config.completion.ghost_text)
-    end
-  end
-end
+function cmdline.validate(config) require('blink.cmp.config.modes.types').validate('cmdline', config) end
 
 return cmdline

--- a/lua/blink/cmp/config/modes/term.lua
+++ b/lua/blink/cmp/config/modes/term.lua
@@ -1,7 +1,5 @@
 --- @class blink.cmp.TermConfig : blink.cmp.ModeConfig
---- @field sources string[] | fun(): string[]
 
-local validate = require('blink.cmp.config.utils').validate
 local term = {
   --- @type blink.cmp.TermConfig
   default = {
@@ -21,57 +19,6 @@ local term = {
 }
 
 --- @param config blink.cmp.TermConfig
-function term.validate(config)
-  validate('term', {
-    enabled = { config.enabled, 'boolean' },
-    keymap = { config.keymap, 'table', true },
-    sources = { config.sources, { 'function', 'table' } },
-    completion = { config.completion, 'table', true },
-  }, config)
-
-  if config.keymap ~= nil then require('blink.cmp.config.keymap').validate(config.keymap) end
-
-  if config.completion ~= nil then
-    validate('term.completion', {
-      trigger = { config.completion.trigger, 'table', true },
-      menu = { config.completion.menu, 'table', true },
-      ghost_text = { config.completion.ghost_text, 'table', true },
-    }, config.completion)
-
-    if config.completion.trigger ~= nil then
-      validate('term.completion.trigger', {
-        show_on_blocked_trigger_characters = {
-          config.completion.trigger.show_on_blocked_trigger_characters,
-          { 'function', 'table' },
-          true,
-        },
-        show_on_x_blocked_trigger_characters = {
-          config.completion.trigger.show_on_x_blocked_trigger_characters,
-          { 'function', 'table' },
-          true,
-        },
-      }, config.completion.trigger)
-    end
-
-    if config.completion.menu ~= nil then
-      validate('term.completion.menu', {
-        auto_show = { config.completion.menu.auto_show, { 'boolean', 'function' }, true },
-        draw = { config.completion.menu.draw, 'table', true },
-      }, config.completion.menu)
-
-      if config.completion.menu.draw ~= nil then
-        validate('term.completion.menu.draw', {
-          columns = { config.completion.menu.draw.columns, { 'function', 'table' }, true },
-        }, config.completion.menu.draw)
-      end
-    end
-
-    if config.completion.ghost_text ~= nil then
-      validate('cmdline.completion.ghost_text', {
-        enabled = { config.completion.ghost_text.enabled, { 'boolean', 'function' }, true },
-      }, config.completion.ghost_text)
-    end
-  end
-end
+function term.validate(config) require('blink.cmp.config.modes.types').validate('term', config) end
 
 return term

--- a/lua/blink/cmp/config/modes/types.lua
+++ b/lua/blink/cmp/config/modes/types.lua
@@ -1,12 +1,21 @@
 --- @class blink.cmp.ModeConfig
 --- @field enabled? boolean
 --- @field keymap? blink.cmp.KeymapConfig
+--- @field sources string[] | fun(): string[]
 --- @field completion? blink.cmp.ModeCompletionConfig
 
 --- @class blink.cmp.ModeCompletionConfig
 --- @field trigger? blink.cmp.ModeCompletionTriggerConfig
+--- @field list? blink.cmp.ModeCompletionListConfig
 --- @field menu? blink.cmp.ModeCompletionMenuConfig
 --- @field ghost_text? blink.cmp.ModeCompletionGhostTextConfig
+
+--- @class blink.cmp.ModeCompletionListConfig
+--- @field selection? blink.cmp.ModeCompletionListSelectionConfig
+
+--- @class blink.cmp.ModeCompletionListSelectionConfig
+--- @field preselect? boolean | fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): boolean Whether to preselect the first item when the list is shown
+--- @field auto_insert? boolean | fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): boolean When `true`, inserts the completion item automatically when selecting it
 
 --- @class blink.cmp.ModeCompletionTriggerConfig
 --- @field show_on_blocked_trigger_characters? string[] | (fun(): string[]) LSPs can indicate when to show the completion window via trigger characters. However, some LSPs (i.e. tsserver) return characters that would essentially always show the window. We block these by default.
@@ -21,3 +30,76 @@
 
 --- @class blink.cmp.ModeCompletionGhostTextConfig
 --- @field enabled? boolean | fun(): boolean
+
+local validate = require('blink.cmp.config.utils').validate
+local mode = {}
+
+--- @param config blink.cmp.ModeConfig
+function mode.validate(prefix, config)
+  validate(prefix, {
+    enabled = { config.enabled, 'boolean' },
+    keymap = { config.keymap, 'table', true },
+    sources = { config.sources, { 'function', 'table' } },
+    completion = { config.completion, 'table', true },
+  }, config)
+
+  if config.keymap ~= nil then require('blink.cmp.config.keymap').validate(config.keymap) end
+
+  if config.completion ~= nil then
+    validate(prefix .. '.completion', {
+      trigger = { config.completion.trigger, 'table', true },
+      list = { config.completion.list, 'table', true },
+      menu = { config.completion.menu, 'table', true },
+      ghost_text = { config.completion.ghost_text, 'table', true },
+    }, config.completion)
+
+    if config.completion.trigger ~= nil then
+      validate(prefix .. '.completion.trigger', {
+        show_on_blocked_trigger_characters = {
+          config.completion.trigger.show_on_blocked_trigger_characters,
+          { 'function', 'table' },
+          true,
+        },
+        show_on_x_blocked_trigger_characters = {
+          config.completion.trigger.show_on_x_blocked_trigger_characters,
+          { 'function', 'table' },
+          true,
+        },
+      }, config.completion.trigger)
+    end
+
+    if config.completion.list ~= nil then
+      validate(prefix .. '.completion.list', {
+        selection = { config.completion.list.selection, 'table', true },
+      }, config.completion.list)
+
+      if config.completion.list.selection ~= nil then
+        validate(prefix .. '.completion.list.selection', {
+          preselect = { config.completion.list.selection.preselect, { 'boolean', 'function' }, true },
+          auto_insert = { config.completion.list.selection.auto_insert, { 'boolean', 'function' }, true },
+        }, config.completion.list.selection)
+      end
+    end
+
+    if config.completion.menu ~= nil then
+      validate(prefix .. '.completion.menu', {
+        auto_show = { config.completion.menu.auto_show, { 'boolean', 'function' }, true },
+        draw = { config.completion.menu.draw, 'table', true },
+      }, config.completion.menu)
+
+      if config.completion.menu.draw ~= nil then
+        validate(prefix .. '.completion.menu.draw', {
+          columns = { config.completion.menu.draw.columns, { 'function', 'table' }, true },
+        }, config.completion.menu.draw)
+      end
+    end
+
+    if config.completion.ghost_text ~= nil then
+      validate(prefix .. '.completion.ghost_text', {
+        enabled = { config.completion.ghost_text.enabled, { 'boolean', 'function' }, true },
+      }, config.completion.ghost_text)
+    end
+  end
+end
+
+return mode

--- a/lua/blink/cmp/keymap/presets.lua
+++ b/lua/blink/cmp/keymap/presets.lua
@@ -1,3 +1,4 @@
+--- @type table<string, table<string, blink.cmp.KeymapCommand[]>>
 local presets = {
   none = {},
 
@@ -18,6 +19,23 @@ local presets = {
     ['<S-Tab>'] = { 'snippet_backward', 'fallback' },
 
     ['<C-k>'] = { 'show_signature', 'hide_signature', 'fallback' },
+  },
+
+  cmdline = {
+    ['<Tab>'] = {
+      function(cmp)
+        if cmp.is_ghost_text_visible() and not cmp.is_menu_visible() then return cmp.accept() end
+      end,
+      'show_and_insert',
+      'select_next',
+    },
+    ['<S-Tab>'] = { 'show_and_insert', 'select_prev' },
+
+    ['<C-n>'] = { 'select_next' },
+    ['<C-p>'] = { 'select_prev' },
+
+    ['<C-y>'] = { 'select_and_accept' },
+    ['<C-e>'] = { 'cancel' },
   },
 
   ['super-tab'] = {


### PR DESCRIPTION
Reworks the default configuration for cmdline to match the built-in neovim behavior, and adds documentation for common configurations.