### PR TITLE
feat(sources): allow setting kind_name and kind_icon in provider config

### DIFF
--- a/lua/blink/cmp/completion/windows/render/context.lua
+++ b/lua/blink/cmp/completion/windows/render/context.lua
@@ -37,6 +37,7 @@ end
 
 local config = require('blink.cmp.config').appearance
 local kinds = require('blink.cmp.types').CompletionItemKind
+local get_provider_by_id = require('blink.cmp.sources.lib').get_provider_by_id
 
 --- @param draw blink.cmp.Draw
 --- @param item_idx number
@@ -44,8 +45,9 @@ local kinds = require('blink.cmp.types').CompletionItemKind
 --- @param matched_indices number[]
 --- @return blink.cmp.DrawItemContext
 function draw_context.new(draw, item_idx, item, matched_indices)
-  local kind = item.kind_name or kinds[item.kind] or 'Unknown'
-  local kind_icon = item.kind_icon or config.kind_icons[kind] or config.kind_icons.Field
+  local provider = get_provider_by_id(item.source_id).config
+  local kind = item.kind_name or provider.kind_name or kinds[item.kind] or 'Unknown'
+  local kind_icon = item.kind_icon or provider.kind_icon or config.kind_icons[kind] or config.kind_icons.Field
   local kind_hl = item.kind_hl or ('BlinkCmpKind' .. (kinds[item.kind] or 'Unknown'))
 
   local icon_spacing = config.nerd_font_variant == 'mono' and '' or ' '

--- a/lua/blink/cmp/config/sources.lua
+++ b/lua/blink/cmp/config/sources.lua
@@ -29,6 +29,8 @@
 --- @field opts? table
 --- @field async? boolean | fun(ctx: blink.cmp.Context): boolean Whether blink should wait for the source to return before showing the completions
 --- @field timeout_ms? number | fun(ctx: blink.cmp.Context): number How long to wait for the provider to return before showing completions and treating it as asynchronous
+--- @field kind_name? string Kind name to apply to returned items
+--- @field kind_icon? string Kind icon to apply to returned items
 --- @field transform_items? fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): blink.cmp.CompletionItem[] Function to transform the items before they're returned
 --- @field should_show_items? boolean | fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): boolean Whether or not to show the items
 --- @field max_items? number | fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): number Maximum number of items to display in the menu
@@ -131,6 +133,8 @@ function sources.validate_provider(id, provider)
     opts = { provider.opts, 'table', true },
     async = { provider.async, { 'boolean', 'function' }, true },
     timeout_ms = { provider.timeout_ms, { 'number', 'function' }, true },
+    kind_name = { provider.kind_name, 'string', true },
+    kind_icon = { provider.kind_icon, 'string', true },
     transform_items = { provider.transform_items, 'function', true },
     should_show_items = { provider.should_show_items, { 'boolean', 'function' }, true },
     max_items = { provider.max_items, { 'number', 'function' }, true },

--- a/lua/blink/cmp/sources/lib/provider/config.lua
+++ b/lua/blink/cmp/sources/lib/provider/config.lua
@@ -6,6 +6,8 @@
 --- @field enabled fun(): boolean
 --- @field async fun(ctx: blink.cmp.Context): boolean
 --- @field timeout_ms fun(ctx: blink.cmp.Context): number
+--- @field kind_name? string
+--- @field kind_icon? string
 --- @field transform_items fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): blink.cmp.CompletionItem[]
 --- @field should_show_items fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): boolean
 --- @field max_items? fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): number
@@ -34,6 +36,8 @@ function wrapper.new(config)
   self.enabled = call_or_get(config.enabled, true)
   self.async = call_or_get(config.async, false)
   self.timeout_ms = call_or_get(config.timeout_ms, 2000)
+  self.kind_name = config.kind_name
+  self.kind_icon = config.kind_icon
   self.transform_items = config.transform_items or function(_, items) return items end
   self.should_show_items = call_or_get(config.should_show_items, true)
   self.max_items = call_or_get(config.max_items, nil)


### PR DESCRIPTION
Setting the kind_name and kind_icon on every item requires overriding the transform_items function, which can get tedious. Oftenly, custom sources provide only one item kind (e.g., blink-copilot, blink-emoji, blink-cmp-env, blink-ripgrep, css-vars.nvim, blink-cmp-spell).

Allow providers to specify a default kind_name and kind_icon to apply to all of its returned items. These should have lower priority than the kind_name and kind_icon set explicitly on returned items, but higher priority than globals (e.g., appearance.kind_icons). This allows providers to set finer-grained kind_name or kind_icon on an item-by-item basis, but also simplifies logic for providers with only one kind.

NOTE: I tested the changes locally and it seems to work.