### PR TITLE
feat!: allow creating generic sources for `complete-functions`

### DIFF
--- a/doc/blink-cmp.txt
+++ b/doc/blink-cmp.txt
@@ -1,4 +1,4 @@
-*blink-cmp.txt*         For NVIM v0.10.0         Last change: 2025 February 27
+*blink-cmp.txt*         For NVIM v0.10.0         Last change: 2025 February 28
 
 ==============================================================================
 Table of Contents                                *blink-cmp-table-of-contents*
@@ -2151,9 +2151,11 @@ PROVIDERS
     
       omni = {
         name = 'Omni',
-        module = 'blink.cmp.sources.omni',
+        module = 'blink.cmp.sources.complete_func',
+        enabled = function() return vim.bo.omnifunc ~= 'v:lua.vim.lsp.omnifunc' end,
+        ---@type blink.cmp.CompleteFuncOpts
         opts = {
-          disable_omnifuncs = { 'v:lua.vim.lsp.omnifunc' },
+            complete_func = function() return vim.bo.omnifunc end,
         },
       },
     }

--- a/doc/configuration/reference.md
+++ b/doc/configuration/reference.md
@@ -532,9 +532,11 @@ sources.providers = {
 
   omni = {
     name = 'Omni',
-    module = 'blink.cmp.sources.omni',
+    module = 'blink.cmp.sources.complete_func',
+    enabled = function() return vim.bo.omnifunc ~= 'v:lua.vim.lsp.omnifunc' end,
+    ---@type blink.cmp.CompleteFuncOpts
     opts = {
-      disable_omnifuncs = { 'v:lua.vim.lsp.omnifunc' },
+        complete_func = function() return vim.bo.omnifunc end,
     },
   },
 }

--- a/lua/blink/cmp/config/sources.lua
+++ b/lua/blink/cmp/config/sources.lua
@@ -83,7 +83,12 @@ local sources = {
       },
       omni = {
         name = 'Omni',
-        module = 'blink.cmp.sources.omni',
+        module = 'blink.cmp.sources.complete_func',
+        enabled = function() return vim.bo.omnifunc ~= 'v:lua.vim.lsp.omnifunc' end,
+        ---@type blink.cmp.CompleteFuncOpts
+        opts = {
+          complete_func = function() return vim.bo.omnifunc end,
+        },
       },
       -- NOTE: in future we may want a built-in terminal source. For now
       -- the infrastructure exists, e.g. so community terminal sources can be
@@ -103,6 +108,10 @@ function sources.validate(config)
   )
   assert(config.cmdline == nil, '`sources.cmdline` has been replaced with `cmdline.sources`')
   assert(config.term == nil, '`sources.term` has been replaced with `term.sources`')
+  assert(
+    config.providers.omni.module ~= 'blink.cmp.sources.omni',
+    '`blink.cmp.sources.omni` has been replaced with `blink.cmp.sources.complete_func`'
+  )
 
   validate('sources', {
     default = { config.default, { 'function', 'table' } },


### PR DESCRIPTION
Currently the `omni` source is a specific implementation of `complete-functions` for omnifuncs only. This PR allows for more control over omnifuncs  (e.g. using two different omnifuncs at once), as well as the creation of sources for any arbitrary complete-func using that machinery.

```lua
-- e.g.
thesaurus = {
    name = "Thesaurus",
    module = "blink.cmp.sources.complete_func",
    opts = {
        complete_func = function()
            return vim.bo.thesaurusfunc
        end,
    },
}
```