### PR TITLE
doc: use the correct way to check comment block

### DIFF
--- a/doc/recipes.md
+++ b/doc/recipes.md
@@ -235,11 +235,48 @@ sources = {
 ### Dynamically picking providers by treesitter node/filetype
 
 ```lua
-sources.default = function(ctx)
-  local success, node = pcall(vim.treesitter.get_node)
+-- check if current line is inside a comment block
+local function inside_comment_block()
+    if vim.api.nvim_get_mode().mode ~= 'i' then
+        return false
+    end
+    local node_under_cursor = vim.treesitter.get_node()
+    local parser = vim.treesitter.get_parser(nil, nil, { error = false })
+    local query = vim.treesitter.query.get(vim.bo.filetype, 'highlights')
+    if not parser or not node_under_cursor or not query then
+        return false
+    end
+    local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+    row = row - 1
+    for id, node, _ in query:iter_captures(node_under_cursor, 0, row, row + 1) do
+        if query.captures[id]:find('comment') then
+            local start_row, start_col, end_row, end_col = node:range()
+            if start_row <= row and row <= end_row then
+                if start_row == row and end_row == row then
+                    if start_col <= col and col <= end_col then
+                        return true
+                    end
+                elseif start_row == row then
+                    if start_col <= col then
+                        return true
+                    end
+                elseif end_row == row then
+                    if col <= end_col then
+                        return true
+                    end
+                else
+                    return true
+                end
+            end
+        end
+    end
+    return false
+end
+
+sources.default = function()
   if vim.bo.filetype == 'lua' then
     return { 'lsp', 'path' }
-  elseif success and node and vim.tbl_contains({ 'comment', 'line_comment', 'block_comment' }, node:type()) then
+  elseif inside_comment_block() then
     return { 'buffer' }
   else
     return { 'lsp', 'path', 'snippets', 'buffer' }


### PR DESCRIPTION
Using node:type() do not work as expected, sometimes, the type will go with a "chunk" or even empty string, we must iterate the node of current line to check if current line is inside a comment block. Besides, in the code, there is no `ctx` passed to the default function, just remove the parameter in the doc.