### PR TITLE
fix(nix): don't add trailing newline to version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
             preInstall = ''
               mkdir -p target/release
               ln -s ${self'.packages.blink-fuzzy-lib}/lib/libblink_cmp_fuzzy.* target/release/
-              echo "nix" > target/release/version
+              echo -n "nix" > target/release/version
             '';
           };
 


### PR DESCRIPTION
see discussion in: https://github.com/Saghen/blink.cmp/pull/1334

Trailing newline caused it to be detected as `{ "tag" = "nix\n" }` instead of `{ "nix" = true } `