### PR TITLE
docs: add cmp-pandoc-references community source

### DIFF
--- a/doc/configuration/sources.md
+++ b/doc/configuration/sources.md
@@ -92,3 +92,4 @@ The command `:BlinkCmp status` can be used to view which sources providers are e
 - [blink-cmp-env](https://github.com/bydlw98/blink-cmp-env)
 - [blink-cmp-avante](https://github.com/Kaiser-Yang/blink-cmp-avante)
 - [blink-cmp-conventional-commits](https://github.com/disrupted/blink-cmp-conventional-commits)
+- [cmp-pandoc-references](https://github.com/jmbuhr/cmp-pandoc-references)


### PR DESCRIPTION
The repo also still contains a source for nvim-cmp, which is why I didn't change the repository name to `blink-cmp-...` like you suggest in the developer documentation. Does this still work for you as a community source?

Thanks for the great plugin! :)