### PR TITLE
docs: fix recipes fuzzy sorts custom function example

### DIFF
--- a/doc/recipes.md
+++ b/doc/recipes.md
@@ -121,7 +121,9 @@ You may use a custom sort function to deprioritize LSPs such as Emmet Language S
 fuzzy = {
   sorts = {
     function(a, b)
-      if a.client_name == nil or b.client_name == nil then return end
+      if (a.client_name == nil or b.client_name == nil) or (a.client_name == b.client_name) then
+        return
+      end
       return b.client_name == 'emmet_ls'
     end,
     -- default sorts


### PR DESCRIPTION
The previous example crashes when the 2 completion item params of the sort function have the same client_name, with:
```
Error executing vim.schedule lua callback: ...l/share/nvim/lazy/blink.cmp/lua/blink/cmp/fuzzy/sort.lua:11: invalid order function for sorting
stack traceback:
	[C]: in function 'sort'
```
Returning whenever client_names are the same, fixes it.