### PR TITLE
fix: prefer luasnip name over regex trigger in completion results

### DIFF
--- a/lua/blink/cmp/sources/snippets/luasnip.lua
+++ b/lua/blink/cmp/sources/snippets/luasnip.lua
@@ -89,7 +89,7 @@ function source:get_completions(ctx, callback)
       --- @type lsp.CompletionItem
       local item = {
         kind = require('blink.cmp.types').CompletionItemKind.Snippet,
-        label = snip.trigger,
+        label = snip.regTrig and snip.name or snip.trigger,
         insertText = snip.trigger,
         insertTextFormat = vim.lsp.protocol.InsertTextFormat.PlainText,
         sortText = sort_text,


### PR DESCRIPTION
This addresses an issue where snippets composed only by lua regex
patterns make them barely searchable in the completion menu.

Luasnip provides a `name` property that, when available, display the
snippet's `name` instead of the raw regex `trigger` pattern, making
regex triggers discoverable and user-friendly.

Related to #1373

Co-authored-by: helins <adam@protosens.com>
