### PR TITLE
fix: handle blob-type in documentation height computation

### DIFF
--- a/lua/blink/cmp/lib/window/scrollbar/geometry.lua
+++ b/lua/blink/cmp/lib/window/scrollbar/geometry.lua
@@ -23,6 +23,7 @@ local function get_win_buf_height(target_win)
   local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
   local height = 0
   for _, l in ipairs(lines) do
+    if vim.fn.type(l) == vim.v.t_blob then l = vim.fn.string(l) end
     height = height + math.max(1, (math.ceil(vim.fn.strwidth(l) / width)))
   end
   return height


### PR DESCRIPTION
Resolves scrollbar rendering issues when LSP servers (e.g., Pyright)
sometimes return blob-type content in documentation. Converts blobs to
strings before computing line widths to ensure accurate documentation
window sizing.

Fix #1320
