### PR TITLE
feat: handle large buf text completion with pure lua

### DIFF
--- a/lua/blink/cmp/sources/buffer.lua
+++ b/lua/blink/cmp/sources/buffer.lua
@@ -147,7 +147,7 @@ function buffer:get_completions(_, callback)
     local buf_text = table.concat(buf_texts, '\n')
 
     -- should take less than 2ms
-    if #buf_text < 0 then
+    if #buf_text < 20000 then
       run_sync(buf_text, transformed_callback)
     -- should take less than 10ms
     elseif #buf_text < 500000 then

--- a/lua/blink/cmp/sources/buffer.lua
+++ b/lua/blink/cmp/sources/buffer.lua
@@ -52,7 +52,7 @@ local function run_sync(buf_text, callback) callback(words_to_items(require('bli
 
 local function run_async_rust(buf_text, callback)
   local worker = uv.new_work(
-    -- must use ffi directly since the normal one requires the config which isnt present
+    -- must use rust module directly since the normal one requires the config which isnt present
     function(buf_text, cpath)
       package.cpath = cpath
       return table.concat(require('blink.cmp.fuzzy.rust').get_words(buf_text), '\n')
@@ -66,53 +66,49 @@ local function run_async_rust(buf_text, callback)
 end
 
 local function run_async_lua(buf_text, callback)
-  local chunk_size = 8000 -- Min chunk size in bytes
+  local min_chunk_size = 2000 -- Min chunk size in bytes
+  local max_chunk_size = 4000 -- Max chunk size in bytes
   local total_length = #buf_text
-  local max_chunks = math.ceil(total_length / chunk_size)
 
-  ---@type string[][]
-  local all_words = {}
+  ---@type table<string, boolean>
+  local words = {}
 
-  for idx = 1, max_chunks do
-    local start_pos = (idx - 1) * chunk_size + 1
-    local end_pos = math.min(start_pos + chunk_size - 1, total_length)
+  local cancelled = false
+  local pos = 1
+  local function next_chunk()
+    if cancelled then return end
+
+    local start_pos = pos
+    local end_pos = math.min(start_pos + min_chunk_size - 1, total_length)
 
     -- Ensure we don't break in the middle of a word
     if end_pos < total_length then
-      while end_pos < total_length and not string.match(string.sub(buf_text, end_pos, end_pos), '%s') do
+      while
+        end_pos < total_length
+        and (end_pos - start_pos) < max_chunk_size
+        and not string.match(string.sub(buf_text, end_pos, end_pos), '%s')
+      do
         end_pos = end_pos + 1
       end
     end
 
+    pos = end_pos + 1
+
     local chunk_text = string.sub(buf_text, start_pos, end_pos)
+    local chunk_words = require('blink.cmp.fuzzy').get_words(chunk_text)
+    for _, word in ipairs(chunk_words) do
+      words[word] = true
+    end
 
-    vim.defer_fn(
-      function()
-        all_words[idx] = require('blink.cmp.fuzzy').get_words(chunk_text)
-
-        if idx == max_chunks then
-          vim.schedule(function()
-            -- remove duplicates
-            ---@type string[]
-            local dedup_words = {}
-            local dict = {}
-            for _, chunk_words in ipairs(all_words) do
-              for _, word in ipairs(chunk_words) do
-                if dict[word] == nil then
-                  dict[word] = true
-                  dedup_words[#dedup_words + 1] = word
-                end
-              end
-            end
-
-            callback(words_to_items(dedup_words))
-          end)
-        end
-      end,
-      -- first iter is instant, then 2ms delay between chunks
-      (idx - 1) * 2
-    )
+    -- next iter
+    if pos < total_length then return vim.schedule(next_chunk) end
+    -- or finish
+    vim.schedule(function() callback(words_to_items(vim.tbl_keys(words))) end)
   end
+
+  next_chunk()
+
+  return function() cancelled = true end
 end
 
 --- @class blink.cmp.BufferOpts
@@ -151,23 +147,20 @@ function buffer:get_completions(_, callback)
     local buf_text = table.concat(buf_texts, '\n')
 
     -- should take less than 2ms
-    if #buf_text < 20000 then
+    if #buf_text < 0 then
       run_sync(buf_text, transformed_callback)
     -- should take less than 10ms
     elseif #buf_text < 500000 then
       if fuzzy.implementation_type == 'rust' then
-        run_async_rust(buf_text, transformed_callback)
+        return run_async_rust(buf_text, transformed_callback)
       else
-        run_async_lua(buf_text, transformed_callback)
+        return run_async_lua(buf_text, transformed_callback)
       end
     -- too big so ignore
     else
       transformed_callback({})
     end
   end)
-
-  -- TODO: cancel run_async
-  return function() end
 end
 
 return buffer


### PR DESCRIPTION
fixes #1392 

It parses buffers content in chunks which should help to not block the UI thread. I also had to manually dedup words, otherwise we can get duplicates in the completion menu. 

There are definitely ways to improve the performance further. Yet I didn't want to increase the scope of this PR and the option to enforce lua fuzzy implementation already notably highlights that performance won't be as good