### PR TITLE
feat(keymap): toggle signature help window in snippet

### DIFF
--- a/lua/blink/cmp/keymap/apply.lua
+++ b/lua/blink/cmp/keymap/apply.lua
@@ -1,6 +1,6 @@
 local apply = {}
 
-local snippet_commands = { 'snippet_forward', 'snippet_backward' }
+local snippet_commands = { 'snippet_forward', 'snippet_backward', 'show_signature', 'hide_signature' }
 
 --- Applies the keymaps to the current buffer
 --- @param keys_to_commands table<string, blink.cmp.KeymapCommand[]>


### PR DESCRIPTION
In addition to insert mode, when an LSP supports snippets for built-in
functions, allow toggling the signature help window in select mode as
well.
