### PR TITLE
Fix some typos in docs and code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Bug Fixes
 
-* **download:** correctly handle `download = false` and `implementationn = "rust"` ([#1334](https://github.com/Saghen/blink.cmp/issues/1334)) ([2c8e4c7](https://github.com/Saghen/blink.cmp/commit/2c8e4c78b2ca735262be2ef201c38738db3c9674))
+* **download:** correctly handle `download = false` and `implementation = "rust"` ([#1334](https://github.com/Saghen/blink.cmp/issues/1334)) ([2c8e4c7](https://github.com/Saghen/blink.cmp/commit/2c8e4c78b2ca735262be2ef201c38738db3c9674))
 * lua fuzzy implementation off by 1 and suffix matching ([2c1524f](https://github.com/Saghen/blink.cmp/commit/2c1524f369b27ec09ff7b0425188933768622918)), closes [#1335](https://github.com/Saghen/blink.cmp/issues/1335)
 * mini snippets validation ([c412578](https://github.com/Saghen/blink.cmp/commit/c412578824eb58f9f521643be16d9eb1568d068f)), closes [#1332](https://github.com/Saghen/blink.cmp/issues/1332) [#1342](https://github.com/Saghen/blink.cmp/issues/1342)
 

--- a/doc/blink-cmp.txt
+++ b/doc/blink-cmp.txt
@@ -415,7 +415,7 @@ SHOW ON NEWLINE, TAB AND SPACE ~
 
 
 Note that you may want to add the override to other sources as well, since if
-the LSP doesnt return any items, we won’t show the menu if it was triggered
+the LSP doesn't return any items, we won’t show the menu if it was triggered
 by any of these three characters.
 
 >lua
@@ -558,7 +558,7 @@ SOURCES                                            *blink-cmp-recipes-sources*
 BUFFER COMPLETION FROM ALL OPEN BUFFERS ~
 
 The default behavior is to only show completions from **visible** "normal"
-buffers (i.e. it woudldn’t include neo-tree). This will instead show
+buffers (i.e. it wouldn't include neo-tree). This will instead show
 completions from all buffers, even if they’re not visible on screen. Note
 that the performance impact of this has not been tested.
 
@@ -767,7 +767,7 @@ For more common configurations, see the recipes <../recipes.md>.
         default = { 'lsp', 'path', 'snippets', 'buffer' },
       },
     
-      -- Blink.cmp uses a Rust fuzzy matcher by default for frecency, proximity bonsu, typo resistance and
+      -- Blink.cmp uses a Rust fuzzy matcher by default for frecency, proximity bonus, typo resistance and
       -- significantly better performance. A lua implementation has been included as well.
       -- See the fuzzy documentation for more information
       fuzzy = { implementation = 'prefer_rust_with_warning' },
@@ -1628,7 +1628,7 @@ to the source directly, and will vary by source.
       max_items = nil, -- Maximum number of items to display in the menu
       min_keyword_length = 0, -- Minimum number of characters in the keyword to trigger the provider
       -- If this provider returns 0 items, it will fallback to these providers.
-      -- If multiple providers falback to the same provider, all of the providers must return 0 items for it to fallback
+      -- If multiple providers fallback to the same provider, all of the providers must return 0 items for it to fallback
       fallbacks = {},
       score_offset = 0, -- Boost/penalize the score of the items
       override = nil, -- Override the source's functions
@@ -1960,7 +1960,7 @@ COMPLETION DOCUMENTATION
       update_delay_ms = 50,
       -- Whether to use treesitter highlighting, disable if you run into performance issues
       treesitter_highlighting = true,
-      -- Draws the item in the documentation window, by default using an internal treessitter based implementation
+      -- Draws the item in the documentation window, by default using an internal treesitter based implementation
       draw = function(opts) opts.default_implementation() end,
       window = {
         min_width = 10,
@@ -2171,7 +2171,7 @@ PROVIDERS
         max_items = nil, -- Maximum number of items to display in the menu
         min_keyword_length = 0, -- Minimum number of characters in the keyword to trigger the provider
         -- If this provider returns 0 items, it will fallback to these providers.
-        -- If multiple providers falback to the same provider, all of the providers must return 0 items for it to fallback
+        -- If multiple providers fallback to the same provider, all of the providers must return 0 items for it to fallback
         fallbacks = {},
         score_offset = 0, -- Boost/penalize the score of the items
         override = nil, -- Override the source's functions

--- a/doc/configuration/general.md
+++ b/doc/configuration/general.md
@@ -62,7 +62,7 @@ For more common configurations, see the [recipes](../recipes.md).
     default = { 'lsp', 'path', 'snippets', 'buffer' },
   },
 
-  -- Blink.cmp uses a Rust fuzzy matcher by default for frecency, proximity bonsu, typo resistance and
+  -- Blink.cmp uses a Rust fuzzy matcher by default for frecency, proximity bonus, typo resistance and
   -- significantly better performance. A lua implementation has been included as well.
   -- See the fuzzy documentation for more information
   fuzzy = { implementation = 'prefer_rust_with_warning' },

--- a/doc/configuration/reference.md
+++ b/doc/configuration/reference.md
@@ -269,7 +269,7 @@ completion.documentation = {
   update_delay_ms = 50,
   -- Whether to use treesitter highlighting, disable if you run into performance issues
   treesitter_highlighting = true,
-  -- Draws the item in the documentation window, by default using an internal treessitter based implementation
+  -- Draws the item in the documentation window, by default using an internal treesitter based implementation
   draw = function(opts) opts.default_implementation() end,
   window = {
     min_width = 10,
@@ -474,7 +474,7 @@ sources.providers = {
     max_items = nil, -- Maximum number of items to display in the menu
     min_keyword_length = 0, -- Minimum number of characters in the keyword to trigger the provider
     -- If this provider returns 0 items, it will fallback to these providers.
-    -- If multiple providers falback to the same provider, all of the providers must return 0 items for it to fallback
+    -- If multiple providers fallback to the same provider, all of the providers must return 0 items for it to fallback
     fallbacks = {},
     score_offset = 0, -- Boost/penalize the score of the items
     override = nil, -- Override the source's functions

--- a/doc/configuration/sources.md
+++ b/doc/configuration/sources.md
@@ -50,7 +50,7 @@ sources.providers.lsp = {
   max_items = nil, -- Maximum number of items to display in the menu
   min_keyword_length = 0, -- Minimum number of characters in the keyword to trigger the provider
   -- If this provider returns 0 items, it will fallback to these providers.
-  -- If multiple providers falback to the same provider, all of the providers must return 0 items for it to fallback
+  -- If multiple providers fallback to the same provider, all of the providers must return 0 items for it to fallback
   fallbacks = {},
   score_offset = 0, -- Boost/penalize the score of the items
   override = nil, -- Override the source's functions

--- a/doc/recipes.md
+++ b/doc/recipes.md
@@ -138,7 +138,7 @@ vim.api.nvim_create_autocmd('User', {
 This may not be working as expected at the moment. Please see [#836](https://github.com/Saghen/blink.cmp/issues/836)
 :::
 
-Note that you may want to add the override to other sources as well, since if the LSP doesnt return any items, we won't show the menu if it was triggered by any of these three characters.
+Note that you may want to add the override to other sources as well, since if the LSP doesn't return any items, we won't show the menu if it was triggered by any of these three characters.
 
 ```lua
 -- by default, blink.cmp will block newline, tab and space trigger characters, disable that behavior
@@ -270,7 +270,7 @@ completion = {
 
 ### Buffer completion from all open buffers
 
-The default behavior is to only show completions from **visible** "normal" buffers (i.e. it woudldn't include neo-tree). This will instead show completions from all buffers, even if they're not visible on screen. Note that the performance impact of this has not been tested. 
+The default behavior is to only show completions from **visible** "normal" buffers (i.e. it wouldn't include neo-tree). This will instead show completions from all buffers, even if they're not visible on screen. Note that the performance impact of this has not been tested.
 
 ```lua
 sources = {

--- a/lua/blink/cmp/config/snippets.lua
+++ b/lua/blink/cmp/config/snippets.lua
@@ -3,7 +3,7 @@
 --- @field expand fun(snippet: string) Function to use when expanding LSP provided snippets
 --- @field active fun(filter?: { direction?: number }): boolean Function to use when checking if a snippet is active
 --- @field jump fun(direction: number) Function to use when jumping between tab stops in a snippet, where direction can be negative or positive
---- @field score_offset number Offset to the score of all snipppet items
+--- @field score_offset number Offset to the score of all snippet items
 
 --- @param handlers table<'default' | 'luasnip' | 'mini_snippets', fun(...): any>
 local function by_preset(handlers)

--- a/lua/blink/cmp/fuzzy/download/git.lua
+++ b/lua/blink/cmp/fuzzy/download/git.lua
@@ -15,7 +15,7 @@ end
 
 function git.get_tag()
   return async.task.new(function(resolve, reject)
-    -- If repo_dir is nil, no git reposiory is found, similar to `out.code == 128`
+    -- If repo_dir is nil, no git repository is found, similar to `out.code == 128`
     local repo_dir = vim.fs.root(files.root_dir, '.git')
     if not repo_dir then resolve() end
 
@@ -43,7 +43,7 @@ end
 
 function git.get_sha()
   return async.task.new(function(resolve, reject)
-    -- If repo_dir is nil, no git reposiory is found, similar to `out.code == 128`
+    -- If repo_dir is nil, no git repository is found, similar to `out.code == 128`
     local repo_dir = vim.fs.root(files.root_dir, '.git')
     if not repo_dir then resolve() end
 

--- a/lua/blink/cmp/fuzzy/rust/error.rs
+++ b/lua/blink/cmp/fuzzy/rust/error.rs
@@ -7,7 +7,7 @@ pub enum Error {
     #[error("Failed to acquire lock for items by provider")]
     AcquireItemLock,
 
-    #[error("Attempted to use frencecy before initialization")]
+    #[error("Attempted to use frecency before initialization")]
     UseFrecencyBeforeInit,
 
     #[error(


### PR DESCRIPTION
Hi, I noticed some typos in the documentation, and my autism kicked in, so I went through the entire repo with [hunspell](https://github.com/hunspell/hunspell) 

Great plugin by the way