### PR TITLE
fix(cmdline): correctly handle bulk deletions in nvim < 0.11

### DIFF
--- a/lua/blink/cmp/lib/cmdline_events.lua
+++ b/lua/blink/cmp/lib/cmdline_events.lua
@@ -76,21 +76,26 @@ function cmdline_events:listen(opts)
     local callback = vim.schedule_wrap(function()
       if vim.api.nvim_get_mode().mode ~= 'c' then return end
 
-      local cmdline_equal = vim.fn.getcmdline() == previous_cmdline
-      local cursor_equal = vim.fn.getcmdpos() == previous_cursor
+      local current_cmdline = vim.fn.getcmdline()
+      local current_cursor = vim.fn.getcmdpos()
 
-      previous_cmdline = vim.fn.getcmdline()
-      previous_cursor = vim.fn.getcmdpos()
+      -- Detect changes in command line or cursor position
+      local cmdline_changed = current_cmdline ~= previous_cmdline
+      local cursor_changed = current_cursor ~= previous_cursor
 
-      if cursor_equal or (not cmdline_equal and not did_backspace) then return end
-      did_backspace = false
+      previous_cmdline = current_cmdline
+      previous_cursor = current_cursor
 
-      local is_ignored = self.ignore_next_cursor_moved
-      self.ignore_next_cursor_moved = false
+      -- Fire on_cursor_moved if either text or cursor changed
+      if cursor_changed or (cmdline_changed and not did_backspace) then
+        did_backspace = false
 
-      opts.on_cursor_moved('CursorMoved', is_ignored)
+        local is_ignored = self.ignore_next_cursor_moved
+        self.ignore_next_cursor_moved = false
+
+        opts.on_cursor_moved('CursorMoved', is_ignored)
+      end
     end)
-
     vim.api.nvim_create_autocmd('CmdlineEnter', {
       callback = function()
         previous_cmdline = ''


### PR DESCRIPTION
Update fallback logic for detecting cursor movements to handle bulk
deletions like `<C-u>` and `<C-w>`.

Fix #1369
