### PR TITLE
 Restore original 'buflisted' state for current buffer

### DIFF
--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -20,7 +20,12 @@ function text_edits.apply(text_edit, additional_text_edits)
 
     local all_edits = utils.shallow_copy(additional_text_edits)
     table.insert(all_edits, text_edit)
-    vim.lsp.util.apply_text_edits(all_edits, vim.api.nvim_get_current_buf(), 'utf-8')
+
+    -- preserve 'buflisted' state because vim.lsp.util.apply_text_edits forces it to true.  
+    local cur_bufnr = vim.api.nvim_get_current_buf()
+    local prev_buflisted = vim.bo[cur_bufnr].buflisted
+    vim.lsp.util.apply_text_edits(all_edits, cur_bufnr, 'utf-8')
+    vim.bo[cur_bufnr].buflisted = prev_buflisted
   end
 
   if mode == 'cmdline' then


### PR DESCRIPTION
fixes https://github.com/olimorris/codecompanion.nvim/issues/1060

This change preserves the original `buflisted` state of the current buffer when applying LSP text edits. The function `vim.lsp.util.apply_text_edits` forces `buflisted` to true (see https://github.com/neovim/neovim/issues/12488 and https://github.com/neovim/neovim/pull/12489, which is useful for non-current buffers but not desired for the current one. This fix saves the state before applying edits and restores it afterward.