### PR TITLE
Remove trailing spaces

### DIFF
--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -21,7 +21,7 @@ function text_edits.apply(text_edit, additional_text_edits)
     local all_edits = utils.shallow_copy(additional_text_edits)
     table.insert(all_edits, text_edit)
 
-    -- preserve 'buflisted' state because vim.lsp.util.apply_text_edits forces it to true.  
+    -- preserve 'buflisted' state because vim.lsp.util.apply_text_edits forces it to true
     local cur_bufnr = vim.api.nvim_get_current_buf()
     local prev_buflisted = vim.bo[cur_bufnr].buflisted
     vim.lsp.util.apply_text_edits(all_edits, cur_bufnr, 'utf-8')


### PR DESCRIPTION
I accidentally added trailing spaces in the [previous PR](https://github.com/Saghen/blink.cmp/pull/1432). Sorry about that 🙂
Now Stylua shows no errors locally.