### PR TITLE
fix(lsp): missing `source` parameter

### DIFF
--- a/lua/blink/cmp/sources/lsp/init.lua
+++ b/lua/blink/cmp/sources/lsp/init.lua
@@ -177,16 +177,16 @@ end
 
 --- Execute ---
 
-function lsp:execute(source, item, callback, default_implementation)
+function lsp:execute(ctx, item, callback, default_implementation)
   default_implementation()
 
   local client = vim.lsp.get_client_by_id(item.client_id)
   if client and item.command then
     if vim.fn.has('nvim-0.11') == 1 then
-      client:exec_cmd(item.command, { bufnr = source.bufnr }, function() callback() end)
+      client:exec_cmd(item.command, { bufnr = ctx.bufnr }, function() callback() end)
     else
       -- TODO: remove this once 0.11 is the minimum version
-      client:_exec_cmd(item.command, { bufnr = source.bufnr }, function() callback() end)
+      client:_exec_cmd(item.command, { bufnr = ctx.bufnr }, function() callback() end)
     end
   else
     callback()

--- a/lua/blink/cmp/sources/lsp/init.lua
+++ b/lua/blink/cmp/sources/lsp/init.lua
@@ -177,7 +177,7 @@ end
 
 --- Execute ---
 
-function lsp:execute(_, item, callback, default_implementation)
+function lsp:execute(source, item, callback, default_implementation)
   default_implementation()
 
   local client = vim.lsp.get_client_by_id(item.client_id)


### PR DESCRIPTION
Error: "failed to execute item with error: ...e/nvim/lazy/blink.cmp/lua/blink/cmp/sources/lsp/init.lua:186: attempt to index global 'source' (a nil value)"