### PR TITLE
fix(luasnip): use `enter` instead of `leave` luasnip event

### DIFF
--- a/lua/blink/cmp/sources/snippets/luasnip.lua
+++ b/lua/blink/cmp/sources/snippets/luasnip.lua
@@ -82,7 +82,7 @@ function source:get_completions(ctx, callback)
     if self.config.show_autosnippets then
       local autosnippets = require('luasnip').get_snippets(ft, { type = 'autosnippets' })
       for _, s in ipairs(autosnippets) do
-        add_luasnip_callback(s, 'leave', require('blink.cmp').hide)
+        add_luasnip_callback(s, 'enter', require('blink.cmp').hide)
       end
       snippets = require('blink.cmp.lib.utils').shallow_copy(snippets)
       vim.list_extend(snippets, autosnippets)


### PR DESCRIPTION

After #1450, the menu won't be hidden if there are more then one nodes in the autosnippet
(in video, `mk` -> `${}${}` and `lrg` -> `\lbrack {} \rparen{}` where `{}` are nodes cursor can jump about)
In my humble opinion, `leave` event used in #1450 is not proper, for it will only hide the menu when
cursor leave the node. If the autosnippet only insert some texts without any node to jump around, then
this implementation is ok, but if there are more than one nodes, after trigger the autosnippet, you will `enter`
the node and `leave` event won't be triggered until call `luasnip.jump`.

[Screencast_20250318_223646.webm](https://github.com/user-attachments/assets/1aef2baa-1f44-4557-bf7c-876c6c01cfaa)

After this PR

[Screencast_20250318_223356.webm](https://github.com/user-attachments/assets/40dc4592-7935-490f-a0e2-367c780194c6)

Fix https://github.com/Saghen/blink.cmp/issues/1443