### PR TITLE
fix(luasnip): use `cursor` to locate `clear_region.to`

### DIFF
--- a/lua/blink/cmp/sources/snippets/luasnip.lua
+++ b/lua/blink/cmp/sources/snippets/luasnip.lua
@@ -183,7 +183,7 @@ function source:execute(ctx, item)
   local range = require('blink.cmp.lib.text_edits').get_from_item(item).range
   local clear_region = {
     from = { range.start.line, range.start.character },
-    to = { range['end'].line, range['end'].character },
+    to = cursor,
   }
 
   local expand_params = snip:matches(require('luasnip.util.util').get_current_line_to_cursor())


### PR DESCRIPTION
The current implementation is
```lua
local range = require('blink.cmp.lib.text_edits').get_from_item(item).range
local clear_region = {
from = { range.start.line, range.start.character },
to = { range['end'].line, range['end'].character },
}
```
However, when expanding autosnippets by `<C-y>`, I find it eat up text after the cursor and when I try to debug it, I find inconsistency in `range['end'].character`, my debug code is
```lua
local range = require('blink.cmp.lib.text_edits').get_from_item(item).range
local clear_region = {
from = { range.start.line, range.start.character },
to = { range['end'].line, range['end'].character },
}
local result = vim.inspect(clear_region)
vim.api.nvim_echo({{result}}, true, {})
```
Video:

[Screencast_20250319_105240.webm](https://github.com/user-attachments/assets/7a098c80-f4b3-4356-8e5a-91dd37e31d34)

Pay attention to the bottom left, where you can see that `range['end'].character` change from 10 to 7 to 7 to 10. In fact, when I try more times, I find it takes value from 6 to 11 at random.

So I choose to use `cursor` to locate `clear_region.to` instead, which is also the method adopted by `cmp_luasnip`

[Link to code](https://github.com/saadparwaiz1/cmp_luasnip/blob/98d9cb5c2c38532bd9bdb481067b20fea8f32e90/lua/cmp_luasnip/init.lua#L148-L154)

Maybe there are any reason to use `range` to locate the end of clear region? In this PR, the new implementation only applies to the situation where cursor is at the end of text. If the cursor is in the middle of the text, it may not work.