### PR TITLE
fix(scrollbar): explicitly set border to 'none'

### DIFF
--- a/lua/blink/cmp/lib/window/scrollbar/win.lua
+++ b/lua/blink/cmp/lib/window/scrollbar/win.lua
@@ -82,6 +82,7 @@ function scrollbar_win:_make_win(geometry, hl_group)
     style = 'minimal',
     focusable = false,
     noautocmd = true,
+    border = 'none',
   })
   local win = vim.api.nvim_open_win(self.buf, false, win_config)
   vim.api.nvim_set_option_value('winhighlight', 'Normal:' .. hl_group .. ',EndOfBuffer:' .. hl_group, { win = win })


### PR DESCRIPTION
There was a [bug in neovim](https://github.com/neovim/neovim/issues/32974) that caused the border of floating windows to be overwritten with the globally configured ['winborder'](https://neovim.io/doc/user/options.html#'winborder') value if set.

This behavior is now [fixed in HEAD](https://github.com/neovim/neovim/commit/0e59f6f4c7cd376926fc5027b42a94e12cb017fe), but the border of the scrollbar still needs to be set to `none` explicitly to prevent it from being overwritten with the global value.

Screenshots are made with `vim.o.winborder = 'rounded'` and `{ completion = { menu = { border = 'none' } } }`:

Without explicit border:
![without explicit border](https://github.com/user-attachments/assets/587112f8-e590-46da-b456-09e0665ae584)

Expected:
![expected](https://github.com/user-attachments/assets/462c332b-cc65-4b8e-85a4-0280b284da75)
