### PR TITLE
fix(scrollbar): should never have border

### DIFF
--- a/lua/blink/cmp/lib/window/scrollbar/win.lua
+++ b/lua/blink/cmp/lib/window/scrollbar/win.lua
@@ -31,7 +31,7 @@ function scrollbar_win:show_thumb(geometry)
   else
     -- update with the geometry
     local thumb_existing_config = vim.api.nvim_win_get_config(self.thumb_win)
-    local thumb_config = vim.tbl_deep_extend('force', thumb_existing_config, geometry)
+    local thumb_config = vim.tbl_deep_extend('force', thumb_existing_config, geometry, { border = 'none' })
     vim.api.nvim_win_set_config(self.thumb_win, thumb_config)
   end
 


### PR DESCRIPTION
**Problem**: using most recent neovim nightly and setting `vim.opt.winborder = 'single'` results in scrollbar having a border. 

<small>I presume this is not something that people want generally</small>

<img width="321" alt="Screenshot 2025-03-19 at 20 41 21" src="https://github.com/user-attachments/assets/be2fb3a1-978b-4d14-93e2-d0d502cbe600" />

**Solution**: explicitly set no border for the scrollbar

<img width="318" alt="Screenshot 2025-03-19 at 20 53 57" src="https://github.com/user-attachments/assets/e40d5f5c-224c-4fc4-9bd3-80efea43d892" />
