### PR TITLE
fix: "replacement string" item contains newlines

### DIFF
--- a/lua/blink/cmp/completion/windows/render/init.lua
+++ b/lua/blink/cmp/completion/windows/render/init.lua
@@ -112,6 +112,8 @@ function renderer:draw(context, bufnr, items)
     line = line:sub(1, -self.gap - 1)
 
     if self.padding[2] > 0 then line = line .. string.rep(' ', self.padding[2]) end
+    line = string.gsub(line, '\r', '')
+    line = string.gsub(line, '\n', '')
 
     table.insert(lines, line)
   end


### PR DESCRIPTION
fix a problem in the `draw_contexts`, where in some lines there can be new line character or carriage return character, by removing them before inserting the line to the draw lines list.

Closes [#1418](https://github.com/Saghen/blink.cmp/issues/1418)