### PR TITLE
fix(download): handle first-time loading issue of rust lua module

### DIFF
--- a/lua/blink/cmp/fuzzy/download/init.lua
+++ b/lua/blink/cmp/fuzzy/download/init.lua
@@ -117,7 +117,12 @@ function download.ensure_downloaded(callback)
       )
       return download.download(target_git_tag)
     end)
-    :map(function() callback(nil, 'rust') end)
+    :map(function()
+      -- clear cached module first since we call it in the pcall above
+      package.loaded['blink.cmp.fuzzy.rust'] = nil
+
+      callback(nil, 'rust')
+    end)
     :catch(function(err)
       -- fallback to lua implementation
       if fuzzy_config.implementation == 'prefer_rust' then


### PR DESCRIPTION
The pcall check introduced in commit #38a234e9 loads now the fuzzy rust
lua module. It needs to be cache cleared if required again.

Fix #1471
