### PR TITLE
feat(keymap): allow to override `inherit` preset with user keymaps

### DIFF
--- a/lua/blink/cmp/keymap/init.lua
+++ b/lua/blink/cmp/keymap/init.lua
@@ -63,18 +63,15 @@ function keymap.setup()
     require('blink.cmp.keymap.apply').keymap_to_current_buffer(mappings)
   end
 
-  -- Apply cmdline keymaps
-  if config.cmdline.enabled then
-    local cmdline_mappings =
-      keymap.get_mappings(config.cmdline.keymap.preset == 'inherit' and config.keymap or config.cmdline.keymap)
-    require('blink.cmp.keymap.apply').cmdline_keymaps(cmdline_mappings)
-  end
-
-  -- Apply term keymaps
-  if config.term.enabled then
-    local term_mappings =
-      keymap.get_mappings(config.term.keymap.preset == 'inherit' and config.keymap or config.term.keymap)
-    require('blink.cmp.keymap.apply').term_keymaps(term_mappings)
+  -- Apply cmdline and term keymaps
+  for _, mode in ipairs({ 'cmdline', 'term' }) do
+    local config_mode = config[mode]
+    if config_mode.enabled then
+      local keymaps = config_mode.keymap.preset == 'inherit'
+        and vim.tbl_deep_extend('force', config.keymap, config_mode.keymap)
+      local mappings = keymap.get_mappings(keymaps or config_mode.keymap)
+      require('blink.cmp.keymap.apply')[mode .. '_keymaps'](mappings)
+    end
   end
 end
 

--- a/lua/blink/cmp/keymap/presets.lua
+++ b/lua/blink/cmp/keymap/presets.lua
@@ -1,6 +1,7 @@
 --- @type table<string, table<string, blink.cmp.KeymapCommand[]>>
 local presets = {
   none = {},
+  inherit = {},
 
   default = {
     ['<C-space>'] = { 'show', 'show_documentation', 'hide_documentation' },


### PR DESCRIPTION
When using the `inherit` preset for `cmdline` and/or `term`, the
subsequent user keymaps are ignored. This change now merge them with the
inherited ones.

Fix #1479
