### PR TITLE
Doc: Fix typo in installation guide.

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -137,7 +137,7 @@ local capabilities = vim.lsp.protocol.make_client_capabilities()
 
 capabilities = vim.tbl_deep_extend('force', capabilities, require('blink.cmp').get_lsp_capabilities({}, false))
 
-capabilities = vim.tbl_deep_extend('force', {
+capabilities = vim.tbl_deep_extend('force', capabilities, {
   textDocument = {
     foldingRange = {
       dynamicRegistration = false,


### PR DESCRIPTION
tbl_deep_extend() requires two tables passed to it.