### PR TITLE
docs: fix the json in the snippets example

### DIFF
--- a/doc/blink-cmp.txt
+++ b/doc/blink-cmp.txt
@@ -1524,7 +1524,7 @@ Here’s an example, using the linux/mac path for the neovim configuration:
         "body": [
           "local ${1:foo} = ${2:bar}",
           "return ${3:baz}"
-        ],
+        ]
       }
     }
 <

--- a/doc/configuration/snippets.md
+++ b/doc/configuration/snippets.md
@@ -31,7 +31,7 @@ By default, the `snippets` source will check `~/.config/nvim/snippets` for your 
     "body": [
       "local ${1:foo} = ${2:bar}",
       "return ${3:baz}"
-    ],
+    ]
   }
 }
 ```


### PR DESCRIPTION
The json in the snippets examples isn't valid because of the trailing space.