### PR TITLE
refactor(validate): Use `nvim_echo` for emitting config errors

### DIFF
--- a/doc/configuration/fuzzy.md
+++ b/doc/configuration/fuzzy.md
@@ -29,7 +29,7 @@ If possible, it's highly recommended to use the Rust implementation of the fuzzy
 
 ### Prebuilt binaries (default on a release tag)
 
-By default, Blink will download a prebuilt binary from the latest release, when you're on a release tag (via `version = '*'` on `lazy.nvim` for example). If you're not on a release tag, you may force a specific version via `fuzzy.prebuilt_binaries.force_version`. See [the latest release](https://github.com/saghen/blink.cmp/releases/latest) for supported systems. See `prebuilt_binaries` section of the [reference configuration](./reference.md#fuzzy) for more options.
+By default, Blink will download a prebuilt binary from the latest release, when you're on a release tag (via `version = '1.*'` on `lazy.nvim` for example). If you're not on a release tag, you may force a specific version via `fuzzy.prebuilt_binaries.force_version`. See [the latest release](https://github.com/saghen/blink.cmp/releases/latest) for supported systems. See `prebuilt_binaries` section of the [reference configuration](./reference.md#fuzzy) for more options.
 
 You may instead install the prebuilt binaries manually by downloading the appropriate binary from the [latest release](https://github.com/saghen/blink.cmp/releases/latest) and placing it at `$data/lazy/blink.cmp/target/release/libblink_cmp_fuzzy.$ext`. Get the `$data` path via `:echo stdpath('data')`. Use `.so` for linux, `.dylib` for mac, and `.dll` for windows. If you're unsure whether you want `-musl` or `-gnu` for linux, you very likely want `-gnu`.
 

--- a/lua/blink/cmp/config/utils.lua
+++ b/lua/blink/cmp/config/utils.lua
@@ -34,7 +34,34 @@ function utils.validate(path, tbl, source)
 
   -- check for erroneous fields
   for k, _ in pairs(source) do
-    if tbl[k] == nil then error(path .. '.' .. k .. ': unexpected field found in configuration') end
+    if tbl[k] == nil then
+		---@type string Use `→` to make each part distinct. `.` may confuse non-programmer users.
+		local new_path = string.gsub(path, "%.", " → ");
+
+		if vim.api.nvim_echo then
+			local path_parts = vim.split(path, ".", { plain = true });
+			local _msg = {
+				{ " blink.cmp ", "DiagnosticVirtualTextWarn" },
+				{ ": ", "Comment" }
+			};
+
+			for p, part in ipairs(path_parts) do
+				table.insert(_msg, { " " .. part .. " ", "DiagnosticVirtualTextInfo" });
+				table.insert(_msg, { " → ", "Comment" });
+			end
+
+			--- Highlight the last segment in ERROR since that's
+			--- where the issue lies.
+			table.insert(_msg, { " " .. k .. " ", "DiagnosticVirtualTextError" })
+			table.insert(_msg, { " Unexpected field in configuration!", "Comment" })
+
+			vim.api.nvim_echo(_msg, true, {
+				verbose = false
+			})
+		else
+			vim.notify_once("[blink.cmp]: " .. new_path .. " → " .. k .. ": Unexpected field in configuration!", vim.log.levels.WARN, {});
+		end
+	end
   end
 end
 

--- a/lua/blink/cmp/config/utils.lua
+++ b/lua/blink/cmp/config/utils.lua
@@ -53,6 +53,7 @@ function utils.validate(path, tbl, source)
       local new_path = string.gsub(path, '%.', ' → ')
 
       if vim.api.nvim_echo then
+        ---@type string[]
         local path_parts = vim.split(path, '.', { plain = true })
         local _msg = {
           { ' blink.cmp ', 'DiagnosticVirtualTextWarn' },
@@ -89,7 +90,7 @@ function utils.validate(path, tbl, source)
         vim.notify_once(
           '[blink.cmp]: ' .. new_path .. ' → ' .. k .. ': Unexpected field in configuration!',
           vim.log.levels.WARN,
-          {}
+          { title = 'blink.cmp' }
         )
       end
     end

--- a/lua/blink/cmp/config/utils.lua
+++ b/lua/blink/cmp/config/utils.lua
@@ -36,30 +36,34 @@ function utils.validate(path, tbl, source)
   for k, _ in pairs(source) do
     if tbl[k] == nil then
       ---@type string Use `→` to make each part distinct. `.` may confuse non-programmer users.
-      local new_path = string.gsub(path, "%.", " → ");
+      local new_path = string.gsub(path, '%.', ' → ')
 
       if vim.api.nvim_echo then
-        local path_parts = vim.split(path, ".", { plain = true });
+        local path_parts = vim.split(path, '.', { plain = true })
         local _msg = {
-          { " blink.cmp ", "DiagnosticVirtualTextWarn" },
-          { ": ", "Comment" }
-        };
+          { ' blink.cmp ', 'DiagnosticVirtualTextWarn' },
+          { ': ', 'Comment' },
+        }
 
         for _, part in ipairs(path_parts) do
-          table.insert(_msg, { " " .. part .. " ", "DiagnosticVirtualTextInfo" });
-          table.insert(_msg, { " → ", "Comment" });
+          table.insert(_msg, { ' ' .. part .. ' ', 'DiagnosticVirtualTextInfo' })
+          table.insert(_msg, { ' → ', 'Comment' })
         end
 
         --- Highlight the last segment in ERROR since that's
         --- where the issue lies.
-        table.insert(_msg, { " " .. k .. " ", "DiagnosticVirtualTextError" })
-        table.insert(_msg, { " Unexpected field in configuration!", "Comment" })
+        table.insert(_msg, { ' ' .. k .. ' ', 'DiagnosticVirtualTextError' })
+        table.insert(_msg, { ' Unexpected field in configuration!', 'Comment' })
 
         vim.api.nvim_echo(_msg, true, {
-          verbose = false
+          verbose = false,
         })
       else
-        vim.notify_once("[blink.cmp]: " .. new_path .. " → " .. k .. ": Unexpected field in configuration!", vim.log.levels.WARN, {});
+        vim.notify_once(
+          '[blink.cmp]: ' .. new_path .. ' → ' .. k .. ': Unexpected field in configuration!',
+          vim.log.levels.WARN,
+          {}
+        )
       end
     end
   end

--- a/lua/blink/cmp/config/utils.lua
+++ b/lua/blink/cmp/config/utils.lua
@@ -41,13 +41,13 @@ function utils.validate(path, tbl, source)
       if vim.api.nvim_echo then
         local path_parts = vim.split(path, ".", { plain = true });
         local _msg = {
-            { " blink.cmp ", "DiagnosticVirtualTextWarn" },
-            { ": ", "Comment" }
+          { " blink.cmp ", "DiagnosticVirtualTextWarn" },
+          { ": ", "Comment" }
         };
 
-        for p, part in ipairs(path_parts) do
-            table.insert(_msg, { " " .. part .. " ", "DiagnosticVirtualTextInfo" });
-            table.insert(_msg, { " → ", "Comment" });
+        for _, part in ipairs(path_parts) do
+          table.insert(_msg, { " " .. part .. " ", "DiagnosticVirtualTextInfo" });
+          table.insert(_msg, { " → ", "Comment" });
         end
 
         --- Highlight the last segment in ERROR since that's
@@ -56,7 +56,7 @@ function utils.validate(path, tbl, source)
         table.insert(_msg, { " Unexpected field in configuration!", "Comment" })
 
         vim.api.nvim_echo(_msg, true, {
-            verbose = false
+          verbose = false
         })
       else
         vim.notify_once("[blink.cmp]: " .. new_path .. " → " .. k .. ": Unexpected field in configuration!", vim.log.levels.WARN, {});

--- a/lua/blink/cmp/config/utils.lua
+++ b/lua/blink/cmp/config/utils.lua
@@ -35,33 +35,33 @@ function utils.validate(path, tbl, source)
   -- check for erroneous fields
   for k, _ in pairs(source) do
     if tbl[k] == nil then
-		---@type string Use `→` to make each part distinct. `.` may confuse non-programmer users.
-		local new_path = string.gsub(path, "%.", " → ");
+      ---@type string Use `→` to make each part distinct. `.` may confuse non-programmer users.
+      local new_path = string.gsub(path, "%.", " → ");
 
-		if vim.api.nvim_echo then
-			local path_parts = vim.split(path, ".", { plain = true });
-			local _msg = {
-				{ " blink.cmp ", "DiagnosticVirtualTextWarn" },
-				{ ": ", "Comment" }
-			};
+      if vim.api.nvim_echo then
+        local path_parts = vim.split(path, ".", { plain = true });
+        local _msg = {
+            { " blink.cmp ", "DiagnosticVirtualTextWarn" },
+            { ": ", "Comment" }
+        };
 
-			for p, part in ipairs(path_parts) do
-				table.insert(_msg, { " " .. part .. " ", "DiagnosticVirtualTextInfo" });
-				table.insert(_msg, { " → ", "Comment" });
-			end
+        for p, part in ipairs(path_parts) do
+            table.insert(_msg, { " " .. part .. " ", "DiagnosticVirtualTextInfo" });
+            table.insert(_msg, { " → ", "Comment" });
+        end
 
-			--- Highlight the last segment in ERROR since that's
-			--- where the issue lies.
-			table.insert(_msg, { " " .. k .. " ", "DiagnosticVirtualTextError" })
-			table.insert(_msg, { " Unexpected field in configuration!", "Comment" })
+        --- Highlight the last segment in ERROR since that's
+        --- where the issue lies.
+        table.insert(_msg, { " " .. k .. " ", "DiagnosticVirtualTextError" })
+        table.insert(_msg, { " Unexpected field in configuration!", "Comment" })
 
-			vim.api.nvim_echo(_msg, true, {
-				verbose = false
-			})
-		else
-			vim.notify_once("[blink.cmp]: " .. new_path .. " → " .. k .. ": Unexpected field in configuration!", vim.log.levels.WARN, {});
-		end
-	end
+        vim.api.nvim_echo(_msg, true, {
+            verbose = false
+        })
+      else
+        vim.notify_once("[blink.cmp]: " .. new_path .. " → " .. k .. ": Unexpected field in configuration!", vim.log.levels.WARN, {});
+      end
+    end
   end
 end
 

--- a/lua/blink/cmp/config/utils.lua
+++ b/lua/blink/cmp/config/utils.lua
@@ -55,9 +55,23 @@ function utils.validate(path, tbl, source)
         table.insert(_msg, { ' ' .. k .. ' ', 'DiagnosticVirtualTextError' })
         table.insert(_msg, { ' Unexpected field in configuration!', 'Comment' })
 
-        vim.api.nvim_echo(_msg, true, {
-          verbose = false,
-        })
+        if package.loaded['noice'] then
+          --- BUG, `vim.ui_attach()` can't open windows
+          --- when starting Neovim.
+          --- Delay the message.
+          vim.defer_fn(
+            function()
+              vim.api.nvim_echo(_msg, true, {
+                verbose = false,
+              })
+            end,
+            200
+          )
+        else
+          vim.api.nvim_echo(_msg, true, {
+            verbose = false,
+          })
+        end
       else
         vim.notify_once(
           '[blink.cmp]: ' .. new_path .. ' → ' .. k .. ': Unexpected field in configuration!',

--- a/lua/blink/cmp/config/utils.lua
+++ b/lua/blink/cmp/config/utils.lua
@@ -35,23 +35,21 @@ function utils.validate(path, tbl, source)
   -- check for erroneous fields
   for k, _ in pairs(source) do
     if tbl[k] == nil then
-      if vim.api.nvim_echo then
-        ---@type string[]
-        local path_parts = vim.split(path, '.', { plain = true })
-        local msg = {}
+      ---@type string[]
+      local path_parts = vim.split(path, '.', { plain = true })
+      local msg = {}
 
-        for _, part in ipairs(path_parts) do
-          table.insert(msg, { ' ' .. part .. ' ', 'DiagnosticVirtualTextInfo' })
-          table.insert(msg, { ' → ' })
-        end
-
-        --- Highlight the last segment in ERROR since that's
-        --- where the issue lies.
-        table.insert(msg, { ' ' .. k .. ' ', 'DiagnosticVirtualTextError' })
-        table.insert(msg, { ' Unexpected field in configuration!' })
-
-        require('blink.cmp.lib.utils').notify(msg)
+      for _, part in ipairs(path_parts) do
+        table.insert(msg, { ' ' .. part .. ' ', 'DiagnosticVirtualTextInfo' })
+        table.insert(msg, { ' → ' })
       end
+
+      --- Highlight the last segment in ERROR since that's
+      --- where the issue lies.
+      table.insert(msg, { ' ' .. k .. ' ', 'DiagnosticVirtualTextError' })
+      table.insert(msg, { ' Unexpected field in configuration!' })
+
+      require('blink.cmp.lib.utils').notify(msg)
     end
   end
 end

--- a/lua/blink/cmp/fuzzy/download/init.lua
+++ b/lua/blink/cmp/fuzzy/download/init.lua
@@ -41,32 +41,8 @@ function download.ensure_downloaded(callback)
           { 'fuzzy matching library', 'DiagnosticInfo' },
         })
 
-        -- downloading enabled but not on a git tag, error
-        if download_config.download and target_git_tag == nil then
-          if target_git_tag == nil then
-            utils.notify({
-              { "Couldn't download the updated " },
-              { 'fuzzy matching library', 'DiagnosticInfo' },
-              { ' due to not being on a ' },
-              { 'git tag', 'DiagnosticInfo' },
-              { '. Try building from source via ' },
-              { " build = 'cargo build --release' ", 'DiagnosticVirtualTextInfo' },
-              { ' in your lazy.nvim spec and re-installing (requires Rust nightly), or switch to a ' },
-              { 'git tag', 'DiagnosticInfo' },
-              { ' via ' },
-              { " version = '1.*' ", 'DiagnosticVirtualTextInfo' },
-              { ' in your lazy.nvim spec. Or ignore this error by enabling ' },
-              { 'fuzzy.prebuilt_binaries.', 'DiagnosticInfo' },
-              { 'ignore_version_mismatch', 'DiagnosticWarn' },
-              { '. Or force a specific version via ' },
-              { 'fuzzy.prebuilt_binaries.', 'DiagnosticInfo' },
-              { 'force_version', 'DiagnosticWarn' },
-            })
-            return false
-          end
-
         -- downloading is disabled, error
-        else
+        if not download_config.download then
           utils.notify({
             { "Couldn't update fuzzy matching library due to github downloads being disabled." },
             { ' Try setting ' },
@@ -75,6 +51,28 @@ function download.ensure_downloaded(callback)
             { 'fuzzy.prebuilt_binaries.', 'DiagnosticInfo' },
             { 'ignore_version_mismatch', 'DiagnosticWarn' },
             { ' or set ' },
+            { 'fuzzy.prebuilt_binaries.', 'DiagnosticInfo' },
+            { 'force_version', 'DiagnosticWarn' },
+          })
+          return false
+
+        -- downloading enabled but not on a git tag, error
+        elseif target_git_tag == nil then
+          utils.notify({
+            { "Couldn't download the updated " },
+            { 'fuzzy matching library', 'DiagnosticInfo' },
+            { ' due to not being on a ' },
+            { 'git tag', 'DiagnosticInfo' },
+            { '. Try building from source via ' },
+            { " build = 'cargo build --release' ", 'DiagnosticVirtualTextInfo' },
+            { ' in your lazy.nvim spec and re-installing (requires Rust nightly), or switch to a ' },
+            { 'git tag', 'DiagnosticInfo' },
+            { ' via ' },
+            { " version = '1.*' ", 'DiagnosticVirtualTextInfo' },
+            { ' in your lazy.nvim spec. Or ignore this error by enabling ' },
+            { 'fuzzy.prebuilt_binaries.', 'DiagnosticInfo' },
+            { 'ignore_version_mismatch', 'DiagnosticWarn' },
+            { '. Or force a specific version via ' },
             { 'fuzzy.prebuilt_binaries.', 'DiagnosticInfo' },
             { 'force_version', 'DiagnosticWarn' },
           })

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -20,7 +20,7 @@ function cmp.setup(opts)
   config.merge_with(opts)
 
   require('blink.cmp.fuzzy.download').ensure_downloaded(function(err, fuzzy_implementation)
-    if err then return vim.notify(err, vim.log.levels.ERROR) end
+    if err then error(err) end
     require('blink.cmp.fuzzy').set_implementation(fuzzy_implementation)
 
     -- setup highlights, keymap, completion, commands and signature help

--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -163,4 +163,42 @@ function utils.with_no_autocmds(cb)
   return result_or_err
 end
 
+---@type boolean Have we passed UIEnter?
+local _ui_entered = vim.v.vim_did_enter == 1 -- technically for VimEnter, but should be good enough for when we're lazy loaded
+---@type function[] List of notifications.
+local _notification_queue = {}
+
+--- Fancy notification wrapper.
+--- @param msg [string, string?][]
+--- @param lvl? number
+function utils.notify(msg, lvl)
+  local header_hl = 'DiagnosticVirtualTextWarn'
+  if lvl == vim.log.levels.ERROR then
+    header_hl = 'DiagnosticVirtualTextError'
+  elseif lvl == vim.log.levels.INFO then
+    header_hl = 'DiagnosticVirtualTextInfo'
+  end
+
+  table.insert(msg, 1, { ' blink.cmp ', header_hl })
+  table.insert(msg, 2, { ' ' })
+
+  if _ui_entered then
+    -- After UIEnter emit message immediately
+    vim.api.nvim_echo(msg, true, { err = true, verbose = false })
+  else
+    -- Queue notification for the UIEnter event.
+    table.insert(_notification_queue, function() vim.api.nvim_echo(msg, true, { verbose = false }) end)
+  end
+end
+
+vim.api.nvim_create_autocmd('UIEnter', {
+  callback = function()
+    _ui_entered = true
+
+    for _, fn in ipairs(_notification_queue) do
+      pcall(fn)
+    end
+  end,
+})
+
 return utils


### PR DESCRIPTION
## Issue

The default error message is way too big and it's kinda hard to find the *actual* error part.

## Solution

Use `nvim_echo()` instead of `error()`.

> As this will most likely be run only once we shouldn't need `notify_once()`.

## Images

A few images of the new error is given below,

![Screenshot_2025-03-28-14-52-22-110_com termux-edit](https://github.com/user-attachments/assets/bd49e514-4ba9-4093-8186-4a1dfd501695)
<sup>Uses `nvim_echo()`</sup>
![Screenshot_2025-03-28-14-52-45-957_com termux-edit](https://github.com/user-attachments/assets/acdebd73-bb1d-4435-b697-7d1ae1290933)
<sup>Fallback to `vim.notify()` when the other function isn't available</sup>

Ref: #973