### PR TITLE
docs: add recipe for disabling completion with bang in command mode

### DIFF
--- a/doc/recipes.md
+++ b/doc/recipes.md
@@ -29,6 +29,32 @@ sources = {
 }
 ```
 
+### Disable completion source when command mode contains a bang
+
+This configuration handles the situation when a "bang" (exclamation mark) is entered in command mode. Typically, if the auto-show menu is active (for example, when running commands like `!sort` or `!uniq`), sourcing the command will eventually fail and hang the program. To prevent this, the snippet disables the completion source when a bang is detected in the command line.
+
+```lua
+sources = {
+  providers = {
+    cmdline = {
+      sources = function()
+        local type = vim.fn.getcmdtype()
+        -- Search forward and backward
+        if type == '/' or type == '?' then return { 'buffer' } end
+        -- Commands
+        if type == ':' or type == '@' then
+          if vim.fn.getcmdline():match("!") ~= nil then
+            return {}
+          end
+
+          return 'cmdline'
+        end
+        return {}
+      end,
+    }
+  }
+```
+
 ### Emacs behavior
 
 Full discussion: https://github.com/Saghen/blink.cmp/issues/1367


### PR DESCRIPTION
Thanks for the great plugin.

I ran into some issue where when I place a bang trying to do common `!sort` `!uniq` for some lines the autocomplete would hang and eventually failed to fetch the completion source. I added a video here where I interrupted it but typically it would take longer to fail. Could be due to me being WSL and containing windows directories in the `$PATH` but nonetheless this recipe should help!

[NVIDIA_Overlay_2025-03-29_01-56-04.webm](https://github.com/user-attachments/assets/82486d72-6b4d-4953-89ab-98c0ff8cd773)

Edit: removed the unintended formatter changes from other section of the `.md` in the force pushes