### PR TITLE
docs: add small recipe on how to exclude specific completion type

### DIFF
--- a/doc/recipes.md
+++ b/doc/recipes.md
@@ -186,9 +186,9 @@ fuzzy = {
 }
 ```
 
-### Exclude constants from autocomplete
+### Exclude keywords/constants from autocomplete
 
-Removes language constants (if, else, while, etc.) provided by the language server from completion results. Useful if you prefer to use builtin or custom snippets for such constructs.
+Removes language keywords/constants (if, else, while, etc.) provided by the language server from completion results. Useful if you prefer to use builtin or custom snippets for such constructs.
 
 ```lua
 sources = {
@@ -198,7 +198,7 @@ sources = {
       module = 'blink.cmp.sources.lsp',
       transform_items = function(_, items)
         return vim.tbl_filter(function(item)
-          return item.kind ~= vim.lsp.protocol.CompletionItemKind.Keyword
+          return item.kind ~= require('blink.cmp.types').CompletionItemKind.Keyword
         end, items)
       end,
     },

--- a/doc/recipes.md
+++ b/doc/recipes.md
@@ -186,6 +186,26 @@ fuzzy = {
 }
 ```
 
+### Exclude constants from autocomplete
+
+Removes language constants (if, else, while, etc.) provided by the language server from completion results. Useful if you prefer to use builtin or custom snippets for such constructs.
+
+```lua
+sources = {
+  providers = {
+    lsp = {
+      name = 'LSP',
+      module = 'blink.cmp.sources.lsp',
+      transform_items = function(_, items)
+        return vim.tbl_filter(function(item)
+          return item.kind ~= 14
+        end, items)
+      end,
+    },
+  },
+}
+```
+
 ## Completion menu drawing
 
 ### `mini.icons`

--- a/doc/recipes.md
+++ b/doc/recipes.md
@@ -198,7 +198,7 @@ sources = {
       module = 'blink.cmp.sources.lsp',
       transform_items = function(_, items)
         return vim.tbl_filter(function(item)
-          return item.kind ~= 14
+          return item.kind ~= vim.lsp.protocol.CompletionItemKind.Keyword
         end, items)
       end,
     },


### PR DESCRIPTION
Thanks for the great plugin! It feels so much easier and intuitive to customize compared to `nvim-cmp`.

This PR adds a small recipe to exclude short language constants (if, else, while, etc.) from language server autocompletion results. For me, these completions appear after typing just one or two letters, creating unnecessary noise. I've found it's cleaner and simpler to use snippets or manually type these short keywords instead.

Hopefully others find this useful too)

