### PR TITLE
ci(docs): add path filters to deploy-docs workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - doc/**
+      - .github/workflows/docs.yaml
 
 jobs:
   deploy-docs:


### PR DESCRIPTION
With this commit, an additional check is ran on whether files in 'doc' directory or 'docs.yaml' workflow file are modified.

This prevents documentation website from being updated when there are no changes in documentation nor changes in deployment settings.