### PR TITLE
feat: use non-deprecated LSP methods when supported

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+  "runtime": {
+    "version": "LuaJIT"
+  },
+  "workspace": {
+    "library": ["lua", "$VIMRUNTIME"],
+    "checkThirdParty": false
+  }
+}

--- a/lua/blink/cmp/sources/lsp/completion.lua
+++ b/lua/blink/cmp/sources/lsp/completion.lua
@@ -14,13 +14,13 @@ local function request(context, client)
     }
     if context.trigger.kind == 'trigger_character' then params.context.triggerCharacter = context.trigger.character end
 
-    local _, request_id = client.request(
+    local _, request_id = client:request(
       'textDocument/completion',
       params,
       function(err, result) resolve({ err = err, result = result }) end
     )
     return function()
-      if request_id ~= nil then client.cancel_request(request_id) end
+      if request_id ~= nil then client:cancel_request(request_id) end
     end
   end)
 end


### PR DESCRIPTION
Gets rid of the deprecation warnings on nightly Neovim. The approach in this PR is inspired by `fzf-lua`'s implementation: https://github.com/ibhagwan/fzf-lua/blob/caee13203d6143d691710c34f85ad6441fe3f535/lua/fzf-lua/utils.lua#L1374