### PR TITLE
doc: include proxy settings in Fuzzy reference

### DIFF
--- a/doc/configuration/reference.md
+++ b/doc/configuration/reference.md
@@ -422,7 +422,16 @@ fuzzy = {
     force_system_triple = nil,
 
     -- Extra arguments that will be passed to curl like { 'curl', ..extra_curl_args, ..built_in_args }
-    extra_curl_args = {}
+    extra_curl_args = {},
+
+    proxy = {
+
+        -- When downloading a prebuilt binary, use the HTTPS_PROXY environment variable
+        from_env = true,
+
+        -- When downloading a prebuilt binary, use this proxy URL. This will ignore the HTTPS_PROXY environment variable
+        url = nil,
+    },
   },
 }
 ```

--- a/doc/configuration/reference.md
+++ b/doc/configuration/reference.md
@@ -425,7 +425,6 @@ fuzzy = {
     extra_curl_args = {},
 
     proxy = {
-
         -- When downloading a prebuilt binary, use the HTTPS_PROXY environment variable
         from_env = true,
 


### PR DESCRIPTION
PR #1030 added proxy support when downloading prebuilt fuzzy binaries.

Adding the changes to the reference Fuzzy docs as well.