### PR TITLE
fix(docs): show_documentation crashing when documentation is nil

### DIFF
--- a/lua/blink/cmp/lib/window/docs.lua
+++ b/lua/blink/cmp/lib/window/docs.lua
@@ -29,7 +29,7 @@ function docs.render_detail_and_documentation(opts)
   local doc_lines = {}
   if opts.documentation ~= nil then
     local doc = type(opts.documentation) == 'string' and opts.documentation or opts.documentation.value
-    doc_lines = docs.split_lines(doc)
+    if doc then doc_lines = docs.split_lines(doc) end
   end
 
   ---@type string[]


### PR DESCRIPTION
Issue
=====

When a completion item's documentation is nil, invoking the `show_documentation` action shows an error message:

```lua
...nvim/plugged/blink.cmp/lua/blink/cmp/lib/window/docs.lua:136: attempt to index local 'text' (a nil value)
```

![image](https://github.com/user-attachments/assets/bd46750a-4cfe-4f36-848f-b25008d06c57)


This was reported here:
https://github.com/mikavilpas/blink-ripgrep.nvim/issues/185#issuecomment-2764804327

A reproduction setup:

<details><summary>Details</summary>
<p>

```lua
vim.env.LAZY_STDPATH = ".repro"
load(
  vim.fn.system(
    "curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"
  )
)()

local plugins = {
  {
    "saghen/blink.cmp",
    commit = "49f211f",
    dependencies = { { "mikavilpas/blink-ripgrep.nvim", commit = "d4af981" } },
    opts = {
      keymap = {
        preset = "super-tab",
        ["<C-k>"] = { "show_documentation" },
      },
      sources = {
        default = { "lsp", "path", "buffer", "ripgrep" },
        providers = {
          ripgrep = {
            name = "Ripgrep",
            module = "blink-ripgrep",
            opts = {
              future_features = { issue185_workaround = true },
            },
            transform_items = function(_, items)
              for _, item in ipairs(items) do
                item.labelDetails = {
                  description = "(rg)",
                }
              end
              return items
            end,
          },
        },
      },
      cmdline = { enabled = false },
    },
  },
}

require("lazy.minit").repro({ spec = plugins })
```

how to run it:
- save that as `minimal.lua`
- run `rm  -rf .repro/ && nvim --clean -u minimal.lua`
- start writing a completion, for example input "test" in the blink.cmp repo
- hover a blink-ripgrep completion
- press `<c-k>` to display documentation
- an error is displayed

</p>
</details> 

https://github.com/mikavilpas/blink-ripgrep.nvim/issues/185#issuecomment-2765621509

Solution
========

Avoid the error by checking if `opts.documentation` is nil before processing it.