### PR TITLE
fix(snippet): keep luasnip item in completion list on exact match

### DIFF
--- a/lua/blink/cmp/config/snippets.lua
+++ b/lua/blink/cmp/config/snippets.lua
@@ -35,7 +35,6 @@ local snippets = {
       default = function(filter) return vim.snippet.active(filter) end,
       luasnip = function(filter)
         local ls = require('luasnip')
-        if ls.expand_or_jumpable() then return true end
         if filter and filter.direction then return ls.jumpable(filter.direction) end
         return ls.in_snippet()
       end,


### PR DESCRIPTION
This remove a useless condition to guess if a snippet is in an active
state.

Fix #1553
