### PR TITLE
fix(trigger): adjust query bounds logic to handle 0-indexed cursor

### DIFF
--- a/lua/blink/cmp/completion/trigger/context.lua
+++ b/lua/blink/cmp/completion/trigger/context.lua
@@ -81,7 +81,7 @@ function context:within_query_bounds(cursor)
   col = col + 1 -- Convert from 0-indexed to 1-indexed
 
   local bounds = self.bounds
-  return row == bounds.line_number and col >= bounds.start_col and col <= (bounds.start_col + bounds.length)
+  return row == bounds.line_number and col > bounds.start_col and col <= (bounds.start_col + bounds.length)
 end
 
 function context.get_mode()


### PR DESCRIPTION
Correct the comparison logic in `within_query_bounds` by ensuring the
start column check uses `>` instead of `>=`. This resolves an off-by-one
error introduced in commit 60a571e2155c18d18a6021ad4f89709d46e8445a when
converting the cursor column from 0-indexed to 1-indexed.

Fix #1500
Related #1548 
