### PR TITLE
docs: clarify the `async` source provider option

### DIFF
--- a/doc/blink-cmp.txt
+++ b/doc/blink-cmp.txt
@@ -1688,7 +1688,7 @@ to the source directly, and will vary by source.
       --- NOTE: All of these options may be functions to get dynamic behavior
       --- See the type definitions for more information
       enabled = true, -- Whether or not to enable the provider
-      async = false, -- Whether we should wait for the provider to return before showing the completions
+      async = false, -- Whether we should show the completions before this provider returns, without waiting for it
       timeout_ms = 2000, -- How long to wait for the provider to return before showing completions and treating it as asynchronous
       transform_items = nil, -- Function to transform the items before they're returned
       should_show_items = true, -- Whether or not to show the items
@@ -2241,7 +2241,7 @@ PROVIDERS
         --- See the type definitions for more information
         name = nil, -- Defaults to the id ("lsp" in this case) capitalized when not set
         enabled = true, -- Whether or not to enable the provider
-        async = false, -- Whether we should wait for the provider to return before showing the completions
+	async = false, -- Whether we should show the completions before this provider returns, without waiting for it
         timeout_ms = 2000, -- How long to wait for the provider to return before showing completions and treating it as asynchronous
         transform_items = nil, -- Function to transform the items before they're returned
         should_show_items = true, -- Whether or not to show the items

--- a/doc/configuration/reference.md
+++ b/doc/configuration/reference.md
@@ -474,7 +474,7 @@ sources.providers = {
     --- See the type definitions for more information
     name = nil, -- Defaults to the id ("lsp" in this case) capitalized when not set
     enabled = true, -- Whether or not to enable the provider
-    async = false, -- Whether we should wait for the provider to return before showing the completions
+    async = false, -- Whether we should show the completions before this provider returns, without waiting for it
     timeout_ms = 2000, -- How long to wait for the provider to return before showing completions and treating it as asynchronous
     transform_items = nil, -- Function to transform the items before they're returned
     should_show_items = true, -- Whether or not to show the items

--- a/doc/configuration/sources.md
+++ b/doc/configuration/sources.md
@@ -40,7 +40,7 @@ sources.providers.lsp = {
   --- NOTE: All of these options may be functions to get dynamic behavior
   --- See the type definitions for more information
   enabled = true, -- Whether or not to enable the provider
-  async = false, -- Whether we should wait for the provider to return before showing the completions
+  async = false, -- Whether we should show the completions before this provider returns, without waiting for it
   timeout_ms = 2000, -- How long to wait for the provider to return before showing completions and treating it as asynchronous
   transform_items = nil, -- Function to transform the items before they're returned
   should_show_items = true, -- Whether or not to show the items

--- a/lua/blink/cmp/config/sources.lua
+++ b/lua/blink/cmp/config/sources.lua
@@ -27,7 +27,7 @@
 --- @field name? string
 --- @field enabled? boolean | fun(): boolean Whether or not to enable the provider
 --- @field opts? table
---- @field async? boolean | fun(ctx: blink.cmp.Context): boolean Whether blink should wait for the source to return before showing the completions
+--- @field async? boolean | fun(ctx: blink.cmp.Context): boolean Whether we should show the completions before this provider returns, without waiting for it
 --- @field timeout_ms? number | fun(ctx: blink.cmp.Context): number How long to wait for the provider to return before showing completions and treating it as asynchronous
 --- @field transform_items? fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): blink.cmp.CompletionItem[] Function to transform the items before they're returned
 --- @field should_show_items? boolean | fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): boolean Whether or not to show the items


### PR DESCRIPTION
The old description was opposite to the actual meaning.