### PR TITLE
chore: allow controlling highlight priority of the cursor line

### DIFF
--- a/lua/blink/cmp/config/appearance.lua
+++ b/lua/blink/cmp/config/appearance.lua
@@ -1,6 +1,7 @@
 --- @class (exact) blink.cmp.AppearanceConfig
 --- @field highlight_ns number
 --- @field use_nvim_cmp_as_default boolean Sets the fallback highlight groups to nvim-cmp's highlight groups. Useful for when your theme doesn't support blink.cmp, will be removed in a future release.
+--- @field cursor_line_highlight_priority number Sets the priority on the cursor line's highlight group. Useful for drawing it under background highlights of your components, like kind icons, by setting priority to 0.
 --- @field nerd_font_variant 'mono' | 'normal' Set to 'mono' for 'Nerd Font Mono' or 'normal' for 'Nerd Font'. Adjusts spacing to ensure icons are aligned
 --- @field kind_icons table<string, string>
 
@@ -10,6 +11,7 @@ local appearance = {
   default = {
     highlight_ns = vim.api.nvim_create_namespace('blink_cmp'),
     use_nvim_cmp_as_default = false,
+    cursor_line_highlight_priority = 10000,
     nerd_font_variant = 'mono',
     kind_icons = {
       Text = '󰉿',
@@ -49,6 +51,7 @@ local appearance = {
 function appearance.validate(config)
   validate('appearance', {
     highlight_ns = { config.highlight_ns, 'number' },
+    cursor_line_highlight_priority = { config.cursor_line_highlight_priority, 'number' },
     use_nvim_cmp_as_default = { config.use_nvim_cmp_as_default, 'boolean' },
     nerd_font_variant = { config.nerd_font_variant, 'string' },
     kind_icons = { config.kind_icons, 'table' },

--- a/lua/blink/cmp/lib/window/cursor_line.lua
+++ b/lua/blink/cmp/lib/window/cursor_line.lua
@@ -49,7 +49,7 @@ function cursor_line:update(win)
         hl_group = hack_hl,
         hl_mode = 'combine',
         ephemeral = true,
-        priority = 10000,
+        priority = config.appearance.cursor_line_highlight_priority,
       })
     end,
   })


### PR DESCRIPTION
Right now the cursor line seems to replace all component highlights, due to that high priority, so a field to control it would be really nice.

Will help out people migrating from company, using background colors on kind icons was pretty common.

<img width="700" alt="Screenshot 2025-04-03 at 19 09 22" src="https://github.com/user-attachments/assets/925d59b9-432b-4292-86eb-a70aa7a0f0ac" />
