### PR TITLE
fix: disable Neovide drawing when setting up dot repeat

### DIFF
--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -16,13 +16,7 @@ function text_edits.apply(text_edit, additional_text_edits)
   if mode == 'default' then
     -- writing to dot repeat may fail in cases like `q:`, which aren't easy to detect
     -- so we ignore the error
-    if config.completion.accept.dot_repeat then
-      -- disable neovide redraw to prevent unwanted cursor movements. Keep it outside of the write_to_dot_repeat
-      -- function to guarantee that the redraw is re-enabled even if the function call fails.
-      if neovide and neovide.disable_redraw then neovide.disable_redraw() end
-      pcall(text_edits.write_to_dot_repeat, text_edit)
-      if neovide and neovide.enable_redraw then neovide.enable_redraw() end
-    end
+    if config.completion.accept.dot_repeat then pcall(text_edits.write_to_dot_repeat, text_edit) end
 
     local all_edits = utils.shallow_copy(additional_text_edits)
     table.insert(all_edits, text_edit)
@@ -357,41 +351,64 @@ function text_edits.write_to_dot_repeat(text_edit)
   )
   local chars_to_insert = text_edit.newText
 
-  utils.with_no_autocmds(function()
-    local curr_win = vim.api.nvim_get_current_win()
+  utils.defer_neovide_redraw(function()
+    utils.with_no_autocmds(function()
+      local curr_win = vim.api.nvim_get_current_win()
 
-    -- create temporary floating window and buffer for writing
-    local buf = get_dot_repeat_buffer()
-    local win = vim.api.nvim_open_win(buf, true, {
-      relative = 'win',
-      win = vim.api.nvim_get_current_win(),
-      width = 1,
-      height = 1,
-      row = 0,
-      col = 0,
-      noautocmd = true,
-    })
-    vim.api.nvim_buf_set_text(0, 0, 0, 0, 0, { '_' .. string.rep('a', chars_to_delete) })
-    vim.api.nvim_win_set_cursor(0, { 1, chars_to_delete + 1 })
+      -- create temporary floating window and buffer for writing
+      local buf = get_dot_repeat_buffer()
+      local win = vim.api.nvim_open_win(buf, true, {
+        relative = 'win',
+        win = vim.api.nvim_get_current_win(),
+        width = 1,
+        height = 1,
+        row = 0,
+        col = 0,
+        noautocmd = true,
+      })
+      vim.api.nvim_buf_set_text(0, 0, 0, 0, 0, { '_' .. string.rep('a', chars_to_delete) })
+      vim.api.nvim_win_set_cursor(0, { 1, chars_to_delete + 1 })
 
-    -- emulate builtin completion (dot repeat)
-    local saved_completeopt = vim.opt.completeopt
-    local saved_shortmess = vim.o.shortmess
-    vim.opt.completeopt = ''
-    if not vim.o.shortmess:match('c') then vim.o.shortmess = vim.o.shortmess .. 'c' end
-    vim.fn.complete(1, { '_' .. chars_to_insert })
-    vim.opt.completeopt = saved_completeopt
-    vim.o.shortmess = saved_shortmess
+      -- emulate builtin completion (dot repeat)
+      local saved_completeopt = vim.opt.completeopt
+      local saved_shortmess = vim.o.shortmess
+      vim.opt.completeopt = ''
+      if not vim.o.shortmess:match('c') then vim.o.shortmess = vim.o.shortmess .. 'c' end
+      vim.fn.complete(1, { '_' .. chars_to_insert })
+      vim.opt.completeopt = saved_completeopt
+      vim.o.shortmess = saved_shortmess
 
-    -- close window and focus original window
-    vim.api.nvim_win_close(win, true)
-    vim.api.nvim_set_current_win(curr_win)
+      -- close window and focus original window
+      vim.api.nvim_win_close(win, true)
+      vim.api.nvim_set_current_win(curr_win)
 
-    -- exit completion mode
-    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<Plug>BlinkCmpDotRepeatHack', true, true, true), 'in', false)
-    -- make sure that the screen is updated and the mouse cursor returned to the right position before re-enabling redrawing
-    vim.api.nvim__redraw({ cursor = true, flush = true })
+      -- exit completion mode
+      vim.api.nvim_feedkeys(
+        vim.api.nvim_replace_termcodes('<Plug>BlinkCmpDotRepeatHack', true, true, true),
+        'in',
+        false
+      )
+    end)
   end)
+end
+
+--- Disable redraw in neovide for the duration of the callback
+--- Useful for preventing the cursor from jumping to the top left during `vim.fn.complete`
+--- @generic T
+--- @param fn fun(): T
+--- @return T
+function utils.defer_neovide_redraw(fn)
+  if neovide and neovide.disable_redraw then neovide.disable_redraw() end
+
+  local success, result = pcall(fn)
+
+  -- make sure that the screen is updated and the mouse cursor returned to the right position before re-enabling redrawing
+  pcall(vim.api.nvim__redraw, { cursor = true, flush = true })
+
+  if neovide and neovide.enable_redraw then neovide.enable_redraw() end
+
+  if not success then error(result) end
+  return result
 end
 
 --- Moves the cursor while preserving dot repeat


### PR DESCRIPTION
Disable Neovide redrawing during dot repeat setup to fix https://github.com/Saghen/blink.cmp/issues/1247

Works in conjunction with https://github.com/neovide/neovide/pull/3097, which will be included in the Neovide 0.15.1 release.