### PR TITLE
ci(nix): add path filters to build workflow

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -2,7 +2,29 @@ name: Test Nix
 
 on:
   push:
+    paths:
+      - "**/*.lua"
+      - "**/*.rs"
+      - ".cargo/**"
+      - Cargo.lock
+      - Cargo.toml
+      - Cross.toml
+      - rust-toolchain.toml
+      - flake.lock
+      - flake.nix
+      - .github/workflows/nix.yaml
   pull_request:
+    paths:
+      - "**/*.lua"
+      - "**/*.rs"
+      - ".cargo/**"
+      - Cargo.lock
+      - Cargo.toml
+      - Cross.toml
+      - rust-toolchain.toml
+      - flake.lock
+      - flake.nix
+      - .github/workflows/nix.yaml
 
 jobs:
   build:


### PR DESCRIPTION
With this commit, an additional check is ran on whether build files, source files and 'nix.yaml' workflow file are modified.

This prevents the slow nix build workflow from being ran when non-build files, non-source files and non-nix workflow files are updated such as documentation files.