### PR TITLE
ci(panvimdoc): do not run panvimdoc workflow in forks

### DIFF
--- a/.github/workflows/panvimdoc.yaml
+++ b/.github/workflows/panvimdoc.yaml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   docs:
+    if: github.repository == 'Saghen/blink.cmp'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
When syncing changes to the forked repository, the panvimdoc workflow will always run when a file in doc directory and/or 'panvimdoc.yaml' workflow file is modified.

This generates an additional "docs: update vimdocs" commit which has to be removed or else it will be included in pull requests.

With this commit, the panvimdoc workflow will check if the current github repository is the original "upstream" repository before running the workflow.