### PR TITLE
fix: disable kind_resolution by default for cpp filetype

### DIFF
--- a/doc/blink-cmp.txt
+++ b/doc/blink-cmp.txt
@@ -1979,7 +1979,7 @@ COMPLETION ACCEPT
         -- Synchronously use the kind of the item to determine if brackets should be added
         kind_resolution = {
           enabled = true,
-          blocked_filetypes = { 'typescriptreact', 'javascriptreact', 'vue' },
+          blocked_filetypes = { 'cpp', 'typescriptreact', 'javascriptreact', 'vue', 'rust' },
         },
         -- Asynchronously use semantic token to determine if brackets should be added
         semantic_token_resolution = {

--- a/doc/configuration/reference.md
+++ b/doc/configuration/reference.md
@@ -133,11 +133,12 @@ completion.accept = {
     -- Default brackets to use for unknown languages
     default_brackets = { '(', ')' },
     -- Overrides the default blocked filetypes
+    -- See: https://github.com/Saghen/blink.cmp/blob/main/lua/blink/cmp/completion/brackets/config.lua#L5-L9
     override_brackets_for_filetypes = {},
     -- Synchronously use the kind of the item to determine if brackets should be added
     kind_resolution = {
       enabled = true,
-      blocked_filetypes = { 'cpp', 'typescriptreact', 'javascriptreact', 'vue', 'rust' },
+      blocked_filetypes = { 'typescriptreact', 'javascriptreact', 'vue' },
     },
     -- Asynchronously use semantic token to determine if brackets should be added
     semantic_token_resolution = {

--- a/doc/configuration/reference.md
+++ b/doc/configuration/reference.md
@@ -137,7 +137,7 @@ completion.accept = {
     -- Synchronously use the kind of the item to determine if brackets should be added
     kind_resolution = {
       enabled = true,
-      blocked_filetypes = { 'typescriptreact', 'javascriptreact', 'vue' },
+      blocked_filetypes = { 'cpp', 'typescriptreact', 'javascriptreact', 'vue', 'rust' },
     },
     -- Asynchronously use semantic token to determine if brackets should be added
     semantic_token_resolution = {

--- a/lua/blink/cmp/completion/brackets/config.lua
+++ b/lua/blink/cmp/completion/brackets/config.lua
@@ -3,7 +3,7 @@ return {
   blocked_filetypes = {
     'sql', 'ruby', 'perl', 'lisp', 'scheme', 'clojure',
     'prolog', 'vb', 'elixir', 'smalltalk', 'applescript',
-    'elm', 'rust', 'nu'
+    'elm', 'rust', 'nu', 'cpp'
   },
   per_filetype = {
     -- languages with a space

--- a/lua/blink/cmp/config/completion/accept.lua
+++ b/lua/blink/cmp/config/completion/accept.lua
@@ -37,7 +37,7 @@ local accept = {
       blocked_filetypes = {},
       kind_resolution = {
         enabled = true,
-        blocked_filetypes = { 'cpp', 'typescriptreact', 'javascriptreact', 'vue', 'rust' },
+        blocked_filetypes = { 'typescriptreact', 'javascriptreact', 'vue' },
       },
       semantic_token_resolution = {
         enabled = true,

--- a/lua/blink/cmp/config/completion/accept.lua
+++ b/lua/blink/cmp/config/completion/accept.lua
@@ -37,7 +37,7 @@ local accept = {
       blocked_filetypes = {},
       kind_resolution = {
         enabled = true,
-        blocked_filetypes = { 'typescriptreact', 'javascriptreact', 'vue', 'rust' },
+        blocked_filetypes = { 'cpp', 'typescriptreact', 'javascriptreact', 'vue', 'rust' },
       },
       semantic_token_resolution = {
         enabled = true,


### PR DESCRIPTION
For `auto_brackets.kind_resolution`, add `cpp` to the `blocked_filetypes` list. This is necessary to ensure appropriate completion behavior, as there are some completion contexts (such as [using-declarations](https://en.cppreference.com/w/cpp/language/using_declaration)) where it is not appropriate to insert parenthesis when completing a function name.

Also, update corresponding documentation to make it consistent with `accept.lua`