### PR TITLE
Update preview.lua: Protect against non-empty empty textEdit

### DIFF
--- a/lua/blink/cmp/completion/accept/preview.lua
+++ b/lua/blink/cmp/completion/accept/preview.lua
@@ -12,7 +12,7 @@ local function preview(item)
   end
 
   -- only keep the first line.
-  text_edit.newText = vim.split(text_edit.newText, '\n', { plain = true, trimempty = true })[1] or "" -- vim.split returns an empty list if the string was empty, making [1] nil
+  text_edit.newText = vim.split(text_edit.newText, '\n', { plain = true, trimempty = true })[1] or '' -- vim.split returns an empty list if the string was empty, making [1] nil
 
   local original_cursor = vim.api.nvim_win_get_cursor(0)
   local cursor_pos = {

--- a/lua/blink/cmp/completion/accept/preview.lua
+++ b/lua/blink/cmp/completion/accept/preview.lua
@@ -11,8 +11,8 @@ local function preview(item)
     text_edit.newText = get_prefix_before_brackets_and_quotes(snippet)
   end
 
-  -- only keep the first line
-  text_edit.newText = vim.split(text_edit.newText, '\n', { plain = true, trimempty = true })[1]
+  -- only keep the first line.
+  text_edit.newText = vim.split(text_edit.newText, '\n', { plain = true, trimempty = true })[1] or "" -- vim.split returns an empty list if the string was empty, making [1] nil
 
   local original_cursor = vim.api.nvim_win_get_cursor(0)
   local cursor_pos = {


### PR DESCRIPTION
In a nutshell, language servers may specify an non-empty textEdit, that doesnt have any content (`newText` == `""` and `range.start` == `range.end`). 

This edge-case was previously unhandled. Now it is.