### PR TITLE
fix: avoid undefined highlight group 'CmpGhostText'

### DIFF
--- a/lua/blink/cmp/highlights.lua
+++ b/lua/blink/cmp/highlights.lua
@@ -27,7 +27,7 @@ function highlights.setup()
   set_hl('BlinkCmpScrollBarThumb', { link = 'PmenuThumb' })
   set_hl('BlinkCmpScrollBarGutter', { link = 'PmenuSbar' })
 
-  set_hl('BlinkCmpGhostText', { link = use_nvim_cmp and 'CmpGhostText' or 'NonText' })
+  set_hl('BlinkCmpGhostText', { link = 'NonText' })
 
   set_hl('BlinkCmpMenu', { link = 'Pmenu' })
   set_hl('BlinkCmpMenuBorder', { link = 'Pmenu' })


### PR DESCRIPTION
Careful!! While testing with themes like [`gruvbox`](https://github.com/search?q=repo%3Aellisonleao%2Fgruvbox.nvim+CmpGhostText&type=code) , [`rose-pine`](https://github.com/search?q=repo%3Arose-pine%2Fneovim+CmpGhostText&type=code), and others, I noticed that the `'CmpGhostText'` highlight group is not defined.  
This causes Neovim to render it as `'Cleared'`, which results in the ghost text appearing as plain white text without any highlight.

To avoid this issue, I’ve updated the highlight to always use `'NonText'`.  
I believe ghost text should appear similar to comments or slightly dimmed, and `'NonText'` generally reflects that intention.

If this behavior isn't desirable or doesn't match your expectations, feel free to close the PR.