### PR TITLE
ci(stylua): add path filters to stylua workflow

### DIFF
--- a/.github/workflows/stylua.yaml
+++ b/.github/workflows/stylua.yaml
@@ -7,7 +7,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "**/*.lua"
+      - .stylua.toml
+      - .github/workflows/stylua.yaml
   pull_request:
+    paths:
+      - "**/*.lua"
+      - .stylua.toml
+      - .github/workflows/stylua.yaml
 
 env:
   CLICOLOR: 1


### PR DESCRIPTION
With this commit, an additional check is ran on whether lua files, '.stylua.toml' and 'stylua.yaml' workflow file are modified.

This prevents the stylua workflow from being ran when non-lua, non-stylua config and non-stylua workflow files are updated such as documentation and rust files.