### PR TITLE
ci(stylua): check all lua files

### DIFF
--- a/.github/workflows/stylua.yaml
+++ b/.github/workflows/stylua.yaml
@@ -26,4 +26,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
-          args: --color=always --check lua
+          args: --color=always --check .


### PR DESCRIPTION
Before this commit, the stylua workflow only checks lua files in 'lua/' directory.

With this commit, lua files outside 'lua/' directory such as 'repro.lua' and 'plugin/blink-cmp.lua' are also checked by the stylua workflow.