### PR TITLE
fix: unify and correct source list type

### DIFF
--- a/lua/blink/cmp/config/modes/types.lua
+++ b/lua/blink/cmp/config/modes/types.lua
@@ -1,7 +1,7 @@
 --- @class blink.cmp.ModeConfig
 --- @field enabled? boolean
 --- @field keymap blink.cmp.KeymapConfig
---- @field sources string[] | fun(): string[]
+--- @field sources blink.cmp.SourceList
 --- @field completion? blink.cmp.ModeCompletionConfig
 
 --- @class blink.cmp.ModeCompletionConfig

--- a/lua/blink/cmp/config/sources.lua
+++ b/lua/blink/cmp/config/sources.lua
@@ -14,8 +14,8 @@
 ---     end
 ---   end
 --- ```
---- @field default string[] | fun(): string[]
---- @field per_filetype table<string, string[] | fun(): string[]>
+--- @field default blink.cmp.SourceList
+--- @field per_filetype table<string, blink.cmp.SourceList>
 ---
 --- @field transform_items fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): blink.cmp.CompletionItem[] Function to transform the items before they're returned
 --- @field min_keyword_length number | fun(ctx: blink.cmp.Context): number Minimum number of characters in the keyword to trigger

--- a/lua/blink/cmp/config/types_partial.lua
+++ b/lua/blink/cmp/config/types_partial.lua
@@ -1,4 +1,4 @@
----@alias blink.cmp.SourceList string[] | fun(): string[]
+--- @alias blink.cmp.SourceList string[] | fun(): string[]
 
 --- @class (exact) blink.cmp.Config : blink.cmp.ConfigStrict
 --- @field enabled? fun(): boolean
@@ -85,7 +85,5 @@
 --- @class (exact) blink.cmp.AppearanceConfigPartial : blink.cmp.AppearanceConfig, {}
 
 --- @class (exact) blink.cmp.CmdlineConfigPartial : blink.cmp.CmdlineConfig, {}
---- @field sources? blink.cmp.SourceList
 
 --- @class (exact) blink.cmp.TermConfigPartial : blink.cmp.TermConfig, {}
---- @field sources? blink.cmp.SourceList

--- a/lua/blink/cmp/config/types_partial.lua
+++ b/lua/blink/cmp/config/types_partial.lua
@@ -1,3 +1,5 @@
+---@alias blink.cmp.SourceList string[] | fun(): string[]
+
 --- @class (exact) blink.cmp.Config : blink.cmp.ConfigStrict
 --- @field enabled? fun(): boolean
 --- @field keymap? blink.cmp.KeymapConfig
@@ -83,11 +85,7 @@
 --- @class (exact) blink.cmp.AppearanceConfigPartial : blink.cmp.AppearanceConfig, {}
 
 --- @class (exact) blink.cmp.CmdlineConfigPartial : blink.cmp.CmdlineConfig, {}
---- @field sources? blink.cmp.CmdlineSourceConfigPartial
-
---- @class (exact) blink.cmp.CmdlineSourceConfigPartial : blink.cmp.CmdlineSourceConfig, {}
+--- @field sources? blink.cmp.SourceList
 
 --- @class (exact) blink.cmp.TermConfigPartial : blink.cmp.TermConfig, {}
---- @field sources? blink.cmp.TermSourceConfigPartial
-
---- @class (exact) blink.cmp.TermSourceConfigPartial : blink.cmp.TermSourceConfig, {}
+--- @field sources? blink.cmp.SourceList


### PR DESCRIPTION
the sources type used in the cmdline and term config is not consistent
with that used in the sources config. we unify and correct the types
here since their usage is also unified.
