### PR TITLE
fix(fuzzy): fix misleading conditions for outdated version related logs

### DIFF
--- a/lua/blink/cmp/fuzzy/download/init.lua
+++ b/lua/blink/cmp/fuzzy/download/init.lua
@@ -43,23 +43,21 @@ function download.ensure_downloaded(callback)
           end
         )
 
-        -- downloading enabled but not on a git tag, error
-        if download_config.download and target_git_tag == nil then
-          if target_git_tag == nil then
-            error(
-              "Found an outdated version of the fuzzy matching library, but can't download from github due to not being on a git tag."
-                .. '\n!! FOR DEVELOPERS !!, set `fuzzy.prebuilt_binaries.ignore_version_mismatch = true` in config.'
-                .. '\n!! FOR USERS !!, either run `cargo build --release` via your package manager, switch to a git tag, or set `fuzzy.prebuilt_binaries.force_version` in config.'
-                .. '\nSee the docs for more info.'
-            )
-          end
-
         -- downloading is disabled, error
-        else
+        if not download_config.download then
           error(
             'Found an outdated version of the fuzzy matching library, but downloading from github is disabled.'
               .. '\n!! FOR DEVELOPERS !!, set `fuzzy.prebuilt_binaries.ignore_version_mismatch = true` in config.'
               .. '\n!! FOR USERS !!, either run `cargo build --release` via your package manager, or set either `fuzzy.prebuilt_binaries.download = true` or `fuzzy.prebuilt_binaries.force_version` in config.'
+              .. '\nSee the docs for more info.'
+          )
+
+        -- downloading enabled but not on a git tag, error
+        elseif not target_git_tag then
+          error(
+            "Found an outdated version of the fuzzy matching library, but can't download from github due to not being on a git tag."
+              .. '\n!! FOR DEVELOPERS !!, set `fuzzy.prebuilt_binaries.ignore_version_mismatch = true` in config.'
+              .. '\n!! FOR USERS !!, either run `cargo build --release` via your package manager, switch to a git tag, or set `fuzzy.prebuilt_binaries.force_version` in config.'
               .. '\nSee the docs for more info.'
           )
         end


### PR DESCRIPTION
Currently, for the fuzzy module, if a mismatched version is found, the current implementation checks for a condition that leads to incorrect logs and behaviors.

## Current behavior
If the `download_config.download` is set to `true` and `target_git_tag` is set, it falls into the `else` case line 58.

## Wanted behavior
If the `download_config.download` is set to `true` and `target_git_tag` is set, it falls into any case.

## Side Notes
I chose to first test if `download` is false and then if `target_git_tag` is not set as it seems more idiomatic and fluid to reason about it.
