### PR TITLE
fix: Unhandled terminal mode in set_cursor implementation

### DIFF
--- a/lua/blink/cmp/completion/accept/init.lua
+++ b/lua/blink/cmp/completion/accept/init.lua
@@ -68,7 +68,7 @@ local function apply_item(ctx, item)
 
     text_edits_lib.apply(item.textEdit, all_text_edits)
 
-    if ctx.get_mode() ~= 'term' then ctx.set_cursor(new_cursor) end
+    ctx.set_cursor(new_cursor)
     text_edits_lib.move_cursor_in_dot_repeat(offset)
   end
 

--- a/lua/blink/cmp/completion/trigger/context.lua
+++ b/lua/blink/cmp/completion/trigger/context.lua
@@ -101,7 +101,7 @@ end
 
 function context.set_cursor(cursor)
   local mode = context.get_mode()
-  if mode == 'default' then return vim.api.nvim_win_set_cursor(0, cursor) end
+  if mode == 'default' or mode == 'term' then return vim.api.nvim_win_set_cursor(0, cursor) end
 
   assert(mode == 'cmdline', 'Unsupported mode for setting cursor: ' .. mode)
   assert(cursor[1] == 1, 'Cursor must be on the first line in cmdline mode')


### PR DESCRIPTION
**Summary of the change**
The `set_cursor` function on the `blink.cmp.Context` did not handle terminal mode gracefully. Since terminal buffers support using the `vim.api.nvim_win_set_cursor` function we can just extend the default behavior of `set_cursor` for terminal buffers.

**How I noticed the problem:** 
Every time I've tried to switch to the third (or more) completion entry by hitting my `select_next` keybind in a terminal buffer I ran into this error:
```
Error executing vim.schedule lua callback: ...t/blink.cmp/lua/blink/cmp/completion/trigger/context.lua:106: Unsupported mode for setting cursor: term
stack traceback:
	[C]: in function 'assert'
	...t/blink.cmp/lua/blink/cmp/completion/trigger/context.lua:106: in function 'set_cursor'
	...ckages/start/blink.cmp/lua/blink/cmp/completion/list.lua:241: in function 'undo_preview'
	...ckages/start/blink.cmp/lua/blink/cmp/completion/list.lua:167: in function 'cb'
	...ckages/start/blink.cmp/lua/blink/cmp/lib/term_events.lua:81: in function 'suppress_events_for_callback'
	...tart/blink.cmp/lua/blink/cmp/completion/trigger/init.lua:201: in function 'suppress_events_for_callback'
	...ckages/start/blink.cmp/lua/blink/cmp/completion/list.lua:166: in function 'select'
	...ckages/start/blink.cmp/lua/blink/cmp/completion/list.lua:196: in function 'select_next'
	.../myNeovimPackages/start/blink.cmp/lua/blink/cmp/init.lua:189: in function <.../myNeovimPackages/start/blink.cmp/lua/blink/cmp/init.lua:189>
```

**Why I noticed the problem**
I'm currently building zsh completions for blink.cmp. More on that in other PRs in a couple of days :).