### PR TITLE
fix: do not show signature help on multi-line callbacks (#1670)

### DIFF
--- a/lua/blink/cmp/signature/init.lua
+++ b/lua/blink/cmp/signature/init.lua
@@ -10,16 +10,55 @@ function signature.setup()
   trigger.show_emitter:on(function(event)
     local context = event.context
     sources.cancel_signature_help()
-    sources.get_signature_help(context):map(function(signature_helps)
-      -- TODO: pick intelligently
-      local signature_help = signature_helps[1]
-      if signature_help ~= nil and trigger.context ~= nil and trigger.context.id == context.id then
-        trigger.set_active_signature_help(signature_help)
-        window.open_with_signature_help(context, signature_help)
-      else
-        trigger.hide()
-      end
-    end)
+
+    if not context.by_show_on_insert then
+      sources.get_signature_help(context):map(function(signature_helps)
+        -- TODO: pick intelligently
+        local signature_help = signature_helps[1]
+        if signature_help ~= nil and trigger.context ~= nil and trigger.context.id == context.id then
+          trigger.set_active_signature_help(signature_help)
+          window.open_with_signature_help(context, signature_help)
+        else
+          trigger.hide()
+        end
+      end)
+    else
+      -- If triggered by show on insert, we also check the signature on the
+      -- previous and following line to determine if we are in a multi-line
+      -- callback, should abort if so.
+      local context_current_line = context
+      local context_previous_line = vim.deepcopy(context)
+      context_previous_line.cursor[1] = context.cursor[1] - 1
+      local context_following_line = vim.deepcopy(context)
+      context_following_line.cursor[1] = context.cursor[1] + 1
+      local label_previous_line, label_following_line, label_current_line
+
+      sources.get_signature_help(context_previous_line):map(
+        function(signature_helps) label_previous_line = signature_helps[1] and signature_helps[1].signatures[1].label end
+      )
+      sources.get_signature_help(context_following_line):map(
+        function(signature_helps) label_following_line = signature_helps[1] and signature_helps[1].signatures[1].label end
+      )
+
+      sources.get_signature_help(context_current_line):map(function(signature_helps)
+        local signature_help = signature_helps[1]
+        label_current_line = signature_help and signature_help.signatures[1].label
+
+        local is_multiline_callback = label_previous_line == label_current_line
+          or label_following_line == label_current_line
+        if
+          signature_help ~= nil
+          and trigger.context ~= nil
+          and trigger.context.id == context.id
+          and not is_multiline_callback
+        then
+          trigger.set_active_signature_help(signature_help)
+          window.open_with_signature_help(context, signature_help)
+        else
+          trigger.hide()
+        end
+      end)
+    end
   end)
   trigger.hide_emitter:on(function() window.close() end)
 end

--- a/lua/blink/cmp/signature/trigger.lua
+++ b/lua/blink/cmp/signature/trigger.lua
@@ -12,6 +12,7 @@
 --- @field is_retrigger boolean
 --- @field active_signature_help lsp.SignatureHelp | nil
 --- @field trigger { kind: lsp.SignatureHelpTriggerKind, character?: string }
+--- @field by_show_on_insert boolean
 
 --- @class blink.cmp.SignatureTrigger
 --- @field current_context_id number
@@ -23,7 +24,7 @@
 --- @field activate fun()
 --- @field is_trigger_character fun(char: string, is_retrigger?: boolean): boolean
 --- @field show_if_on_trigger_character fun()
---- @field show fun(opts?: { trigger_character: string })
+--- @field show fun(opts?: { trigger_character: string, by_show_on_insert?: boolean })
 --- @field hide fun()
 --- @field set_active_signature_help fun(signature_help: lsp.SignatureHelp)
 
@@ -72,11 +73,11 @@ function trigger.activate()
       if not config.enabled and trigger.context == nil then
         return
       elseif config.show_on_insert_on_trigger_character and is_on_trigger and event == 'InsertEnter' then
-        trigger.show({ trigger_character = char_under_cursor })
+        trigger.show({ trigger_character = char_under_cursor, by_show_on_insert = true })
       elseif event == 'CursorMoved' and trigger.context ~= nil then
         trigger.show()
       elseif event == 'InsertEnter' and config.show_on_insert then
-        trigger.show()
+        trigger.show({ by_show_on_insert = true })
       end
     end,
     on_insert_leave = function() trigger.hide() end,
@@ -126,6 +127,7 @@ function trigger.show(opts)
     },
     is_retrigger = trigger.context ~= nil,
     active_signature_help = trigger.context and trigger.context.active_signature_help or nil,
+    by_show_on_insert = opts.by_show_on_insert,
   }
 
   trigger.show_emitter:emit({ context = trigger.context })

--- a/lua/blink/cmp/sources/lsp/init.lua
+++ b/lua/blink/cmp/sources/lsp/init.lua
@@ -166,6 +166,8 @@ function lsp:get_signature_help(context, callback)
   local offset_encoding = first_client and first_client.offset_encoding or 'utf-16'
 
   local params = vim.lsp.util.make_position_params(nil, offset_encoding)
+  params.position.line = context.cursor[1] - 1
+  params.position.character = context.cursor[2]
   params.context = {
     triggerKind = context.trigger.kind,
     triggerCharacter = context.trigger.character,


### PR DESCRIPTION
A first draft for fixing #1670, with an (admittedly slightly hacky) workaround to check if the signature is the same on the previous and the following line to detect multiline callbacks.

Some issues:
1. The solution requires making three requests to for LSP signature, and awaiting all three results. However, I don't have any previous experience with dealing with async in lua, and I couldn't figure out how async works in blink.cmp. Thus, there is currently only a naive solution right now running all three requests at the same time, which will probably sometimes fail due to race conditions.
2. Nonetheless, the solution appears to work for me in almost all the cases I tested. It does not work when entering insert mode at the end of a line (or via `cc` and `o`). Though I suspect that is since the signature help is triggered by something else, which might be a bug unrelated to this PR, since I also had a few cases where signatures showed up when they shouldn't when using `show_on_insert = false`.
3. I checked, and calling `vim.lsp.buf.signature_help` in a multiline-callback just results in "No signature help available", so apparently, `vim.lsp.buf.signature_help` already have some method of determining those? Maybe the workaround of this PR is not needed after all.

(Just to note, I based the PR on tag `v1.1.1` and not `main`, since the current HEAD of `main` appears to not work for me.)