### PR TITLE
schedule nvim_echo

### DIFF
--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -183,8 +183,7 @@ function utils.notify(msg, lvl)
   table.insert(msg, 2, { ' ' })
 
   if _ui_entered then
-    -- After UIEnter emit message immediately
-    vim.api.nvim_echo(msg, true, { err = true, verbose = false })
+    vim.schedule(function() vim.api.nvim_echo(msg, true, { err = true, verbose = false }) end)
   else
     -- Queue notification for the UIEnter event.
     table.insert(_notification_queue, function() vim.api.nvim_echo(msg, true, { verbose = false }) end)


### PR DESCRIPTION
It seems that the modified bit of code would lead to

```
Error executing vim.schedule lua callback: [...] nvim_echo must not be c
alled in a fast event context
stack traceback:
        [C]: in function 'error'
        .../.local/share/nvim/lazy/blink.cmp/lua/blink/cmp/init.lua:23: in function 'fn'
        vim/_editor.lua:366: in function <vim/_editor.lua:365>
```
and could be suppressed by wrapping it within vim.schedule.
I'm not sure if this is a good idea though.