### PR TITLE
feat: add bold style for border

### DIFF
--- a/lua/blink/cmp/config/shared.lua
+++ b/lua/blink/cmp/config/shared.lua
@@ -1,2 +1,2 @@
 --- @alias blink.cmp.WindowBorderChar string | table
---- @alias blink.cmp.WindowBorder nil | 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'padded' | 'none' | blink.cmp.WindowBorderChar[] When set to `nil`, uses the `vim.o.winborder` value on nvim 0.11+
+--- @alias blink.cmp.WindowBorder nil | 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'bold' | 'padded' | 'none' | blink.cmp.WindowBorderChar[] When set to `nil`, uses the `vim.o.winborder` value on nvim 0.11+

--- a/lua/blink/cmp/lib/window/init.lua
+++ b/lua/blink/cmp/lib/window/init.lua
@@ -36,7 +36,7 @@ local utils = require('blink.cmp.lib.window.utils')
 --- @field set_option_value fun(self: blink.cmp.Window, option: string, value: any)
 --- @field update_size fun(self: blink.cmp.Window)
 --- @field get_content_height fun(self: blink.cmp.Window): number
---- @field get_border_size fun(self: blink.cmp.Window, border?: 'none' | 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'padded' | string[]): { vertical: number, horizontal: number, left: number, right: number, top: number, bottom: number }
+--- @field get_border_size fun(self: blink.cmp.Window, border?: 'none' | 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'bold' | 'padded' | string[]): { vertical: number, horizontal: number, left: number, right: number, top: number, bottom: number }
 --- @field expand_border_chars fun(border: string[]): string[]
 --- @field get_height fun(self: blink.cmp.Window): number
 --- @field get_content_width fun(self: blink.cmp.Window): number

--- a/lua/blink/cmp/lib/window/utils.lua
+++ b/lua/blink/cmp/lib/window/utils.lua
@@ -2,7 +2,7 @@ local utils = {}
 
 --- @param border blink.cmp.WindowBorder
 --- @param default blink.cmp.WindowBorder
---- @return 'none' | 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'padded' | string[]
+--- @return 'none' | 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'bold' | 'padded' | string[]
 function utils.pick_border(border, default)
   if border ~= nil then return border end
 


### PR DESCRIPTION
bold style for winborder added in neovim 0.11.1
- https://github.com/neovim/neovim/pull/33221
- https://github.com/neovim/neovim/pull/33189

---
Screenshot of Neovim 0.11.1 + `blink.cmp` completion menu with `bold` style (completion and documentation)
```lua
documentation = {
  auto_show = true,
  auto_show_delay_ms = 250,
  treesitter_highlighting = true,
  window = { border = 'bold },
},
completion = {
  menu = {
    border = 'bold',
  }
}
```
![Neovim-blink cmp-winborder_bold](https://github.com/user-attachments/assets/63368c81-dc46-4277-afd8-cfca1bf1096d)

