### PR TITLE
fix(snippets): strings like `%20` in the register resulting in repeated errors

### DIFF
--- a/lua/blink/cmp/sources/snippets/default/registry.lua
+++ b/lua/blink/cmp/sources/snippets/default/registry.lua
@@ -141,10 +141,10 @@ function registry:expand_vars(snippet)
       if eager_vars[data.name] then
         resolved_snippet = resolved_snippet:gsub('%$[{]?(' .. data.name .. ')[}]?', eager_vars[data.name])
       elseif lazy_vars[data.name] then
-        resolved_snippet = resolved_snippet:gsub(
-          '%$[{]?(' .. data.name .. ')[}]?',
-          lazy_vars[data.name]({ clipboard_register = self.config.clipboard_register })
-        )
+        local replacement = lazy_vars[data.name]({ clipboard_register = self.config.clipboard_register })
+        -- gsub otherwise fails with strings like `%20` in the replacement string
+        local escaped_for_gsub = replacement:gsub('%%', '%%%%')
+        resolved_snippet = resolved_snippet:gsub('%$[{]?(' .. data.name .. ')[}]?', escaped_for_gsub)
       end
     end
   end


### PR DESCRIPTION
The following error occurred for me now and then, but when it occurred, it occurred regularly, spamming my notifications with it on every keystroke:

```
failed to get completions with error: ....cmp/lua/blink/cmp/sources/snippets/default/registry.lua:144: invalid capture index
```

Upon some investigation, I figured out that this error is dependent on the content of my clipboard: The error only occurs when you have a substring like `%2` in your current clipboard/register.

Due to url-encoding (e.g., `%20` being the encoded space), this is actually quite often the case, especially if you configure the snippet source to use `clipboard_register = "+"`.

Luckily, the fix for this is quite simple, since we just need to escape all `%` for `gsub`.