### PR TITLE
Handle error if getcompletion returns an error

### DIFF
--- a/lua/blink/cmp/sources/cmdline/init.lua
+++ b/lua/blink/cmp/sources/cmdline/init.lua
@@ -77,11 +77,11 @@ function cmdline:get_completions(context, callback)
         else
           local query = (text_before_argument .. current_arg_prefix):gsub([[\\]], [[\\\\]])
           -- TODO: handle `custom` type
-          local type = not vim.startswith(completion_type, 'custom') and vim.fn.getcmdcompltype() or 'cmdline'
-          if type == '' then
+          local l_type = not vim.startswith(completion_type, 'custom') and vim.fn.getcmdcompltype() or 'cmdline'
+          if l_type == '' then
             completions = {}
           else
-            completions = vim.fn.getcompletion(query, type)
+            completions = vim.fn.getcompletion(query, l_type)
           end
           -- Ensure completions is a table, as getcompletion can return numbers on error
           if type(completions) ~= 'table' then completions = {} end

--- a/lua/blink/cmp/sources/cmdline/init.lua
+++ b/lua/blink/cmp/sources/cmdline/init.lua
@@ -83,6 +83,8 @@ function cmdline:get_completions(context, callback)
           else
             completions = vim.fn.getcompletion(query, type)
           end
+          -- Ensure completions is a table, as getcompletion can return numbers on error
+          if type(completions) ~= 'table' then completions = {} end
         end
 
       -- Cmdline mode
@@ -90,6 +92,9 @@ function cmdline:get_completions(context, callback)
         local query = (text_before_argument .. current_arg_prefix):gsub([[\\]], [[\\\\]])
         completions = vim.fn.getcompletion(query, 'cmdline')
       end
+
+      -- Ensure completions is a table, as getcompletion can return numbers on error
+      if type(completions) ~= 'table' then completions = {} end
 
       -- Special case for files, escape special characters
       if constants.file_commands[cmd] then


### PR DESCRIPTION
Not sure if this is the right fix for this, but it does appear to fix compatibility with Grepper plugin, see this issue here: https://github.com/Saghen/blink.cmp/issues/1512

I don't know much about Lua or the internal workings of this plugin, so unclear if this is the correct fix or not (I.E. if you want to do something better to handle the error, etc).