### PR TITLE
fix: serialization issue with draw function

### DIFF
--- a/lua/blink/cmp/fuzzy/init.lua
+++ b/lua/blink/cmp/fuzzy/init.lua
@@ -35,13 +35,21 @@ function fuzzy.access(item)
 
   fuzzy.init_db()
 
+  local serialized_item = vim.tbl_extend(
+    'force',
+    item,
+    -- the documentation may have a draw() function that will throw an error
+    -- when serialized. Hide it to avoid the issue.
+    { documentation = {} } --[[@as blink.cmp.CompletionItem | {}]]
+  )
+
   -- writing to the db takes ~10ms, so schedule writes in another thread
   vim.uv
     .new_work(function(itm, cpath)
       package.cpath = cpath
       require('blink.cmp.fuzzy.rust').access(vim.mpack.decode(itm))
     end, function() end)
-    :queue(vim.mpack.encode(item), package.cpath)
+    :queue(vim.mpack.encode(serialized_item), package.cpath)
 end
 
 ---@param lines string


### PR DESCRIPTION
Issue
=====

When using the rust implementation for fuzzy matching, when the frecency database is being updated after accepting a completion, the completion item is serialized and passed to the rust code.

If the completion item has a `draw` function (used for a custom implementation for drawing the documentation), it will throw an error when serialized with `vim.mpack.encode()`:

> ...ta/nvim-data/lazy/blink.cmp/lua/blink/cmp/fuzzy/init.lua:44: can't
> serialize object of type 6

A reproduction is available here:
https://github.com/mikavilpas/blink-ripgrep.nvim/issues/185#issuecomment-2759181172

Solution
========

Hide the `draw` function from the completion item before serializing it to avoid the error.