### PR TITLE
fix: fix nvim 0.10 compatibility for `nvim_echo`

### DIFF
--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -182,11 +182,13 @@ function utils.notify(msg, lvl)
   table.insert(msg, 1, { ' blink.cmp ', header_hl })
   table.insert(msg, 2, { ' ' })
 
+  local echo_opts = { verbose = false }
+  if vim.fn.has('nvim-0.11') == 1 then echo_opts.err = true end
   if _ui_entered then
-    vim.schedule(function() vim.api.nvim_echo(msg, true, { err = true, verbose = false }) end)
+    vim.schedule(function() vim.api.nvim_echo(msg, true, echo_opts) end)
   else
     -- Queue notification for the UIEnter event.
-    table.insert(_notification_queue, function() vim.api.nvim_echo(msg, true, { verbose = false }) end)
+    table.insert(_notification_queue, function() vim.api.nvim_echo(msg, true, echo_opts) end)
   end
 end
 


### PR DESCRIPTION
Currently there is an incompatibility with Neovim v0.10 with the `err` key in `nvim_echo` which was added in Neovim v0.11. This resolves this and also makes sure the delayed call to `nvim_echo` uses the same options