### PR TITLE
fix: only set error notifications to `err` in `nvim_echo`

### DIFF
--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -183,7 +183,7 @@ function utils.notify(msg, lvl)
   table.insert(msg, 2, { ' ' })
 
   local echo_opts = { verbose = false }
-  if vim.fn.has('nvim-0.11') == 1 then echo_opts.err = true end
+  if lvl == vim.log.levels.ERROR and vim.fn.has('nvim-0.11') == 1 then echo_opts.err = true end
   if _ui_entered then
     vim.schedule(function() vim.api.nvim_echo(msg, true, echo_opts) end)
   else


### PR DESCRIPTION
We should only set `err` if the notification is an error (follow up to https://github.com/Saghen/blink.cmp/pull/1760#issuecomment-2878734300)