### PR TITLE
fix: Move existing file out of the way during rename

### DIFF
--- a/lua/blink/cmp/fuzzy/download/files.lua
+++ b/lua/blink/cmp/fuzzy/download/files.lua
@@ -170,22 +170,20 @@ end
 function files.rename(old_path, new_path)
   return async.task.new(function(resolve, reject)
     -- Generate a temporary filename with timestamp
-    local time = os.date("%Y%m%d%H%M%S")
+    local time = os.date('%Y%m%d%H%M%S')
     local dirname = vim.fs.dirname(new_path)
     local basename = vim.fs.basename(new_path)
-    local tmpfile = vim.fs.joinpath(dirname or ".", ".trash-" .. time .. "-" .. basename)
+    local tmpfile = vim.fs.joinpath(dirname or '.', '.trash-' .. time .. '-' .. basename)
 
     -- Try to move new_path out of the way unconditionally
     vim.uv.fs_rename(new_path, tmpfile, function(rename_existing_err)
       if rename_existing_err then
         -- Signal the fact that there is no tmp file to delete
-        tmpfile = ""
+        tmpfile = ''
       end
       -- Now move old_path to new_path
       vim.uv.fs_rename(old_path, new_path, function(rename_err)
-        if rename_err then
-          return reject(rename_err)
-        end
+        if rename_err then return reject(rename_err) end
         -- If we moved the original new_path, try to delete the temp file
         if string.len(tmpfile) > 0 then
           vim.uv.fs_unlink(tmpfile, function()

--- a/lua/blink/cmp/fuzzy/download/files.lua
+++ b/lua/blink/cmp/fuzzy/download/files.lua
@@ -169,9 +169,32 @@ end
 --- @param new_path string
 function files.rename(old_path, new_path)
   return async.task.new(function(resolve, reject)
-    vim.uv.fs_rename(old_path, new_path, function(err)
-      if err then return reject(err) end
-      resolve()
+    -- Generate a temporary filename with timestamp
+    local time = os.date("%Y%m%d%H%M%S")
+    local dirname = vim.fs.dirname(new_path)
+    local basename = vim.fs.basename(new_path)
+    local tmpfile = vim.fs.joinpath(dirname or ".", ".trash-" .. time .. "-" .. basename)
+
+    -- Try to move new_path out of the way unconditionally
+    vim.uv.fs_rename(new_path, tmpfile, function(rename_existing_err)
+      if rename_existing_err then
+        -- Signal the fact that there is no tmp file to delete
+        tmpfile = ""
+      end
+      -- Now move old_path to new_path
+      vim.uv.fs_rename(old_path, new_path, function(rename_err)
+        if rename_err then
+          return reject(rename_err)
+        end
+        -- If we moved the original new_path, try to delete the temp file
+        if string.len(tmpfile) > 0 then
+          vim.uv.fs_unlink(tmpfile, function()
+            -- TODO: either report the error or just automatically delete
+            -- stray trash files as part of a routine cleanup.
+          end)
+        end
+        resolve()
+      end)
     end)
   end)
 end


### PR DESCRIPTION
This pull request illustrates one way of potentially ensuring Windows computers can replace the binary even while it is in use. Unfortunately, I'm not experienced with NeoVim plugin development, and I'm not exactly sure how I would simulate the condition that triggers the bug. I tried setting `lazy.nvim` to get the plugin from a local directory for development, but I'm getting the error about being unable to download the binary without any changes to the code. Since I haven't been able to get the `main` branch to work correctly when sourcing `blink.cmp` locally, I'm a bit stuck on how to test this. 

@Saghen, would you mind putting eyes on this anyway? The technique of renaming the existing file (if there is one), then deleting it after `old_path` is renamed to `new_path` should resolve #1493, but it might introduce the possibility that it could fail to delete the file, causing old binaries to accumulate over time. Maybe that should result in a warning, or a lifecycle trigger could attempt to delete stray files silently. That's why I have it renaming files to contain a `.trash-` prefix. It makes them easy to identify. My understanding is that recent versions of Windows are [POSIX compliant](https://github.com/libuv/libuv/issues/3839) with their unlink implementations, so the files shouldn't accumulate, but there could be an edge case there.