### PR TITLE
feat(buffer): add configurable sync/async buffer size thresholds

### DIFF
--- a/doc/configuration/reference.md
+++ b/doc/configuration/reference.md
@@ -563,6 +563,10 @@ sources.providers = {
       end,
       -- buffers when searching with `/` or `?`
       get_search_bufnrs = function() return { vim.api.nvim_get_current_buf() } end,
+      -- Maximum total number of characters (across all selected buffers) for which buffer completion runs synchronously. Above this, asynchronous processing is used.
+      max_sync_buffer_size = 20000    
+      -- Maximum total number of characters (across all selected buffers) for which buffer completion runs asynchronously. Above this, buffer completions are skipped to avoid performance issues.
+      max_async_buffer_size = 500000 
     }
   },
 


### PR DESCRIPTION
Add `max_sync_buffer_size` and `max_async_buffer_size` options for
controlling processing mode.

Also refactor buffer source initialization to use unified option table
with basic validation.

Related #1789
