### PR TITLE
Handle combined/multiple filetypes in per_filetype table

### DIFF
--- a/lua/blink/cmp/sources/lib/init.lua
+++ b/lua/blink/cmp/sources/lib/init.lua
@@ -72,7 +72,7 @@ function sources.get_enabled_provider_ids(mode)
   -- Filetype-specific sources
   local providers = {}
   local inherit_defaults = false
-  for _, filetype in pairs(vim.split(vim.bo.filetype, '.', { trimempty = true })) do
+  for _, filetype in pairs(vim.split(vim.bo.filetype, '.', { plain = true, trimempty = true })) do
     if config.sources.per_filetype[filetype] ~= nil then
       local filetype_providers = config.sources.per_filetype[filetype]
       if type(filetype_providers) == 'function' then filetype_providers = filetype_providers() end


### PR DESCRIPTION
Vim supports multiple filetypes per buffer, e.g. `set ft=mail.markdown`. This patch teaches `blink.cmp` how to handle this situation, such that `per_filetype["mail"]` would be considered in the above situation.