### PR TITLE
Update config.lua to block auto_brackets for Powershell

### DIFF
--- a/lua/blink/cmp/completion/brackets/config.lua
+++ b/lua/blink/cmp/completion/brackets/config.lua
@@ -5,7 +5,7 @@ return {
   blocked_filetypes = {
     'sql', 'ruby', 'perl', 'lisp', 'scheme', 'clojure',
     'prolog', 'vb', 'elixir', 'smalltalk', 'applescript',
-    'elm', 'rust', 'nu', 'cpp', 'powershell'
+    'elm', 'rust', 'nu', 'cpp', 'ps1'
   },
   per_filetype = {
     -- languages with a space

--- a/lua/blink/cmp/completion/brackets/config.lua
+++ b/lua/blink/cmp/completion/brackets/config.lua
@@ -5,7 +5,7 @@ return {
   blocked_filetypes = {
     'sql', 'ruby', 'perl', 'lisp', 'scheme', 'clojure',
     'prolog', 'vb', 'elixir', 'smalltalk', 'applescript',
-    'elm', 'rust', 'nu', 'cpp'
+    'elm', 'rust', 'nu', 'cpp', 'powershell'
   },
   per_filetype = {
     -- languages with a space


### PR DESCRIPTION
Please excuse my terrible commit, I'm still fairly new to neovim, how the plugins work and github in general

By default it's adding brackets after function and cmdlet names for Powershell (which it shouldn't be).  I'm not 100% sure what it uses to determine the language name, but I've found that if I set plugins/blink.cmp.lua like so then it resolves the issue

There are more Powershell file types but I think those are the most popular

```lua
local powershell_types = { "ps1", "ps1m", "ps1d" }

return {
	"Saghen/blink.cmp",
	opts = {
		completion = {
			accept = {
				auto_brackets = {
					kind_resolution = {
						enabled = true,
						blocked_filetypes = powershell_types,
					},
					semantic_token_resolution = {
						enabled = true,
						blocked_filetypes = powershell_types,
					},
				},
			},
		},
	},
}
```