### PR TITLE
fix(cmdline): use current argument for 'file' completion in `input()` prompts

### DIFF
--- a/lua/blink/cmp/sources/cmdline/init.lua
+++ b/lua/blink/cmp/sources/cmdline/init.lua
@@ -87,6 +87,7 @@ function cmdline:get_completions(context, callback)
           -- TODO: handle `custom` type
           local compl_type = not vim.startswith(completion_type, 'custom') and vim.fn.getcmdcompltype() or 'cmdline'
           if compl_type ~= '' then
+            query = compl_type == 'file' and current_arg_prefix or query
             completions = vim.fn.getcompletion(query, compl_type)
             if type(completions) ~= 'table' then completions = {} end
           end


### PR DESCRIPTION
When using `vim.fn.input()` with 'file' completion, the completion
engine expects the query to be the current argument prefix (i.e., the
partial filename or path being typed), not the entire command line.

Closes #1817
