### PR TITLE
docs: add `blink-cmp-register` to community sources

### DIFF
--- a/doc/configuration/sources.md
+++ b/doc/configuration/sources.md
@@ -120,3 +120,4 @@ See [blink.compat](https://github.com/Saghen/blink.compat) for using `nvim-cmp` 
 - [blink-cmp-npm](https://github.com/alexandre-abrioux/blink-cmp-npm.nvim): Completion for NPM package names and versions
 - [blink-cmp-kitty](https://github.com/garyhurtz/blink_cmp_kitty): Kitty terminal completion source
 - [blink-cmp-yanky](https://github.com/marcoSven/blink-cmp-yanky): Completion for [yanky.nvim](https://github.com/gbprod/yanky.nvim)
+- [blink-cmp-register](https://github.com/phanen/blink-cmp-register)


### PR DESCRIPTION
Align with neovim upstream's `i_CTRL-X_CTRL-R` now: https://github.com/neovim/neovim/commit/f2373a89d78356423a84e9636d6949b5322ecc69.
