### PR TITLE
feat: sort in rust when no lua sorts provided

### DIFF
--- a/lua/blink/cmp/config/fuzzy.lua
+++ b/lua/blink/cmp/config/fuzzy.lua
@@ -4,7 +4,7 @@
 --- @field use_frecency boolean Tracks the most recently/frequently used items and boosts the score of the item. Note, this does not apply when using the Lua implementation.
 --- @field use_proximity boolean Boosts the score of items matching nearby words. Note, this does not apply when using the Lua implementation.
 --- @field use_unsafe_no_lock boolean UNSAFE!! When enabled, disables the lock and fsync when writing to the frecency database. This should only be used on unsupported platforms (i.e. alpine termux). Note, this does not apply when using the Lua implementation.
---- @field sorts ("label" | "sort_text" | "kind" | "score" | "exact" | blink.cmp.SortFunction)[] Controls which sorts to use and in which order, these three are currently the only allowed options
+--- @field sorts blink.cmp.Sort[] Controls which sorts to use and in which order, these three are currently the only allowed options
 --- @field prebuilt_binaries blink.cmp.PrebuiltBinariesConfig
 
 --- @class (exact) blink.cmp.PrebuiltBinariesConfig
@@ -26,6 +26,7 @@
 --- | 'lua' Always use the Lua implementation
 
 --- @alias blink.cmp.SortFunction fun(a: blink.cmp.CompletionItem, b: blink.cmp.CompletionItem): boolean | nil
+--- @alias blink.cmp.Sort ("label" | "sort_text" | "kind" | "score" | "exact" | blink.cmp.SortFunction)
 
 local validate = require('blink.cmp.config.utils').validate
 local fuzzy = {

--- a/lua/blink/cmp/fuzzy/lua/init.lua
+++ b/lua/blink/cmp/fuzzy/lua/init.lua
@@ -39,6 +39,8 @@ end
 function fuzzy.set_provider_items(provider_id, items) fuzzy.provider_items[provider_id] = items end
 
 function fuzzy.fuzzy(line, cursor_col, provider_id, opts)
+  assert(opts.sorts == nil, 'Sorting is not supported in the Lua implementation')
+
   local keyword_start, keyword_end = get_keyword_range(line, cursor_col, opts.match_suffix)
   local keyword = line:sub(keyword_start + 1, keyword_end)
 

--- a/lua/blink/cmp/fuzzy/rust/fuzzy.rs
+++ b/lua/blink/cmp/fuzzy/rust/fuzzy.rs
@@ -3,13 +3,15 @@
 use crate::frecency::FrecencyTracker;
 use crate::keyword;
 use crate::lsp_item::LspItem;
+use crate::sort::Sort;
 use mlua::prelude::*;
 use mlua::FromLua;
 use mlua::Lua;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
-#[derive(Clone, Hash)]
+#[derive(Clone)]
 pub struct FuzzyOptions {
     match_suffix: bool,
     max_typos: u16,
@@ -17,6 +19,7 @@ pub struct FuzzyOptions {
     use_proximity: bool,
     nearby_words: Option<Vec<String>>,
     snippet_score_offset: i32,
+    sorts: Option<Vec<Sort>>,
 }
 
 impl FromLua for FuzzyOptions {
@@ -28,6 +31,15 @@ impl FromLua for FuzzyOptions {
             let use_proximity: bool = tab.get("use_proximity").unwrap_or_default();
             let nearby_words: Option<Vec<String>> = tab.get("nearby_words").ok();
             let snippet_score_offset: i32 = tab.get("snippet_score_offset").unwrap_or_default();
+            let sorts: Option<Vec<String>> = tab.get("sorts").ok();
+            let sorts = sorts
+                .map(|sorts| {
+                    sorts
+                        .iter()
+                        .map(|s| s.try_into())
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?;
 
             Ok(FuzzyOptions {
                 match_suffix,
@@ -36,6 +48,7 @@ impl FromLua for FuzzyOptions {
                 use_proximity,
                 nearby_words,
                 snippet_score_offset,
+                sorts,
             })
         } else {
             Err(mlua::Error::FromLuaConversionError {
@@ -99,8 +112,6 @@ pub fn fuzzy(
         })
         .collect::<Vec<_>>();
 
-    matches.sort_by_key(|mtch| mtch.index_in_haystack);
-
     // Get the score for each match, adding score_offset, frecency and proximity bonus
     let nearby_words: HashSet<String> = HashSet::from_iter(opts.nearby_words.unwrap_or_default());
     let match_scores = matches
@@ -126,13 +137,45 @@ pub fn fuzzy(
                 score_offset += opts.snippet_score_offset;
             }
 
-            (mtch.score as i32) + frecency_score + nearby_words_score + score_offset
+            (
+                mtch.index_in_haystack,
+                (mtch.score as i32) + frecency_score + nearby_words_score + score_offset,
+            )
         })
-        .collect::<Vec<_>>();
+        .collect::<HashMap<_, _>>();
+
+    // Sort by index in haystack
+    matches.sort_by_key(|mtch| mtch.index_in_haystack);
+    // Sort by user-defined sorts
+    if let Some(sorts) = opts.sorts {
+        matches.sort_by(|a, b| {
+            sorts.iter().fold(Ordering::Equal, |acc, sort| {
+                let item_a = &haystack[a.index_in_haystack as usize];
+                let item_b = &haystack[b.index_in_haystack as usize];
+                match sort {
+                    // Reverse ordering
+                    Sort::Exact => acc.then(b.exact.cmp(&a.exact)),
+                    Sort::Score => acc.then(
+                        match_scores[&b.index_in_haystack].cmp(&match_scores[&a.index_in_haystack]),
+                    ),
+                    // Regular ordering
+                    Sort::Kind => acc.then(item_a.kind.cmp(&item_b.kind)),
+                    Sort::SortText => acc.then(match (&item_a.sort_text, &item_b.sort_text) {
+                        (None, _) | (_, None) => Ordering::Equal,
+                        (Some(a), Some(b)) => a.cmp(b),
+                    }),
+                    Sort::Label => acc.then(Sort::label(item_a, item_b)),
+                }
+            })
+        })
+    }
 
     // Return scores, indices and whether the match is exact
     (
-        match_scores,
+        matches
+            .iter()
+            .map(|mtch| match_scores[&mtch.index_in_haystack])
+            .collect::<Vec<_>>(),
         matches
             .iter()
             .map(|mtch| mtch.index_in_haystack)

--- a/lua/blink/cmp/fuzzy/rust/fuzzy.rs
+++ b/lua/blink/cmp/fuzzy/rust/fuzzy.rs
@@ -150,6 +150,10 @@ pub fn fuzzy(
     if let Some(sorts) = opts.sorts {
         matches.sort_by(|a, b| {
             sorts.iter().fold(Ordering::Equal, |acc, sort| {
+                if acc != Ordering::Equal {
+                    return acc;
+                }
+
                 let item_a = &haystack[a.index_in_haystack as usize];
                 let item_b = &haystack[b.index_in_haystack as usize];
                 match sort {

--- a/lua/blink/cmp/fuzzy/rust/lib.rs
+++ b/lua/blink/cmp/fuzzy/rust/lib.rs
@@ -13,6 +13,7 @@ mod frecency;
 mod fuzzy;
 mod keyword;
 mod lsp_item;
+mod sort;
 
 static REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"[\p{L}_][\p{L}0-9_\\-]{2,}").unwrap());

--- a/lua/blink/cmp/fuzzy/rust/sort.rs
+++ b/lua/blink/cmp/fuzzy/rust/sort.rs
@@ -1,0 +1,73 @@
+use std::cmp::Ordering;
+
+use crate::lsp_item::LspItem;
+
+#[derive(Debug, Clone, Copy)]
+pub enum Sort {
+    Exact,
+    Score,
+    Kind,
+    SortText,
+    Label,
+}
+
+impl TryFrom<&String> for Sort {
+    type Error = mlua::Error;
+
+    fn try_from(s: &String) -> Result<Self, Self::Error> {
+        match s.as_str() {
+            "exact" => Ok(Sort::Exact),
+            "score" => Ok(Sort::Score),
+            "kind" => Ok(Sort::Kind),
+            "sort_text" => Ok(Sort::SortText),
+            "label" => Ok(Sort::Label),
+            _ => Err(mlua::Error::FromLuaConversionError {
+                from: "string",
+                to: "Sort".to_string(),
+                message: Some(format!(
+                    "Invalid sort: {}. Expected one of: exact, score, kind, sort_text, label",
+                    s
+                )),
+            }),
+        }
+    }
+}
+
+/// Swaps the case of a single character (byte) at index i in string s
+fn swap_case(s: &str, i: usize) -> u8 {
+    let byte = s.as_bytes()[i];
+    match byte {
+        65..=90 => byte + 32,  // uppercase A-Z -> lowercase
+        97..=122 => byte - 32, // lowercase a-z -> uppercase
+        _ => byte,             // non-alphabetic characters
+    }
+}
+
+impl Sort {
+    pub fn label(a: &LspItem, b: &LspItem) -> Ordering {
+        // prefer foo_bar over _foo_bar
+        let entry1_under = a.label.find(|c: char| c != '_').unwrap_or(a.label.len());
+        let entry2_under = b.label.find(|c: char| c != '_').unwrap_or(b.label.len());
+
+        match entry1_under.cmp(&entry2_under) {
+            Ordering::Greater => return Ordering::Greater,
+            Ordering::Less => return Ordering::Less,
+            Ordering::Equal => {}
+        }
+
+        // prefer "a" over "A" and "a" over "b"
+        // Compare characters one by one with case flipping
+        let min_len = a.label.len().min(b.label.len());
+        for i in 0..min_len {
+            let char_a = swap_case(&a.label, i);
+            let char_b = swap_case(&b.label, i);
+
+            match char_a.cmp(&char_b) {
+                Ordering::Equal => continue,
+                other => return other,
+            }
+        }
+
+        a.label.len().cmp(&b.label.len())
+    }
+}

--- a/lua/blink/cmp/fuzzy/sort.lua
+++ b/lua/blink/cmp/fuzzy/sort.lua
@@ -14,6 +14,7 @@ function sort.sort(list, funcs)
       if result ~= nil then return result end
     end
   end)
+
   return list
 end
 

--- a/lua/blink/cmp/fuzzy/types.lua
+++ b/lua/blink/cmp/fuzzy/types.lua
@@ -16,3 +16,4 @@
 --- @field use_proximity boolean
 --- @field nearby_words string[]
 --- @field snippet_score_offset number
+--- @field sorts? blink.cmp.Sort[]


### PR DESCRIPTION
Moves the sorting to rust when there's no Lua functions provided in the sorting array, which should be the case for 95%+ users. It's possible that we should fallback to the default list of sorts when the number of items is extremely high (10k+) as in the case of tailwind. On my system, this reduced the sorting time from 5ms to 0.8ms on 11k tailwind items

Related to #1752 