### PR TITLE
docs: add `blink-cmp-sshconfig` community source

### DIFF
--- a/doc/configuration/sources.md
+++ b/doc/configuration/sources.md
@@ -121,3 +121,4 @@ See [blink.compat](https://github.com/Saghen/blink.compat) for using `nvim-cmp` 
 - [blink-cmp-kitty](https://github.com/garyhurtz/blink_cmp_kitty): Kitty terminal completion source
 - [blink-cmp-yanky](https://github.com/marcoSven/blink-cmp-yanky): Completion for [yanky.nvim](https://github.com/gbprod/yanky.nvim)
 - [blink-cmp-register](https://github.com/phanen/blink-cmp-register)
+- [blink-cmp-sshconfig](https://github.com/bydlw98/blink-cmp-sshconfig)


### PR DESCRIPTION
Hi. This adds [blink-cmp-sshconfig](https://github.com/bydlw98/blink-cmp-sshconfig) to the list of community sources.