### PR TITLE
fix(window): hide all blink windows when another completion menu is triggered

### DIFF
--- a/lua/blink/cmp/completion/trigger/init.lua
+++ b/lua/blink/cmp/completion/trigger/init.lua
@@ -158,6 +158,9 @@ function trigger.activate()
     on_char_added = on_char_added,
     on_cursor_moved = on_cursor_moved,
     on_insert_leave = function() trigger.hide() end,
+    on_complete_changed = function()
+      if vim.fn.pumvisible() == 1 then trigger.hide() end
+    end,
   })
 
   trigger.cmdline_events = require('blink.cmp.lib.cmdline_events').new()
@@ -238,7 +241,7 @@ function trigger.show_if_on_trigger_character(opts)
 end
 
 function trigger.show(opts)
-  if not require('blink.cmp.config').enabled() then return trigger.hide() end
+  if vim.fn.pumvisible() == 1 or not root_config.enabled() then return trigger.hide() end
 
   opts = opts or {}
 

--- a/lua/blink/cmp/lib/buffer_events.lua
+++ b/lua/blink/cmp/lib/buffer_events.lua
@@ -23,6 +23,7 @@
 --- @field on_char_added fun(char: string, is_ignored: boolean)
 --- @field on_cursor_moved fun(event: 'CursorMoved' | 'InsertEnter', is_ignored: boolean, is_backspace: boolean, last_event: string)
 --- @field on_insert_leave fun()
+--- @field on_complete_changed fun()
 
 --- @type blink.cmp.BufferEvents
 --- @diagnostic disable-next-line: missing-fields
@@ -169,6 +170,12 @@ function buffer_events:listen(opts)
       end)
     end
   end)
+
+  if opts.on_complete_changed then
+    vim.api.nvim_create_autocmd('CompleteChanged', {
+      callback = vim.schedule_wrap(function() opts.on_complete_changed() end),
+    })
+  end
 end
 
 --- Effectively ensures that our autocmd listeners run last, after other registered listeners

--- a/lua/blink/cmp/signature/trigger.lua
+++ b/lua/blink/cmp/signature/trigger.lua
@@ -80,6 +80,9 @@ function trigger.activate()
       end
     end,
     on_insert_leave = function() trigger.hide() end,
+    on_complete_changed = function()
+      if vim.fn.pumvisible() == 1 then trigger.hide() end
+    end,
   })
 
   if config.show_on_accept then
@@ -119,7 +122,7 @@ function trigger.show_if_on_trigger_character()
 end
 
 function trigger.show(opts)
-  if not config.enabled then return end
+  if vim.fn.pumvisible() == 1 or not config.enabled then return end
 
   opts = opts or {}
 


### PR DESCRIPTION
If one or more blink windows (menu, documentation, or signature) are
visible and the user triggers a different completion menu (like
`omni-complete`, `user-complete`, ...), all blink windows are now
closed automatically.

This prevents the blink menu from staying open on top of the new menu,
making things less confusing for users.

Closes #1806

---
https://github.com/user-attachments/assets/0035b6a8-504c-49c0-bfce-8972e4347a32

---
Same logic used by [nvim-cmp](https://github.com/search?q=repo%3Ahrsh7th%2Fnvim-cmp%20CompleteChanged&type=code) and seems reliable enough.
