### PR TITLE
docs: update `fuzzy.sorts` config documentation

### DIFF
--- a/lua/blink/cmp/config/fuzzy.lua
+++ b/lua/blink/cmp/config/fuzzy.lua
@@ -4,7 +4,7 @@
 --- @field use_frecency boolean Tracks the most recently/frequently used items and boosts the score of the item. Note, this does not apply when using the Lua implementation.
 --- @field use_proximity boolean Boosts the score of items matching nearby words. Note, this does not apply when using the Lua implementation.
 --- @field use_unsafe_no_lock boolean UNSAFE!! When enabled, disables the lock and fsync when writing to the frecency database. This should only be used on unsupported platforms (i.e. alpine termux). Note, this does not apply when using the Lua implementation.
---- @field sorts blink.cmp.Sort[] Controls which sorts to use and in which order, these three are currently the only allowed options
+--- @field sorts blink.cmp.Sort[] Controls which sorts to use and in which order.
 --- @field prebuilt_binaries blink.cmp.PrebuiltBinariesConfig
 
 --- @class (exact) blink.cmp.PrebuiltBinariesConfig


### PR DESCRIPTION
Looks like the documentation dates back to `Aug 30, 2024`, and back then only three sorts were available:
https://github.com/Saghen/blink.cmp/commit/9e4f6d401bd71143784f57ae5e07e886c7fbf20f#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R76

These days many more sort options are available, so update the documentation to be more up to date.