### PR TITLE
fix(cmdline): preserve regex character class in search mode

### DIFF
--- a/lua/blink/cmp/completion/list.lua
+++ b/lua/blink/cmp/completion/list.lua
@@ -115,12 +115,12 @@ end
 
 function list.fuzzy(context, items_by_source)
   local fuzzy = require('blink.cmp.fuzzy')
-  local filtered_items = fuzzy.fuzzy(
-    context.get_line(),
-    context.get_cursor()[2],
-    items_by_source,
-    require('blink.cmp.config').completion.keyword.range
-  )
+
+  local line, cursor =
+    require('blink.cmp.lib.text_edits').skip_charclass_prefix(context.get_line(), context.get_cursor()[2])
+
+  local filtered_items =
+    fuzzy.fuzzy(line, cursor, items_by_source, require('blink.cmp.config').completion.keyword.range)
 
   -- apply the per source max_items
   filtered_items = require('blink.cmp.sources.lib').apply_max_items_for_completions(context, filtered_items)


### PR DESCRIPTION
Ensures when applying completions in search mode, any leading regex character class prefixes like `\v` or `\c` are preserved.

Regex atoms like `\s`, `\d`, etc. are also treated as prefixes for simplicity, as users are responsible for their own patterns.

Closes #855
