### PR TITLE
feat: prefer continuous matches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "frizbee"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b2d1fb7a98bc09d95a2d224166e83a8507519dbf78003271acd31f5fb14bf"
+checksum = "d2752e2d03afff2850116bcfe936383d24f60bed3ed9b87da7772ae2c3ac5161"
 dependencies = [
  "memchr",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 regex = "1.11.1"
-frizbee = "0.4.1"
+frizbee = "0.4.3"
 serde = { version = "1.0.216", features = ["derive"] }
 heed = "0.21.0"
 mlua = { version = "0.10.2", features = ["module", "luajit"] }

--- a/lua/blink/cmp/fuzzy/lua/match.lua
+++ b/lua/blink/cmp/fuzzy/lua/match.lua
@@ -73,10 +73,10 @@ local function match(needle, haystack)
   return score, exact
 end
 
-assert(match('fbb', 'barbazfoobarbaz') == 20, 'fbb should match barbazfoobarbaz with score 18')
-assert(match('foo', '_foobar') == 28, 'foo should match foobar with score 29')
-assert(match('Foo', 'foobar') == 29, 'foo should match foobar with score 29')
-assert(match('foo', 'foobar') == 30, 'foo should match foobar with score 30')
+assert(match('fbb', 'barbazfoobarbaz') == 36, 'fbb should match barbazfoobarbaz with score 36')
+assert(match('foo', '_foobar') == 52, 'foo should match foobar with score 52')
+assert(match('Foo', 'foobar') == 56, 'foo should match foobar with score 56')
+assert(match('foo', 'foobar') == 60, 'foo should match foobar with score 60')
 assert(match('foo', 'fobar') == nil, 'foo should not match fobar')
 
 return match

--- a/lua/blink/cmp/fuzzy/lua/match.lua
+++ b/lua/blink/cmp/fuzzy/lua/match.lua
@@ -1,14 +1,15 @@
-local MATCH_SCORE = 7
-local GAP_PENALTY = -1
+local MATCH_SCORE = 12
+local GAP_OPEN_PENALTY = -5
+local GAP_EXTEND_PENALTY = -1
 
 -- bonus for matching the first character of the haystack
-local PREFIX_BONUS = 6
+local PREFIX_BONUS = 12
 -- bonus for matching character after a delimiter in the haystack (e.g. space, comma, underscore, slash, etc)
 local DELIMITER_BONUS = 4
 -- bonus for haystack == needle
 local EXACT_MATCH_BONUS = 4
 -- bonus for matching the case (upper or lower) of the haystack
-local MATCHING_CASE_BONUS = 1
+local MATCHING_CASE_BONUS = 4
 
 local DELIMITERS = {
   [string.byte(' ', 1)] = true,
@@ -43,7 +44,10 @@ local function match(needle, haystack)
         score = score + MATCH_SCORE
 
         -- gap penalty
-        if needle_idx ~= 1 then score = score + GAP_PENALTY * (haystack_idx - haystack_start_idx) end
+        if needle_idx ~= 1 then
+          local gap_length = haystack_idx - haystack_start_idx
+          if gap_length > 0 then score = score + GAP_OPEN_PENALTY + GAP_EXTEND_PENALTY * (gap_length - 1) end
+        end
 
         -- bonuses
         if needle_char == haystack_char then score = score + MATCHING_CASE_BONUS end


### PR DESCRIPTION
Adjusts the scoring in frizbee such that `foo` no longer receives a higher score matched on `f_o_o` than on `fooo`. Adjusts the lua scoring to match frizbee and adds separate gap open/extend penalties to match its behavior. Related: https://github.com/Saghen/blink.cmp/issues/1642#issuecomment-2960907870