### PR TITLE
fix: skip useless redraws when not running in Neovide

### DIFF
--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -394,25 +394,6 @@ function text_edits.write_to_dot_repeat(text_edit)
   end)
 end
 
---- Disable redraw in neovide for the duration of the callback
---- Useful for preventing the cursor from jumping to the top left during `vim.fn.complete`
---- @generic T
---- @param fn fun(): T
---- @return T
-function utils.defer_neovide_redraw(fn)
-  if neovide and neovide.disable_redraw then neovide.disable_redraw() end
-
-  local success, result = pcall(fn)
-
-  -- make sure that the screen is updated and the mouse cursor returned to the right position before re-enabling redrawing
-  pcall(vim.api.nvim__redraw, { cursor = true, flush = true })
-
-  if neovide and neovide.enable_redraw then neovide.enable_redraw() end
-
-  if not success then error(result) end
-  return result
-end
-
 --- Moves the cursor while preserving dot repeat
 --- @param amount number Number of characters to move the cursor by, can be negative to move left
 function text_edits.move_cursor_in_dot_repeat(amount)

--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -169,22 +169,20 @@ end
 --- @param fn fun(): T
 --- @return T
 function utils.defer_neovide_redraw(fn)
-  if _G.neovide and neovide.enable_redraw and neovide.disable_redraw then
-    neovide.disable_redraw()
+  -- don't do anything special when not running inside neovide
+  if not _G.neovide or not neovide.enable_redraw or not neovide.disable_redraw then return fn() end
 
-    local success, result = pcall(fn)
+  neovide.disable_redraw()
 
-    -- make sure that the screen is updated and the mouse cursor returned to the right position before re-enabling redrawing
-    pcall(vim.api.nvim__redraw, { cursor = true, flush = true })
+  local success, result = pcall(fn)
 
-    neovide.enable_redraw()
+  -- make sure that the screen is updated and the mouse cursor returned to the right position before re-enabling redrawing
+  pcall(vim.api.nvim__redraw, { cursor = true, flush = true })
 
-    if not success then error(result) end
-    return result
-  else
-    -- don't do anything special when not running inside neovide
-    return fn()
-  end
+  neovide.enable_redraw()
+
+  if not success then error(result) end
+  return result
 end
 
 ---@type boolean Have we passed UIEnter?

--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -163,6 +163,30 @@ function utils.with_no_autocmds(cb)
   return result_or_err
 end
 
+--- Disable redraw in neovide for the duration of the callback
+--- Useful for preventing the cursor from jumping to the top left during `vim.fn.complete`
+--- @generic T
+--- @param fn fun(): T
+--- @return T
+function utils.defer_neovide_redraw(fn)
+  if _G.neovide and neovide.enable_redraw and neovide.disable_redraw then
+    neovide.disable_redraw()
+
+    local success, result = pcall(fn)
+
+    -- make sure that the screen is updated and the mouse cursor returned to the right position before re-enabling redrawing
+    pcall(vim.api.nvim__redraw, { cursor = true, flush = true })
+
+    neovide.enable_redraw()
+
+    if not success then error(result) end
+    return result
+  else
+    -- don't do anything special when not running inside neovide
+    return fn()
+  end
+end
+
 ---@type boolean Have we passed UIEnter?
 local _ui_entered = vim.v.vim_did_enter == 1 -- technically for VimEnter, but should be good enough for when we're lazy loaded
 ---@type function[] List of notifications.


### PR DESCRIPTION
This is a follow-up to #1582. As far as I understand correctly, `nvim__redraw` is necessary to flush the changes to the neovim UI grid, which does not result in an immediate update if rendering is temporarily suspended by Neovide, but in all other types of UI this does result in an immediate redraw, such as when selecting different completion items with CTRL-N/CTRL-P. Compare:

**without my PR:**

https://github.com/user-attachments/assets/951e04c7-312e-4848-8a7d-0046d49a856c

**with this PR:**

https://github.com/user-attachments/assets/52edfc5c-15a2-467e-b18b-9f6d04902412

I was able to notice this because my statusline shows when I am in the popup completion mode (i.e. when `mode(1)` returns `ic`, `ix` or similar), but also, notice that the cursor quickly jumps around in the inserted line. Also, I am pretty sure that the function `utils.defer_neovide_redraw` is supposed to go in `utils.lua`, not `text_edits.lua`.