### PR TITLE
fix: use async for moving cursor with dot repeat

### DIFF
--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -1,3 +1,4 @@
+local async = require('blink.cmp.lib.async')
 local config = require('blink.cmp.config')
 local utils = require('blink.cmp.lib.utils')
 local context = require('blink.cmp.completion.trigger.context')
@@ -416,10 +417,22 @@ end
 --- Moves the cursor while preserving dot repeat
 --- @param amount number Number of characters to move the cursor by, can be negative to move left
 function text_edits.move_cursor_in_dot_repeat(amount)
-  if amount == 0 then return end
+  if amount == 0 then return async.task.empty() end
 
-  local keys = string.rep('<C-g>U' .. (amount > 0 and '<Right>' or '<Left>'), math.abs(amount))
-  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(keys, true, true, true), 'in', false)
+  return async.task.new(function(resolve)
+    local augroup = vim.api.nvim_create_augroup('BlinkCmpDotRepeatCursorCallback', { clear = true })
+    vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
+      group = augroup,
+      callback = function()
+        resolve()
+        vim.api.nvim_del_augroup_by_id(augroup)
+      end,
+      once = true,
+    })
+
+    local keys = string.rep('<C-g>U' .. (amount > 0 and '<Right>' or '<Left>'), math.abs(amount))
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(keys, true, true, true), 'in', false)
+  end)
 end
 
 return text_edits

--- a/lua/blink/cmp/sources/lib/init.lua
+++ b/lua/blink/cmp/sources/lib/init.lua
@@ -238,9 +238,7 @@ function sources.execute(context, item, default_implementation)
       break
     end
   end
-  if item_source == nil then
-    return async.task.new(function(resolve) resolve() end)
-  end
+  if item_source == nil then return async.task.empty() end
 
   return item_source
     :execute(context, item, default_implementation)

--- a/lua/blink/cmp/sources/lib/provider/init.lua
+++ b/lua/blink/cmp/sources/lib/provider/init.lua
@@ -15,7 +15,7 @@
 --- @field should_show_items fun(self: blink.cmp.SourceProvider, context: blink.cmp.Context, items: blink.cmp.CompletionItem[]): boolean
 --- @field transform_items fun(self: blink.cmp.SourceProvider, context: blink.cmp.Context, items: blink.cmp.CompletionItem[]): blink.cmp.CompletionItem[]
 --- @field resolve fun(self: blink.cmp.SourceProvider, context: blink.cmp.Context, item: blink.cmp.CompletionItem): blink.cmp.Task
---- @field execute fun(self: blink.cmp.SourceProvider, context: blink.cmp.Context, item: blink.cmp.CompletionItem, default_implementation: fun(context?: blink.cmp.Context, item?: blink.cmp.CompletionItem)): blink.cmp.Task
+--- @field execute fun(self: blink.cmp.SourceProvider, context: blink.cmp.Context, item: blink.cmp.CompletionItem, default_implementation: fun(context?: blink.cmp.Context, item?: blink.cmp.CompletionItem): blink.cmp.Task): blink.cmp.Task
 --- @field get_signature_help_trigger_characters fun(self: blink.cmp.SourceProvider): { trigger_characters: string[], retrigger_characters: string[] }
 --- @field get_signature_help fun(self: blink.cmp.SourceProvider, context: blink.cmp.SignatureHelpContext): blink.cmp.Task
 --- @field reload (fun(self: blink.cmp.SourceProvider): nil) | nil
@@ -157,10 +157,7 @@ end
 --- Execute ---
 
 function source:execute(context, item, default_implementation)
-  if self.module.execute == nil then
-    default_implementation()
-    return async.task.empty()
-  end
+  if self.module.execute == nil then return default_implementation() end
 
   return async.task.new(
     function(resolve) return self.module:execute(context, item, resolve, default_implementation) end

--- a/lua/blink/cmp/sources/lsp/init.lua
+++ b/lua/blink/cmp/sources/lsp/init.lua
@@ -192,19 +192,19 @@ end
 --- Execute ---
 
 function lsp:execute(ctx, item, callback, default_implementation)
-  default_implementation()
-
-  local client = vim.lsp.get_client_by_id(item.client_id)
-  if client and item.command then
-    if vim.fn.has('nvim-0.11') == 1 then
-      client:exec_cmd(item.command, { bufnr = ctx.bufnr }, function() callback() end)
+  return default_implementation():map(function()
+    local client = vim.lsp.get_client_by_id(item.client_id)
+    if client and item.command then
+      if vim.fn.has('nvim-0.11') == 1 then
+        client:exec_cmd(item.command, { bufnr = ctx.bufnr }, function() callback() end)
+      else
+        -- TODO: remove this once 0.11 is the minimum version
+        client:_exec_cmd(item.command, { bufnr = ctx.bufnr }, function() callback() end)
+      end
     else
-      -- TODO: remove this once 0.11 is the minimum version
-      client:_exec_cmd(item.command, { bufnr = ctx.bufnr }, function() callback() end)
+      callback()
     end
-  else
-    callback()
-  end
+  end)
 end
 
 return lsp


### PR DESCRIPTION
I don't love this solution in general, so please feel free to suggest other ideas!

We use `<C-g>U<Left>` to move the cursor backwards after accepting with auto-brackets (`move_cursor_in_dot_repeat`). However, because we use `feedkeys`, the input is queued for processing, but doesn't get processed until after `vim.schedule`. This means we don't have an easy way to wait for it to finish processing and the downstream `show_if_on_trigger_character()` will see the cursor at `test()|` instead of at `test(|)`. 

I've setup an autocmd that listens for a `CursorMoved/CursorMovedI` event (need `CursorMovedC` too, but that's nvim 0.11+. need to test terminal too) and resolves the `move_cursor_in_dot_repeat` task when the autocmd fires. Notably, this makes the `default_implementation` passed to `source:execute` `Task` rather than `void`, so sources would need to be updated to support this.

Closes #1685 