### PR TITLE
feat(frecency): use blake3 hash as db key for accesses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,9 +48,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "blink-cmp-fuzzy"
 version = "0.1.0"
 dependencies = [
+ "bincode",
+ "blake3",
  "frizbee",
  "heed",
  "mlua",
@@ -77,6 +104,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "crossbeam-deque"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,5 @@ serde = { version = "1.0.216", features = ["derive"] }
 heed = "0.21.0"
 mlua = { version = "0.10.2", features = ["module", "luajit"] }
 thiserror = "2.0.10"
+blake3 = "1.8.2"
+bincode = "1.3.3"


### PR DESCRIPTION
- Replace raw CompletionItemKey as database key with a blake3 hash of its bincode serialization in FrecencyTracker.
- Update get_accesses and access methods to use the hashed key.
- Add key_to_hash_bytes helper for consistent key hashing.
- Add blake3 and bincode as dependencies in Cargo.toml.
- Update Cargo.lock to reflect new dependencies.

We replace the raw struct key with a hash to ensure database keys are fixed-size and uniform, which improves storage efficiency and lookup performance. This also avoids issues with variable-length or complex struct keys, and makes the database more robust against future changes to the key's serialization format.

Closes #1905
Closes #1895 
Closes #1832 
Closes #1727

## Steps
1. I temporary do this synchronously to get and observe the error thrown here
fuzzy/init.lua
```lua
local rust = require('blink.cmp.fuzzy.rust')
rust.access(trimmed_item)  -- main thread

vim.uv
  .new_work(
    function(itm, cpath)
      package.cpath = cpath
      -- do fuzzy matching only, no mlua-bound calls here
    end,
    function() end
  )
  :queue(require('string.buffer').encode(trimmed_item), package.cpath)
```

2. From here, I understand that the issue is due to directly serializing the "CompletionItemKey" as key to the LMDB.
LMDB has a limit 511 bytes for key size, and will throw exception if larger than that, which is the case of CompletionItemKey with the combination of AI Code companion like Github Copilot.
```sh
runtime error: Failed to write to frecency database: MDB_BAD_VALSIZE: Unsupported size of key/DB name/data, or wrong DUPFIXED size
stack traceback:
	[C]: in function 'access'
	...l/share/nvim/lazy/blink.cmp/lua/blink/cmp/fuzzy/init.lua:57: in function 'access'
	.../lazy/blink.cmp/lua/blink/cmp/completion/accept/init.lua:76: in function 'apply_item'
	.../lazy/blink.cmp/lua/blink/cmp/completion/accept/init.lua:109: in function 'default_implementation'
	...zy/blink.cmp/lua/blink/cmp/sources/lib/provider/init.lua:161: in function 'execute'
	...e/nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/init.lua:237: in function <...e/nvim/lazy/blink.cmp/lua/blink/cmp/sources/lib/init.lua:224>
	[C]: in function 'pcall'
	...al/share/nvim/lazy/blink.cmp/lua/blink/cmp/lib/async.lua:107: in function 'cb'
	...al/share/nvim/lazy/blink.cmp/lua/blink/cmp/lib/async.lua:189: in function 'on_completion'
	...al/share/nvim/lazy/blink.cmp/lua/blink/cmp/lib/async.lua:106: in function <...al/share/nvim/lazy/blink.cmp/lua/blink/cmp/lib/async.lua:105>
	[C]: in function 'pcall'
	...al/share/nvim/lazy/blink.cmp/lua/blink/cmp/lib/async.lua:72: in function 'new'
	...al/share/nvim/lazy/blink.cmp/lua/blink/cmp/lib/async.lua:105: in function 'map'
	.../lazy/blink.cmp/lua/blink/cmp/completion/accept/init.lua:101: in function <.../lazy/blink.cmp/lua/blink/cmp/completion/accept/init.lua:88>
	...re/nvim/lazy/blink.cmp/lua/blink/cmp/completion/list.lua:271: in function 'accept'
	.../.local/share/nvim/lazy/blink.cmp/lua/blink/cmp/init.lua:134: in function <.../.local/share/nvim/lazy/blink.cmp/lua/blink/cmp/init.lua:134>
```

3. Therefore, hashing the key is the approach to this problem, this ticket implements that.
4. For me, I verified using the "fuzzy.rs" files, at the end of the file, I type "pub fn" and on my case my Github Copilot generates a very large functions which will crash the app, and after this fix, it no longer crashes.