### PR TITLE
fix: `!` prefix completion

### DIFF
--- a/lua/blink/cmp/sources/cmdline/init.lua
+++ b/lua/blink/cmp/sources/cmdline/init.lua
@@ -206,7 +206,7 @@ function cmdline:get_completions(context, callback)
           new_text = '$' .. completion
 
         -- for other completions, prepend the prefix
-        elseif vim.tbl_contains({ 'lua', '' }, completion_type) then
+        elseif vim.tbl_contains({ 'lua', 'shellcmd', '' }, completion_type) then
           new_text = current_arg_prefix .. completion
         end
 


### PR DESCRIPTION
Don't work as expected for me(`!ls` -> `ls`) after dc647b3acd9ffac6fd694d23832f0d85c06a66ca.
