### PR TITLE
fix(cmdline): prevent hangs from shellcmd completion on win32/wsl

### DIFF
--- a/doc/configuration/reference.md
+++ b/doc/configuration/reference.md
@@ -606,12 +606,6 @@ sources.providers = {
 
   cmdline = {
     module = 'blink.cmp.sources.cmdline',
-    -- Disable shell commands on windows, since they cause neovim to hang
-    enabled = function()
-      return vim.fn.has('win32') == 0
-        or vim.fn.getcmdtype() ~= ':'
-        or not vim.fn.getcmdline():match("^[%%0-9,'<>%-]*!")
-    end,
   },
 
   omni = {

--- a/lua/blink/cmp/config/sources.lua
+++ b/lua/blink/cmp/config/sources.lua
@@ -79,12 +79,6 @@ local sources = {
       },
       cmdline = {
         module = 'blink.cmp.sources.cmdline',
-        -- Disable shell commands on windows, since they cause neovim to hang
-        enabled = function()
-          return vim.fn.has('win32') == 0
-            or vim.fn.getcmdtype() ~= ':'
-            or not vim.fn.getcmdline():match("^[%%0-9,'<>%-]*!")
-        end,
       },
       omni = {
         module = 'blink.cmp.sources.complete_func',


### PR DESCRIPTION
This change makes the previous attempt to disable shell completion in Windows environments more robust:
- Handles both Windows and WSL, instead of only targeting Windows.
- Handles all shellcmd completions, e.g. `:term`, not just the `:!` command.
- Instead of disabling shellcmd completions entirely, temporarily remove system32 from `PATH`. This avoids hangs while still allowing completion items from other locations to be displayed.

Closes #1926
Related #1029
