### PR TITLE
Add blink-cmp-words to community sources

### DIFF
--- a/doc/configuration/sources.md
+++ b/doc/configuration/sources.md
@@ -122,3 +122,4 @@ See [blink.compat](https://github.com/Saghen/blink.compat) for using `nvim-cmp` 
 - [blink-cmp-yanky](https://github.com/marcoSven/blink-cmp-yanky): Completion for [yanky.nvim](https://github.com/gbprod/yanky.nvim)
 - [blink-cmp-register](https://github.com/phanen/blink-cmp-register)
 - [blink-cmp-sshconfig](https://github.com/bydlw98/blink-cmp-sshconfig)
+- [blink-cmp-words](https://github.com/archie-judd/blink-cmp-words): Definitions and synonyms


### PR DESCRIPTION
Hi, I'd like to add my source: https://github.com/archie-judd/blink-cmp-words to the list of community sources.

It provides word completion, synonym completion, and formatted definitions.

Please let me know if any issues. Thanks!