### PR TITLE
fix: show_signature now ignores trigger.enabled if called directly

### DIFF
--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -271,7 +271,7 @@ function cmp.is_signature_visible() return require('blink.cmp.signature.window')
 function cmp.show_signature()
   local config = require('blink.cmp.config').signature
   if not config.enabled or cmp.is_signature_visible() then return end
-  vim.schedule(function() require('blink.cmp.signature.trigger').show() end)
+  vim.schedule(function() require('blink.cmp.signature.trigger').show({ force = true }) end)
   return true
 end
 

--- a/lua/blink/cmp/signature/trigger.lua
+++ b/lua/blink/cmp/signature/trigger.lua
@@ -23,7 +23,7 @@
 --- @field activate fun()
 --- @field is_trigger_character fun(char: string, is_retrigger?: boolean): boolean
 --- @field show_if_on_trigger_character fun()
---- @field show fun(opts?: { trigger_character: string })
+--- @field show fun(opts?: { trigger_character: string, force?: boolean })
 --- @field hide fun()
 --- @field set_active_signature_help fun(signature_help: lsp.SignatureHelp)
 
@@ -120,7 +120,7 @@ function trigger.show_if_on_trigger_character()
 end
 
 function trigger.show(opts)
-  if not config.enabled then return end
+  if not opts.force and not config.enabled then return end
 
   opts = opts or {}
 


### PR DESCRIPTION
Current State - Calling `show_signature()` when `signature.enabled = true` but `signature.trigger.enabled = false` prevents the signature popup from showing at all.

Expected State - Calling `show_signature()` directly (similar to `show()`) should ignore the `signature.trigger.enabled` flag

Change - Add a force opt to match `show()` that bypasses the `signature.trigger.enabled` flag