### PR TITLE
perf(cmdline): reduce spurious cursor and char events

### DIFF
--- a/lua/blink/cmp/lib/cmdline_events.lua
+++ b/lua/blink/cmp/lib/cmdline_events.lua
@@ -20,16 +20,13 @@ function cmdline_events.new()
   return setmetatable({
     ignore_next_text_changed = false,
     ignore_next_cursor_moved = false,
-  }, { __index = cmdline_events })
+  }, { __index = cmdline_events }) --[[@as blink.cmp.CmdlineEvents]]
 end
 
 function cmdline_events:listen(opts)
   -- TextChanged
   local on_changed = function(key) opts.on_char_added(key, false) end
 
-  -- We handle backspace as a special case, because the text will have changed
-  -- but we still want to fire the CursorMoved event, and not the TextChanged event
-  local did_backspace = false
   local is_change_queued = false
   local pending_key = nil
   vim.on_key(function(raw_key, escaped_key)
@@ -38,7 +35,6 @@ function cmdline_events:listen(opts)
     -- ignore if it's a special key
     -- FIXME: odd behavior when escaped_key has multiple keycodes, i.e. by pressing <C-p> and then "t"
     local key = vim.fn.keytrans(escaped_key)
-    if key == '<BS>' and not is_change_queued then did_backspace = true end
     if key:sub(1, 1) == '<' and key:sub(#key, #key) == '>' and raw_key ~= ' ' then return end
     if key == '' then return end
 
@@ -46,7 +42,6 @@ function cmdline_events:listen(opts)
 
     if not is_change_queued then
       is_change_queued = true
-      did_backspace = false
       vim.schedule(function()
         on_changed(pending_key)
         is_change_queued = false
@@ -54,6 +49,23 @@ function cmdline_events:listen(opts)
       end)
     end
   end)
+
+  -- Abbreviations and other automated features can cause rapid, repeated cursor movements
+  -- (a "burst") that are not intentional user actions. To avoid reacting to these artificial
+  -- movements in CursorMovedC, we detect bursts by measuring the time between moves.
+  -- If two cursor moves occur within a short threshold (burst_threshold_ms), we treat them
+  -- as part of a burst and ignore them.
+  local last_move_time
+  local burst_threshold_ms = 10
+  local function is_burst_move()
+    local current_time = vim.loop.hrtime() / 1e6
+    if last_move_time and (current_time - last_move_time) < burst_threshold_ms then
+      last_move_time = current_time
+      return true
+    end
+    last_move_time = current_time
+    return false
+  end
 
   -- CursorMoved
   if vim.fn.has('nvim-0.11') == 1 then
@@ -66,7 +78,7 @@ function cmdline_events:listen(opts)
 
         if is_change_queued then return end
 
-        opts.on_cursor_moved('CursorMoved', is_ignored)
+        if not is_burst_move() then opts.on_cursor_moved('CursorMoved', is_ignored) end
       end,
     })
 
@@ -83,23 +95,18 @@ function cmdline_events:listen(opts)
 
       local current_cmdline = vim.fn.getcmdline()
       local current_cursor = vim.fn.getcmdpos()
-
-      -- Detect changes in command line or cursor position
-      local cmdline_changed = current_cmdline ~= previous_cmdline
       local cursor_changed = current_cursor ~= previous_cursor
+
+      -- Fire on_cursor_moved if cursor changed or destructive edits (<BS>, <C-W> or <C-u>)
+      if cursor_changed and #current_cmdline < #previous_cmdline then
+        local is_ignored = self.ignore_next_cursor_moved
+        self.ignore_next_cursor_moved = false
+        if is_change_queued then return end
+        opts.on_cursor_moved('CursorMoved', is_ignored)
+      end
 
       previous_cmdline = current_cmdline
       previous_cursor = current_cursor
-
-      -- Fire on_cursor_moved if either text or cursor changed
-      if cursor_changed or (cmdline_changed and not did_backspace) then
-        did_backspace = false
-
-        local is_ignored = self.ignore_next_cursor_moved
-        self.ignore_next_cursor_moved = false
-
-        opts.on_cursor_moved('CursorMoved', is_ignored)
-      end
     end)
     vim.api.nvim_create_autocmd('CmdlineEnter', {
       callback = function()


### PR DESCRIPTION
See discussion in
https://github.com/Saghen/blink.cmp/pull/1952#issuecomment-3013613413

For Neovim 0.11, there’s no change to the core logic, just added throttling for rapid cursor movements. For Neovim 0.10, I simplified the logic. In both cases, the number of triggered events is reduced by at least 50%, should be easier on downstream listeners.

### Test case

```lua
-- abbreviation
vim.keymap.set('ca', 'mes', 'Messages')
vim.api.nvim_create_user_command('Messages', 'echo "It works!"', {})
```

| User action      | Cmdline                     |
| ---------------- | --------------------------- |
| :=               | ':=                         |
| <SPACE>          | ':=                         |
| <ALT+v> (paste)  | ':= vim.treesitter.         |
| f                | ':= vim.treesitter.f        |
| oldexpr (accept) | ':= vim.treesitter.foldexpr |
| <C-w>            | ':= vim.treesitter.         |
| <C-w>            | ':= vim.treesitter          |
| <C-w>            | ':= vim.                    |
| <C-u>            | ':                          |
| mes<CR>          | 'mes                        |

### Events triggered

| Version  | Original | Patched |
| -------- | -------- | ------- |
| **0.11** | 22       | 12      |
| **0.10** | 20       | 11      |

### Details

0.11 original

```
{ char = "=", event = "on_char_added" } 
{ char = " ", event = "on_char_added" }
{ char = ".", event = "on_char_added" } 
{ char = "f", event = "on_char_added" }
{ char = ".", event = "on_cursor_moved" } 
{ char = "r", event = "on_cursor_moved" } 
{ char = ".", event = "on_cursor_moved" } 
{ char = "", event = "on_cursor_moved" } 
{ char = "m", event = "on_char_added" } 
{ char = "e", event = "on_char_added" } 
{ char = "s", event = "on_char_added" } 
{ char = "e", event = "on_cursor_moved" } 
{ char = "m", event = "on_cursor_moved" } 
{ char = "", event = "on_cursor_moved" } 
{ char = "M", event = "on_cursor_moved" } 
{ char = "e", event = "on_cursor_moved" }
{ char = "s", event = "on_cursor_moved" } 
{ char = "s", event = "on_cursor_moved" } 
{ char = "a", event = "on_cursor_moved" } 
{ char = "g", event = "on_cursor_moved" } 
{ char = "e", event = "on_cursor_moved" } 
{ char = "s", event = "on_cursor_moved" }
```

0.11 patched

```
{ char = "=", event = "on_char_added" } 
{ char = " ", event = "on_char_added" }
{ char = ".", event = "on_char_added" } 
{ char = "f", event = "on_char_added" }
{ char = ".", event = "on_cursor_moved" } 
{ char = "r", event = "on_cursor_moved" } 
{ char = ".", event = "on_cursor_moved" } 
{ char = "", event = "on_cursor_moved" } 
{ char = "m", event = "on_char_added" } 
{ char = "e", event = "on_char_added" } 
{ char = "s", event = "on_char_added" } 
{ char = "e", event = "on_cursor_moved" }
```

0.10 original

```
{ char = "", event = "on_cursor_moved" }
{ char = "=", event = "on_char_added" }
{ char = "=", event = "on_cursor_moved" }
{ char = " ", event = "on_char_added" }
{ char = " ", event = "on_cursor_moved" }
{ char = ".", event = "on_char_added" }
{ char = ".", event = "on_cursor_moved" }
{ char = "f", event = "on_char_added" }
{ char = "f", event = "on_cursor_moved" }
{ char = "r", event = "on_cursor_moved" }
{ char = ".", event = "on_cursor_moved" }
{ char = "r", event = "on_cursor_moved" }
{ char = ".", event = "on_cursor_moved" }
{ char = "", event = "on_cursor_moved" }
{ char = "m", event = "on_char_added" }
{ char = "m", event = "on_cursor_moved" }
{ char = "e", event = "on_char_added" }
{ char = "e", event = "on_cursor_moved" }
{ char = "s", event = "on_char_added" }
{ char = "s", event = "on_cursor_moved" }
```

0.10 patched

```
{ char = "=", event = "on_char_added" }
{ char = " ", event = "on_char_added" }
{ char = ".", event = "on_char_added" }
{ char = "f", event = "on_char_added" }
{ char = ".", event = "on_cursor_moved" }
{ char = "r", event = "on_cursor_moved" }
{ char = ".", event = "on_cursor_moved" }
{ char = "", event = "on_cursor_moved" }
{ char = "m", event = "on_char_added" }
{ char = "e", event = "on_char_added" }
{ char = "s", event = "on_char_added" }
```
