### PR TITLE
Add Rails fixture completion sources to community list

### DIFF
--- a/doc/configuration/sources.md
+++ b/doc/configuration/sources.md
@@ -124,3 +124,5 @@ See [blink.compat](https://github.com/Saghen/blink.compat) for using `nvim-cmp` 
 - [blink-cmp-register](https://github.com/phanen/blink-cmp-register)
 - [blink-cmp-sshconfig](https://github.com/bydlw98/blink-cmp-sshconfig)
 - [blink-cmp-words](https://github.com/archie-judd/blink-cmp-words): Definitions and synonyms
+- [cmp-rails-fixture-names](https://github.com/wassimk/cmp-rails-fixture-names): Ruby on Rails fixture names completion
+- [cmp-rails-fixture-types](https://github.com/wassimk/cmp-rails-fixture-types): Ruby on Rails fixture types completion


### PR DESCRIPTION
Adds two Ruby on Rails fixture completion sources to the community sources list:

- **cmp-rails-fixture-names**: Provides completion for Rails fixture names (e.g., completing 'bob' when typing 'users(:')
- **cmp-rails-fixture-types**: Provides completion for Rails fixture types (e.g., completing 'users' for a User model)

Both sources work with Rails fixtures in the standard test/fixtures or spec/fixtures directories and parse YAML fixture files for completion data.