### PR TITLE
fix(ghost_text): prevent out-of-bounds on multiline edits

### DIFF
--- a/lua/blink/cmp/completion/windows/ghost_text/utils.lua
+++ b/lua/blink/cmp/completion/windows/ghost_text/utils.lua
@@ -1,11 +1,5 @@
 local utils = {}
 
---- @param text_edit lsp.TextEdit
-function utils.get_still_untyped_text(text_edit)
-  local type_text_length = text_edit.range['end'].character - text_edit.range.start.character
-  return text_edit.newText:sub(type_text_length + 1)
-end
-
 function utils.is_cmdline() return vim.api.nvim_get_mode().mode == 'c' end
 function utils.is_cmdwin() return vim.fn.win_gettype() == 'command' end
 


### PR DESCRIPTION
For multiline text edits, LSP's end.character may not always match the cursor column (e.g. rust-analyzer with unmatched parentheses) and could cause out-of-bounds errors when placing ghost text extmarks.

To prevent these errors, use the actual cursor position for ghost text placement.

Related #1197
Closes #1739
