### PR TITLE
fix(luasnip): avoid false positives for in-snippet detection

### DIFF
--- a/lua/blink/cmp/config/snippets.lua
+++ b/lua/blink/cmp/config/snippets.lua
@@ -17,7 +17,7 @@ end
 --- @return boolean
 local function is_hidden_snippet()
   local ls = require('luasnip')
-  return not require('blink.cmp').is_visible() and not ls.in_snippet() and ls.expandable()
+  return not require('blink.cmp').is_visible() and not ls.locally_jumpable(1) and ls.expandable()
 end
 
 local validate = require('blink.cmp.config.utils').validate
@@ -44,7 +44,7 @@ local snippets = {
         local ls = require('luasnip')
         if is_hidden_snippet() then return true end
         if filter and filter.direction then return ls.jumpable(filter.direction) end
-        return ls.in_snippet()
+        return ls.locally_jumpable(1)
       end,
       mini_snippets = function()
         if not _G.MiniSnippets then error('mini.snippets has not been setup') end


### PR DESCRIPTION
The previous logic relied on `ls.in_snippet()` to detect if we are in an active snippet. However, this checks only if the cursor is within the snippet's row bounds. This can return true even if the cursor is outside the actual snippet text (e.g., after the snippet on the same line), leading to false positives.

Instead, use `ls.locally_jumpable(1)`, which only returns true when the cursor is inside a snippet and the current node can be jumped forward from. This provides a more reliable behavior.

Related #1805
Closes #1966
