### PR TITLE
fix: use edit range start for compensation instead of old cursor

### DIFF
--- a/lua/blink/cmp/completion/list.lua
+++ b/lua/blink/cmp/completion/list.lua
@@ -238,9 +238,7 @@ function list.undo_preview()
 
   -- The text edit may be out of date due to the user typing more characters
   -- so we adjust the range to compensate
-  local old_cursor_col = list.preview_undo.cursor_after[2]
-  local new_cursor_col = context.get_cursor()[2]
-  text_edit = text_edits_lib.compensate_for_cursor_movement(text_edit, old_cursor_col, new_cursor_col)
+  text_edit = text_edits_lib.compensate_for_cursor_movement(text_edit)
 
   require('blink.cmp.lib.text_edits').apply(text_edit)
   if list.preview_undo.cursor_before ~= nil then


### PR DESCRIPTION
Using the edit's start as the reference keeps the range correct even if completions are refreshed or the cursor moves.

In substance,

The old logic assumes the difference between old and new cursor columns always reflects how much the edit range should move. But if the cursor moves, or if completions are refreshed (trigger char), the "old" cursor column can be completely out of sync with the actual edit range. This can result in negative values (because of the compute of new - old), causing the edit to go backwards or delete the wrong text (end char < start char).

The new logic always computes the offset from the start of the edit range, which I think is stable and always matches the text to be replaced. It only adjusts if the cursor has moved past the original end, expanding the edit to include new user input. It never produces a range where the end is before the start.

For history I was having this case for some time but did not had the time to dig that much:

```lua
---@diagnostic disable-next-line
```

Typing `disable-next-line` would put the cursor at the end of the ghost text. With this change the issue disappear as well.

Closes #1736
Closes #1978
