### PR TITLE
fix: Move runtime inputs to derivation args and add libiconv for macOS compatibility

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,9 +81,11 @@
           program = let
             buildScript = pkgs.writeShellApplication {
               name = "build-plugin";
-              runtimeInputs = with pkgs; [ fenix.minimal.toolchain gcc ];
+              derivationArgs = {
+                NativeBuildInputs = with pkgs; [ fenix.minimal.toolchain gcc ];
+                buildInputs = with pkgs; [ libiconv ];
+              };
               text = ''
-                export LIBRARY_PATH="${lib.makeLibraryPath [ pkgs.libiconv ]}";
                 cargo build --release
               '';
             };


### PR DESCRIPTION
## Problem
On macOS M1 machines, the build process fails with a duplicate LC_RPATH error:

```
duplicate LC_RPATH '/nix/store/42pzdm5r1px15z4g1xyz878cz0ymy8fp-libSystem-B/lib' in /nix/store/w7xabv7cxkz78rhwnyzrfxdv3ngygbyh-gcc-14-20241116/bin/gcc
```

The root cause was improper usage of `writeShellApplication` and missing build dependencies, making it difficult to diagnose the build environment contents.

## Solution
- **Moved runtime inputs to derivation arguments** for proper dependency management
- **Added libiconv as a build input** to ensure compatibility with the Nix build system
- **Fixed [`writeShellApplication`](https://nixos.org/manual/nixpkgs/unstable/#trivial-builder-writeShellApplication) usage** to follow Nix best practices

### Before

<img width="1254" height="718" alt="301752652098_ pic" src="https://github.com/user-attachments/assets/97d87e3b-7e80-48ab-8380-997d11f12553" />

### After 

<img width="1246" height="279" alt="image" src="https://github.com/user-attachments/assets/efca9c00-bc66-4076-a5ea-9e5405987171" />
