### PR TITLE
fix(lsp): prevent duplicate trailing punctuation in clangd

### DIFF
--- a/lua/blink/cmp/sources/lsp/hacks/clangd.lua
+++ b/lua/blink/cmp/sources/lsp/hacks/clangd.lua
@@ -1,4 +1,13 @@
 local clangd = {}
+local completion_item_kind = require('blink.cmp.types').CompletionItemKind
+
+--- @param text string
+--- @return string
+local function strip_ending_punctuation(text)
+  local last_char = text:sub(-1)
+  if last_char == '>' or last_char == '"' then text = text:sub(1, -2) end
+  return text
+end
 
 --- @param response blink.cmp.CompletionResponse | nil
 --- @return blink.cmp.CompletionResponse | nil
@@ -9,6 +18,10 @@ function clangd.process_response(response)
   if not items then return response end
 
   for _, item in ipairs(items) do
+    if item.kind == completion_item_kind.File then
+      item.textEdit.newText = strip_ending_punctuation(item.textEdit.newText)
+      item.label = strip_ending_punctuation(item.label)
+    end
     item.lsp_score = item.score
   end
   return response


### PR DESCRIPTION
Strip the trailing angle bracket or quote from clangd file completion items to avoid duplicated characters.

This issue is a side effect of the recent change in `compensate_for_cursor_movement` (hope this is the only one). Clangd deliberately includes the closing punctuation in all "file" completion candidates. This behavior is opinionated and there is currently no way to opt out (see https://github.com/clangd/clangd/issues/2277).

While it bothers me to add this downstream workaround, I believe it is reasonable to let users handle the closing character themselves—either manually or via a pairs plugin as they do when using the "path" source or from other lsp.

Feel free to close this PR if you think there is a better solution.

Closes #1989
