### PR TITLE
fix: wrap vim.fn.complete into pcall when adding to dot repeat

### DIFF
--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -386,7 +386,8 @@ function text_edits.write_to_dot_repeat(text_edit)
       local saved_shortmess = vim.o.shortmess
       vim.opt.completeopt = ''
       if not vim.o.shortmess:match('c') then vim.o.shortmess = vim.o.shortmess .. 'c' end
-      vim.fn.complete(1, { '_' .. chars_to_insert })
+      local success, err = pcall(vim.fn.complete, 1, { '_' .. chars_to_insert })
+      if not success then vim.print('dot repeat is not added: ' .. err) end
       vim.opt.completeopt = saved_completeopt
       vim.o.shortmess = saved_shortmess
 


### PR DESCRIPTION
Problem: 
There’s a window(`resolve_timeout_ms`) where you can do anything (like switch to Normal mode) between selecting a completion item and LSP resolving it. The problem is that `vim.fn.complete` throws an error outside of Insert mode. So if you type `Tab -> Esc` you can hit this problem if an LSP will take some time to resolve. Happens to me every day or two.

Solution: Wrap it into `pcall` and notify a user that dot repeat logic is failed. But I am not sure about the message format, maybe you can find a better one.

Before


https://github.com/user-attachments/assets/22d25d03-9c66-46f2-9dc2-86e7727cfcef

After

https://github.com/user-attachments/assets/1129b107-0ff2-45b4-a17c-41438f9bd2b3

But it opens up another problem. As you can see in the "after" demo, there's an incorrect t character left at the end of the completion. This happens because switching to Normal mode decreases the cursor's column position by 1, so the last character isn’t cleared.
Still, I think it’s better to deal with an extra character than with the original error.

I described more about this there https://github.com/Saghen/blink.cmp/issues/1491.