### PR TITLE
fix(presets): add missing `cmdline` preset to hide completion on `<End>`

### DIFF
--- a/lua/blink/cmp/keymap/presets.lua
+++ b/lua/blink/cmp/keymap/presets.lua
@@ -36,6 +36,7 @@ local presets_keymaps = {
 
     ['<C-y>'] = { 'select_and_accept' },
     ['<C-e>'] = { 'cancel' },
+    ['<End>'] = { 'hide', 'fallback' },
   },
 
   ['super-tab'] = {


### PR DESCRIPTION
It is my understanding that the `cmdline` keymap preset is meant to replicate the default completion experience in Vim/Neovim. I noticed it is missing a default key for `<End>` which hides the completion for continuing to complete for cases such as paths. This adds it, let me know if it needs anything else! I have also provided recordings of the behavior in a completely clean Neovim instance and then with this change.


Clean, default Neovim: https://asciinema.org/a/tFG3eVlPzhetmShYAIC0akb1I

Same process with this change: https://asciinema.org/a/7CxgstAd4oP8mMPbHRR3CyZMq


_Note:_ One thing to notice in the default Neovim, if the completion only has one item then it doesn't show, this is useful for quickly using `<Tab>` to fill in a deep path with just a single folder. This behavior isn't the same behavior in `blink.cmp`, but it unrelated to this PR. Just wanted to bring it to attention that it is a very clean workflow to use `<Tab>` repeatedly to build a path of just singly nested folders.