### PR TITLE
feat: add `select_or_accept` keymap

### DIFF
--- a/doc/configuration/keymap.md
+++ b/doc/configuration/keymap.md
@@ -43,6 +43,7 @@ keymap = {
   - Optionally use `function(cmp) cmp.show({ providers = { 'snippets' } }) end` to show with a specific list of providers
 - `show_and_insert`: Shows the completion menu and inserts the first item
   - Short form for `cmp.show({ initial_selected_item_idx = 1 })` when `auto_insert = true`
+- `show_and_insert_or_accept_single`: Shows the completion menu and inserts the first item, or accepts the first item if there is only one
 - `hide`: Hides the completion menu
 - `cancel`: Reverts `completion.list.selection.auto_insert` and hides the completion menu
 - `accept`: Accepts the currently selected item
@@ -51,7 +52,6 @@ keymap = {
 - `accept_and_enter`: Accepts the currently selected item and feeds an enter key to neovim
   - Useful in `cmdline` mode to accept the current item and run the command
 - `select_and_accept`: Accepts the currently selected item, or the first item if none are selected
-- `select_or_accept`: Select the first completion item if there are multiple candidates, or accept it if there is only one.
 - `select_accept_and_enter`: Accepts the currently selected item, or the first item if none are selected, and feeds an enter key to neovim
   - Useful in `cmdline` mode to accept the current item and run the command
 - `select_prev`: Selects the previous item, cycling to the bottom of the list if at the top, if `completion.list.cycle.from_top == true`

--- a/doc/configuration/keymap.md
+++ b/doc/configuration/keymap.md
@@ -51,6 +51,7 @@ keymap = {
 - `accept_and_enter`: Accepts the currently selected item and feeds an enter key to neovim
   - Useful in `cmdline` mode to accept the current item and run the command
 - `select_and_accept`: Accepts the currently selected item, or the first item if none are selected
+- `select_or_accept`: Select the first completion item if there are multiple candidates, or accept it if there is only one.
 - `select_accept_and_enter`: Accepts the currently selected item, or the first item if none are selected, and feeds an enter key to neovim
   - Useful in `cmdline` mode to accept the current item and run the command
 - `select_prev`: Selects the previous item, cycling to the bottom of the list if at the top, if `completion.list.cycle.from_top == true`

--- a/doc/modes/cmdline.md
+++ b/doc/modes/cmdline.md
@@ -33,8 +33,8 @@ Set via `cmdline.keymap.preset = 'cmdline'`, which is the default. Set to `'none
   -- instead of using the neovim defaults
   -- preset = 'inherit',
 
-  ['<Tab>'] = { 'show_and_insert', 'select_next' },
-  ['<S-Tab>'] = { 'show_and_insert', 'select_prev' },
+  ['<Tab>'] = { 'select_or_accept', 'select_next' },
+  ['<S-Tab>'] = { 'select_or_accept', 'select_prev' },
 
   ['<C-space>'] = { 'show', 'fallback' },
 

--- a/doc/modes/cmdline.md
+++ b/doc/modes/cmdline.md
@@ -33,8 +33,8 @@ Set via `cmdline.keymap.preset = 'cmdline'`, which is the default. Set to `'none
   -- instead of using the neovim defaults
   -- preset = 'inherit',
 
-  ['<Tab>'] = { 'select_or_accept', 'select_next' },
-  ['<S-Tab>'] = { 'select_or_accept', 'select_prev' },
+  ['<Tab>'] = { 'show_and_insert_or_accept_single', 'select_next' },
+  ['<S-Tab>'] = { 'show_and_insert_or_accept_single', 'select_prev' },
 
   ['<C-space>'] = { 'show', 'fallback' },
 

--- a/lua/blink/cmp/config/keymap.lua
+++ b/lua/blink/cmp/config/keymap.lua
@@ -8,6 +8,7 @@
 --- | 'accept' Accept the current completion item
 --- | 'accept_and_enter' Accept the current completion item and feed an enter key to neovim (i.e. to execute the current command in cmdline mode)
 --- | 'select_and_accept' Select the first completion item, if there's no selection, and accept
+--- | 'select_or_accept' Select the first completion item if there are multiple candidates, or accept it if there is only one.
 --- | 'select_accept_and_enter' Select the first completion item, if there's no selection, accept and feed an enter key to neovim (i.e. to execute the current command in cmdline mode)
 --- | 'select_prev' Select the previous completion item
 --- | 'select_next' Select the next completion item
@@ -52,14 +53,8 @@
 --- Mappings similar to the built-in completion in cmdline mode:
 --- ```lua
 --- {
----   ['<Tab>'] = {
----     function(cmp)
----       if cmp.is_ghost_text_visible() and not cmp.is_menu_visible() then return cmp.accept() end
----     end,
----     'show_and_insert',
----     'select_next',
----   },
----   ['<S-Tab>'] = { 'show_and_insert', 'select_prev' },
+---   ['<Tab>'] = { 'select_or_accept', 'select_next' },
+---   ['<S-Tab>'] = { 'select_or_accept', 'select_prev' },
 ---
 ---   ['<C-n>'] = { 'select_next' },
 ---   ['<C-p>'] = { 'select_prev' },
@@ -178,6 +173,7 @@ function keymap.validate(config, is_mode)
     'accept',
     'accept_and_enter',
     'select_and_accept',
+    'select_or_accept',
     'select_accept_and_enter',
     'select_prev',
     'select_next',

--- a/lua/blink/cmp/config/keymap.lua
+++ b/lua/blink/cmp/config/keymap.lua
@@ -2,13 +2,13 @@
 --- | 'fallback' Fallback to mappings or the built-in behavior
 --- | 'fallback_to_mappings' Fallback to mappings only (not built-in behavior)
 --- | 'show' Show the completion window
---- | 'show_and_insert' Show the completion window and select the first item
+--- | 'show_and_insert' Show the completion menu and insert the first item. Short form for `cmp.show({ initial_selected_item_idx = 1 })` when `auto_insert = true`
+--- | 'show_and_insert_or_accept_single' Show the completion menu and insert the first item, or accepts the first item if there is only one
 --- | 'hide' Hide the completion window
 --- | 'cancel' Cancel the current completion, undoing the preview from auto_insert
 --- | 'accept' Accept the current completion item
 --- | 'accept_and_enter' Accept the current completion item and feed an enter key to neovim (i.e. to execute the current command in cmdline mode)
 --- | 'select_and_accept' Select the first completion item, if there's no selection, and accept
---- | 'select_or_accept' Select the first completion item if there are multiple candidates, or accept it if there is only one.
 --- | 'select_accept_and_enter' Select the first completion item, if there's no selection, accept and feed an enter key to neovim (i.e. to execute the current command in cmdline mode)
 --- | 'select_prev' Select the previous completion item
 --- | 'select_next' Select the next completion item
@@ -53,8 +53,8 @@
 --- Mappings similar to the built-in completion in cmdline mode:
 --- ```lua
 --- {
----   ['<Tab>'] = { 'select_or_accept', 'select_next' },
----   ['<S-Tab>'] = { 'select_or_accept', 'select_prev' },
+---   ['<Tab>'] = { 'show_and_insert_or_accept_single', 'select_next' },
+---   ['<S-Tab>'] = { 'show_and_insert_or_accept_single', 'select_prev' },
 ---
 ---   ['<C-n>'] = { 'select_next' },
 ---   ['<C-p>'] = { 'select_prev' },
@@ -168,12 +168,12 @@ function keymap.validate(config, is_mode)
     'fallback_to_mappings',
     'show',
     'show_and_insert',
+    'show_and_insert_or_accept_single',
     'hide',
     'cancel',
     'accept',
     'accept_and_enter',
     'select_and_accept',
-    'select_or_accept',
     'select_accept_and_enter',
     'select_prev',
     'select_next',

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -152,7 +152,27 @@ function cmp.select_and_accept(opts)
   return true
 end
 
---- Select the first completion item, if there's no selection, and enter
+--- Select the first completion item if there are multiple candidates, or accept it if there is only one.
+--- @param opts? blink.cmp.CompletionListSelectAndAcceptOpts
+function cmp.select_or_accept(opts)
+  local completion_list = require('blink.cmp.completion.list')
+
+  if #completion_list.items == 1 then
+    vim.schedule(
+      function()
+        completion_list.accept({
+          index = completion_list.selected_item_idx or 1,
+          callback = opts and opts.callback,
+        })
+      end
+    )
+    return true
+  end
+
+  return cmp.show_and_insert()
+end
+
+--- Accept the current completion item and feed an enter key to neovim (i.e. to execute the current command in cmdline mode)
 --- @param opts? blink.cmp.CompletionListSelectAndAcceptOpts
 function cmp.accept_and_enter(opts)
   return cmp.accept({
@@ -163,7 +183,7 @@ function cmp.accept_and_enter(opts)
   })
 end
 
---- Select the first completion item, if there's no selection, and enter
+--- Select the first completion item, if there's no selection, accept and feed an enter key to neovim (i.e. to execute the current command in cmdline mode)
 --- @param opts? blink.cmp.CompletionListSelectAndAcceptOpts
 function cmp.select_accept_and_enter(opts)
   return cmp.select_and_accept({

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -97,6 +97,24 @@ function cmp.show_and_insert(opts)
   return cmp.show(opts)
 end
 
+--- Select the first completion item if there are multiple candidates, or accept it if there is only one, after showing
+--- @param opts? blink.cmp.CompletionListSelectAndAcceptOpts
+function cmp.show_and_insert_or_accept_single(opts)
+  return cmp.show_and_insert({
+    callback = function()
+      local list = require('blink.cmp.completion.list')
+      if #list.items == 1 then
+        list.accept({
+          index = 1,
+          callback = opts and opts.callback,
+        })
+      elseif opts and opts.callback then
+        opts.callback()
+      end
+    end,
+  })
+end
+
 --- Hide the completion window
 --- @param opts? { callback?: fun() }
 function cmp.hide(opts)
@@ -150,26 +168,6 @@ function cmp.select_and_accept(opts)
     end
   )
   return true
-end
-
---- Select the first completion item if there are multiple candidates, or accept it if there is only one.
---- @param opts? blink.cmp.CompletionListSelectAndAcceptOpts
-function cmp.select_or_accept(opts)
-  local completion_list = require('blink.cmp.completion.list')
-
-  if #completion_list.items == 1 then
-    vim.schedule(
-      function()
-        completion_list.accept({
-          index = completion_list.selected_item_idx or 1,
-          callback = opts and opts.callback,
-        })
-      end
-    )
-    return true
-  end
-
-  return cmp.show_and_insert()
 end
 
 --- Accept the current completion item and feed an enter key to neovim (i.e. to execute the current command in cmdline mode)

--- a/lua/blink/cmp/keymap/presets.lua
+++ b/lua/blink/cmp/keymap/presets.lua
@@ -24,8 +24,8 @@ local presets_keymaps = {
   },
 
   cmdline = {
-    ['<Tab>'] = { 'show_and_insert', 'select_next' },
-    ['<S-Tab>'] = { 'show_and_insert', 'select_prev' },
+    ['<Tab>'] = { 'select_or_accept', 'select_next' },
+    ['<S-Tab>'] = { 'select_or_accept', 'select_prev' },
 
     ['<C-space>'] = { 'show', 'fallback' },
 

--- a/lua/blink/cmp/keymap/presets.lua
+++ b/lua/blink/cmp/keymap/presets.lua
@@ -24,8 +24,8 @@ local presets_keymaps = {
   },
 
   cmdline = {
-    ['<Tab>'] = { 'select_or_accept', 'select_next' },
-    ['<S-Tab>'] = { 'select_or_accept', 'select_prev' },
+    ['<Tab>'] = { 'show_and_insert_or_accept_single', 'select_next' },
+    ['<S-Tab>'] = { 'show_and_insert_or_accept_single', 'select_prev' },
 
     ['<C-space>'] = { 'show', 'fallback' },
 


### PR DESCRIPTION
Add `cmp.select_or_accept()` to select the first candidate if multiple or accept the only candidate.

Update default cmdline keymaps to use it for `<Tab>` and `<S-Tab>`, matching Neovim's cmdline `<Tab>` behavior.

Closes #2032
