### PR TITLE
fix(window): clamp highlights to prevent overflow beyond text bounds

### DIFF
--- a/lua/blink/cmp/completion/windows/render/column.lua
+++ b/lua/blink/cmp/completion/windows/render/column.lua
@@ -103,9 +103,12 @@ function column:get_line_highlights(line_idx)
         table.insert(highlights, { offset, offset + #text, group = column_highlights })
       elseif type(column_highlights) == 'table' then
         for _, highlight in ipairs(column_highlights) do
+          local start_col = offset + (highlight[1] or 0)
+          local end_col = offset + (highlight[2] or #text)
+
           table.insert(highlights, {
-            offset + (highlight[1] or 0),
-            offset + (highlight[2] or #text),
+            math.min(math.max(start_col, offset), offset + #text),
+            math.min(math.max(end_col, offset), offset + #text),
             group = highlight.group,
             params = highlight.params,
             priority = highlight.priority,


### PR DESCRIPTION
This prevents highlights from overflowing into next columns, ensuring that highlight ranges stay inside their text.

before
<img width="746" height="267" alt="1753809304-region" src="https://github.com/user-attachments/assets/17ec5165-ddd4-445a-8c09-fff5fdaa7428" />

after
<img width="754" height="279" alt="1753809397-region" src="https://github.com/user-attachments/assets/c93f7f0d-b6e3-4c5d-a9de-905b82e28dbe" />


