### PR TITLE
feat(luasnip): pass matched part of trigger to luasnip.

### DIFF
--- a/lua/blink/cmp/sources/snippets/luasnip.lua
+++ b/lua/blink/cmp/sources/snippets/luasnip.lua
@@ -194,7 +194,12 @@ function source:execute(ctx, item)
     to = cursor,
   }
 
-  local expand_params = snip:matches(require('luasnip.util.util').get_current_line_to_cursor())
+  local line = ctx.get_line()
+  local line_to_cursor = line:sub(1, range['end'].character)
+  local range_text = line:sub(range.start.character + 1, range['end'].character)
+
+  local expand_params = snip:matches(line_to_cursor, { fallback_match = range_text })
+
   if expand_params ~= nil then
     if expand_params.clear_region ~= nil then
       clear_region = expand_params.clear_region


### PR DESCRIPTION
Hi :)

I've added a small new feature to luasnip where it's now possible to get a result from `snip:matches` even if the characters before the cursor don't match the trigger.
While this does not help in cases where the snippet's trigger is a regex/pattern and its captures should be available in the snippet, it fixes e.g. https://github.com/L3MON4D3/LuaSnip/issues/1374, where variables/snippet-match-region is determined by `resolveExpandParams`.