### PR TITLE
feat: allow string return in keymap

### DIFF
--- a/lua/blink/cmp/config/keymap.lua
+++ b/lua/blink/cmp/config/keymap.lua
@@ -24,7 +24,7 @@
 --- | 'scroll_signature_down' Scroll the signature window down
 --- | 'snippet_forward' Move the cursor forward to the next snippet placeholder
 --- | 'snippet_backward' Move the cursor backward to the previous snippet placeholder
---- | (fun(cmp: blink.cmp.API): boolean?) Custom function where returning true will prevent the next command from running
+--- | (fun(cmp: blink.cmp.API): string? | boolean?) Custom function where returning true will prevent the next command from running. Returning a string will insert the literal characters
 
 --- @alias blink.cmp.KeymapPreset
 --- | 'none' No keymaps

--- a/lua/blink/cmp/keymap/apply.lua
+++ b/lua/blink/cmp/keymap/apply.lua
@@ -23,7 +23,9 @@ function apply.keymap_to_current_buffer(keys_to_commands)
 
           -- run user defined functions
         elseif type(command) == 'function' then
-          if command(require('blink.cmp')) then return end
+          local ret = command(require('blink.cmp'))
+          if type(ret) == 'string' then return ret end
+          if ret then return end
 
           -- otherwise, run the built-in command
         elseif require('blink.cmp')[command]() then


### PR DESCRIPTION
Problem:

In #2139 I outlined a bit about what issue I had, where expr mappings are being picked up before `vim.on_key` as opposed to regular mappings.

Solution:

Make it possible to return a string value to potentially opt out of the key being marked as typed.

With this I can for example do something like this:

```lua
                ["<CR>"] = {
                    function(cmp)
                        if not cmp.is_visible or require("blink.cmp.completion.list").get_selected_item() == nil then
                            return
                        end
                        vim.schedule(function()
                            cmp.accept()
                        end)
                        return vim.api.nvim_replace_termcodes("<ESC>a", true, false, true)
                    end,
                    "fallback",
                },
```

This will make the callback in`vim.on_key` _not_ be invoked on `<CR>`