### PR TITLE
docs(recipes): Fix mini.icons + lspkind recipe

### DIFF
--- a/doc/recipes.md
+++ b/doc/recipes.md
@@ -466,10 +466,10 @@ completion = {
               return require("lspkind").symbolic(ctx.kind, { mode = "symbol" }) .. ctx.icon_gap
             end
 
-            local is_fs_type = vim.tbl_contains({ "link", "socket", "fifo", "char", "block", "unknown" }, ctx.item.data.type)
+            local is_unknown_type = vim.tbl_contains({ "link", "socket", "fifo", "char", "block", "unknown" }, ctx.item.data.type)
             local mini_icon, _ = require("mini.icons").get(
-              is_fs_type and "os" or ctx.item.data.type,
-              is_fs_type and "" or ctx.label
+              is_unknown_type and "os" or ctx.item.data.type,
+              is_unknown_type and "" or ctx.label
             )
 
             return (mini_icon or ctx.kind_icon) .. ctx.icon_gap
@@ -478,10 +478,10 @@ completion = {
           highlight = function(ctx)
             if ctx.source_name ~= "Path" then return ctx.kind_hl end
 
-            local is_fs_type = vim.tbl_contains({ "link", "socket", "fifo", "char", "block", "unknown" }, ctx.item.data.type)
+            local is_unknown_type = vim.tbl_contains({ "link", "socket", "fifo", "char", "block", "unknown" }, ctx.item.data.type)
             local mini_icon, mini_hl = require("mini.icons").get(
-              is_fs_type and "os" or ctx.item.data.type,
-              is_fs_type and "" or ctx.label
+              is_unknown_type and "os" or ctx.item.data.type,
+              is_unknown_type and "" or ctx.label
             )
             return mini_icon ~= nil and mini_hl or ctx.kind_hl
           end,


### PR DESCRIPTION
From #2121:

> @Saghen So the problem is, I recenetly discovered that ctx.item.data.type can be "link" and mini.icons doesn't have that category. For instance, while writing shebangs.
>
> I apologize for opening this PR without testing more instances. And what should I do know? Revert this PR?

The issue is that icons related to filesystem types (like `link`, `socket`, `fifo`, etc.) don’t exist in `mini.icons`. With this PR, those types are assigned the default `"os"` icon (a desktop computer), since I couldn’t find a better fit for filesystem-related items.

I am aware that the code pattern repeats twice, but I kept it that way because I felt an external function wouldn’t fit well with the general structure of the “recipes".