### PR TITLE
refactor(path): rework async scan, add `max_entries` limit

### DIFF
--- a/doc/configuration/reference.md
+++ b/doc/configuration/reference.md
@@ -549,6 +549,8 @@ sources.providers = {
       show_hidden_files_by_default = false,
       -- Treat `/path` as starting from the current working directory (cwd) instead of the root of your filesystem
       ignore_root_slash = false,
+      -- Maximum number of files/directories to return. This limits memory use and responsiveness for very large folders.
+      max_entries = 10000,
     }
   },
 


### PR DESCRIPTION
- Rework async scan directory logic using `uv.fs_scandir` (simpler libuv approach for directory iteration)
- Add back a configurable limit to directory scan results
- Manually invoke Lua garbage collector to limit memory growth
- Add missing Lua annotations

Closes #2196