### PR TITLE
fix: don't modify global &iskeyword

### DIFF
--- a/lua/blink/cmp/fuzzy/lua/keyword.lua
+++ b/lua/blink/cmp/fuzzy/lua/keyword.lua
@@ -10,13 +10,13 @@ local FORWARD_REGEX = vim.regex([[^\k*]])
 --- @param cb fun(): T, Y
 --- @return T, Y
 function keyword.with_constant_is_keyword(cb)
-  local existing_is_keyword = vim.opt.iskeyword
+  local existing_is_keyword = vim.bo.iskeyword
   local desired_is_keyword = '@,48-57,_,-,192-255'
   if existing_is_keyword == desired_is_keyword then return cb() end
 
-  vim.opt.iskeyword = '@,48-57,_,-,192-255'
+  vim.bo.iskeyword = '@,48-57,_,-,192-255'
   local success, a, b = pcall(cb)
-  vim.opt.iskeyword = existing_is_keyword
+  vim.bo.iskeyword = existing_is_keyword
 
   if success then return a, b end
   error(a)


### PR DESCRIPTION
When editing a new buffer, its local option values must be initialized.  Since
the local options of the current buffer might be specifically for that buffer,
these are not used.  Instead, for each buffer-local option there also is a
global value, which is used for new buffers.  With ":set" both the local and
global value is changed.  With "setlocal" only the local value is changed,
thus this value is not used when editing a new buffer.

vim.o/:set modify both global/local option.

So when switch to a new buffer without resetting local value
(e.g. without setlocal isk in its ftplugin), it will
our modifed version global value.
