### PR TITLE
fix(snippets): provide `textEdit` field for builtin snippet

### DIFF
--- a/lua/blink/cmp/sources/snippets/default/init.lua
+++ b/lua/blink/cmp/sources/snippets/default/init.lua
@@ -38,7 +38,7 @@ function snippets:get_completions(context, callback)
   end
 
   local items = vim.tbl_map(
-    function(item) return self.registry:snippet_to_completion_item(item, context.id) end,
+    function(item) return self.registry:snippet_to_completion_item(item, context) end,
     self.cache[filetype]
   )
   callback({

--- a/lua/blink/cmp/sources/snippets/default/registry.lua
+++ b/lua/blink/cmp/sources/snippets/default/registry.lua
@@ -107,20 +107,42 @@ function registry:get_global_snippets()
 end
 
 --- @param snippet blink.cmp.Snippet
---- @param cache_key number
+--- @param context blink.cmp.Context
 --- @return blink.cmp.CompletionItem
-function registry:snippet_to_completion_item(snippet, cache_key)
-  local body = type(snippet.body) == 'string' and snippet.body or table.concat(snippet.body, '\n')
+function registry:snippet_to_completion_item(snippet, context)
+  local body = type(snippet.body) == 'string' and snippet.body --[[@as string]]
+    or table.concat(snippet.body --[[@as table]], '\n')
+
+  local new_text = self:expand_vars(body, context.id)
+  local cur_line, cur_col = unpack(context.cursor)
+
+  -- Find the position of the (longest partial) prefix just before the cursor
+  local start_col
+  local line = context.get_line():sub(1, cur_col)
+  for i = #snippet.prefix, 1, -1 do
+    local pos = cur_col - i + 1
+    if line:sub(pos, cur_col) == snippet.prefix:sub(1, i) then
+      start_col = pos
+      break
+    end
+  end
 
   ---@type blink.cmp.CompletionItem
   return {
     kind = require('blink.cmp.types').CompletionItemKind.Snippet,
     label = snippet.prefix,
     insertTextFormat = vim.lsp.protocol.InsertTextFormat.Snippet,
-    insertText = self:expand_vars(body, cache_key),
+    insertText = new_text,
     description = snippet.description,
     labelDetails = snippet.description and self.config.use_label_description and { description = snippet.description }
       or nil,
+    textEdit = {
+      range = {
+        start = { line = cur_line - 1, character = (start_col or context.bounds.start_col) - 1 },
+        ['end'] = { line = cur_line - 1, character = cur_col },
+      },
+      newText = new_text,
+    },
   }
 end
 


### PR DESCRIPTION
Completion items didn't include the `textEdit` field before, so blink.cmp had to guess where to insert them. That guess was sometimes off, e.g., when the character before the cursor is the same as the first character of the expanded snippet, leading to incorrect insertion.

Closes #2159
