### PR TITLE
feat(snippets)!: rework LuaSnip source

### DIFF
--- a/doc/configuration/reference.md
+++ b/doc/configuration/reference.md
@@ -585,8 +585,6 @@ sources.providers = {
       use_show_condition = true,
       -- Whether to show autosnippets in the completion list
       show_autosnippets = true,
-      -- Whether to prefer docTrig placeholders over trig when expanding regTrig snippets
-      prefer_doc_trig = false,
       -- Whether to put the snippet description in the label description
       use_label_description = false,
     }

--- a/doc/configuration/snippets.md
+++ b/doc/configuration/snippets.md
@@ -89,9 +89,7 @@ There's a great introduction to writing custom snippets [in the nvim-scissors re
 ```lua
 {
   'saghen/blink.cmp',
-  version = '1.*',
-  -- `main` is untested, please open a PR if you've confirmed it works as expected
-  dependencies = { 'L3MON4D3/LuaSnip', version = 'v2.*' },
+  dependencies = { 'L3MON4D3/LuaSnip' },
   opts = {
     snippets = { preset = 'luasnip' },
     -- ensure you have the `snippets` source (enabled by default)
@@ -107,7 +105,7 @@ There's a great introduction to writing custom snippets [in the nvim-scissors re
 ```lua
 {
   'saghen/blink.cmp',
-  dependencies = 'echasnovski/mini.snippets',
+  dependencies = { 'echasnovski/mini.snippets' },
   opts = {
     snippets = { preset = 'mini_snippets' },
     -- ensure you have the `snippets` source (enabled by default)
@@ -123,9 +121,10 @@ There's a great introduction to writing custom snippets [in the nvim-scissors re
 ```lua
 {
   'saghen/blink.cmp',
-  dependencies = {'hrsh7th/vim-vsnip', 'https://codeberg.org/FelipeLema/bink-cmp-vsnip.git'},
+  dependencies = { 'hrsh7th/vim-vsnip', 'https://codeberg.org/FelipeLema/bink-cmp-vsnip.git' },
   opts = {
     snippets = { preset = 'vsnip' },
+    -- ensure you have the `snippets` source (enabled by default)
     sources = {
       default = { 'lsp', 'path', 'snippets', 'buffer' },
     },

--- a/lua/blink/cmp/sources/snippets/luasnip.lua
+++ b/lua/blink/cmp/sources/snippets/luasnip.lua
@@ -1,94 +1,197 @@
+---@type LuaSnip.API
+local luasnip
+local cmp = require('blink.cmp')
+local lib = require('blink.lib')
+local nvim = require('blink.lib.nvim')
+local text_edits = require('blink.cmp.lib.text_edits')
+local kind_snippet = require('blink.cmp.types').CompletionItemKind.Snippet
+
 --- @class blink.cmp.LuasnipSourceOptions
 --- @field use_show_condition? boolean Whether to use show_condition for filtering snippets
 --- @field show_autosnippets? boolean Whether to show autosnippets in the completion list
---- @field prefer_doc_trig? boolean When expanding `regTrig` snippets, prefer `docTrig` over `trig` placeholder
 --- @field use_label_description? boolean Whether to put the snippet description in the label description
 
+---@class blink.cmp.LuasnipItemData
+---@field snip_id number
+---@field show_condition function
+---@field raw_text string
+
 --- @class blink.cmp.LuasnipSource : blink.cmp.Source
---- @field config blink.cmp.LuasnipSourceOptions
+--- @field opts blink.cmp.LuasnipSourceOptions
 --- @field items_cache table<string, blink.cmp.CompletionItem[]>
-
-local lib = require('blink.lib')
-local nvim = require('blink.lib.nvim')
-
---- @type blink.cmp.LuasnipSource
---- @diagnostic disable-next-line: missing-fields
+--- @field has_loaded boolean
 local source = {}
 
-local default_config = {
-  use_show_condition = true,
-  show_autosnippets = true,
-  prefer_doc_trig = false,
-  use_label_description = false,
-}
-
 ---@param snippet table
----@param event string
+---@param event number
 ---@param callback fun(table, table)
 local function add_luasnip_callback(snippet, event, callback)
-  local events = require('luasnip.util.events')
   -- not defined for autosnippets
   if snippet.callbacks == nil then return end
   snippet.callbacks[-1] = snippet.callbacks[-1] or {}
-  snippet.callbacks[-1][events[event]] = callback
+  snippet.callbacks[-1][event] = callback
 end
 
+---@param snippet LuaSnip.Snippet
+local function regex_callback(snippet, docTrig)
+  if #snippet.insert_nodes == 0 then
+    snippet.insert_nodes[0].static_text[1] = docTrig
+    return
+  end
+
+  local matches = { string.match(docTrig, snippet.trigger) }
+  for i, match in ipairs(matches) do
+    local idx = i ~= #matches and i or 0
+    snippet.insert_nodes[idx].static_text[1] = match
+  end
+end
+
+---@param snippet LuaSnip.Snippet
+local function choice_callback(snippet, events)
+  local types = require('luasnip.util.types')
+
+  for _, node in ipairs(snippet.insert_nodes) do
+    if node.type == types.choiceNode then
+      node.node_callbacks = {
+        [events.enter] = function(n)
+          --[[@cast n LuaSnip.ChoiceNode]]
+          n:set_text({ '' }) -- Clear the current text, we'll restore it when leaving the node
+          local index = lib.list.find_idx(n.choices, function(choice) return choice == n.active_choice end)
+          -- FIXME: Defer showing the completion menu when jumping to the next choice node.
+          -- This is needed if the previous node is also a choice node. Possible race condition?
+          -- e.g., previous node (menu shown) -> jump -> (menu hidden) -> next node (menu shown)
+          vim.defer_fn(function() cmp.show({ initial_selected_item_idx = index, providers = { 'snippets' } }) end, 50)
+        end,
+        [events.change_choice] = function()
+          -- Auto-jump after accepting the choice value
+          vim.schedule(function() luasnip.jump(1) end)
+        end,
+        [events.leave] = function(n)
+          --[[@cast n LuaSnip.ChoiceNode]]
+          n:set_text(n.active_choice.static_text)
+        end,
+      }
+    end
+  end
+end
+
+local function indent_text(lines, indent)
+  if #lines == 0 then return '' end
+  local text = table.concat(lines, '\n')
+  return text:gsub('\n', '\n' .. indent)
+end
+
+---@param snippet LuaSnip.Snippet
+---@param indent? string
+---@return string
+local function get_insert_text(snippet, indent)
+  indent = indent or ''
+
+  if snippet.docTrig then return snippet.docTrig end
+  if snippet.regTrig then return snippet.trigger end
+  -- TODO: Remove this guard when luasnip#1396 merged
+  if not snippet.nodes then return snippet.trigger end
+
+  local types = require('luasnip.util.types')
+  local res = {}
+  for _, node in ipairs(snippet.nodes) do
+    if node.static_text then
+      res[#res + 1] = indent_text(node:get_static_text(), indent)
+    elseif vim.tbl_contains({ types.dynamicNode, types.functionNode }, node.type) then
+      res[#res + 1] = '...'
+    end
+  end
+
+  return #res == 1 and snippet.trigger or table.concat(res, '')
+end
+
+---@param opts blink.cmp.LuasnipSourceOptions
 function source.new(opts)
-  local config = vim.tbl_deep_extend('keep', opts, default_config)
-  -- require('blink.cmp.config.utils').validate('sources.providers.snippets.opts', {
-  --   use_show_condition = { config.use_show_condition, 'boolean' },
-  --   show_autosnippets = { config.show_autosnippets, 'boolean' },
-  --   prefer_doc_trig = { config.prefer_doc_trig, 'boolean' },
-  --   use_label_description = { config.use_label_description, 'boolean' },
-  -- }, config)
-
   local self = setmetatable({}, { __index = source })
-  self.config = config
-  self.items_cache = {}
 
-  local luasnip_ag = nvim.create_augroup('BlinkCmpLuaSnipReload', { clear = true })
-  nvim.create_autocmd('User', {
-    pattern = 'LuasnipSnippetsAdded',
-    callback = function() self:reload() end,
-    group = luasnip_ag,
-    desc = 'Reset internal cache of luasnip source of blink.cmp when new snippets are added',
+  opts = vim.tbl_deep_extend('keep', opts or {}, {
+    use_show_condition = true,
+    show_autosnippets = true,
+    use_label_description = false,
   })
-  nvim.create_autocmd('User', {
-    pattern = 'LuasnipCleanup',
-    callback = function() self:reload() end,
-    group = luasnip_ag,
-    desc = 'Reload luasnip source of blink.cmp when snippets are cleared',
-  })
+  -- require('blink.cmp.config.utils').validate('sources.providers.snippets.opts', {
+  --   use_show_condition = { opts.use_show_condition, 'boolean' },
+  --   show_autosnippets = { opts.show_autosnippets, 'boolean' },
+  --   use_label_description = { opts.use_label_description, 'boolean' },
+  -- }, opts)
+
+  self.opts = opts
+  self.items_cache = {}
+  self.has_loaded = false
+
+  local ok, mod = pcall(require, 'luasnip')
+  if ok then
+    self.has_loaded = true
+    luasnip = mod --[[@as LuaSnip.API]]
+
+    local augroup = nvim.create_augroup('BlinkCmpLuaSnipReload', { clear = true })
+    local events = {
+      { pattern = 'LuasnipSnippetsAdded', desc = 'Clear the Luasnip cache in blink.cmp when new snippets are added' },
+      { pattern = 'LuasnipCleanup', desc = 'Clear the Luasnip cache in blink.cmp when snippets are cleared' },
+    }
+    for _, event in ipairs(events) do
+      nvim.create_autocmd('User', {
+        pattern = event.pattern,
+        callback = function() self:reload() end,
+        group = augroup,
+        desc = event.desc,
+      })
+    end
+  end
 
   return self
 end
 
-function source:enabled()
-  local ok, _ = pcall(require, 'luasnip')
-  return ok
-end
+function source:enabled() return self.has_loaded end
 
+---@param ctx blink.cmp.Context
+---@param callback fun(result?: blink.cmp.CompletionResponse)
 function source:get_completions(ctx, callback)
   --- @type blink.cmp.CompletionItem[]
   local items = {}
 
-  -- gather snippets from relevant filetypes, including extensions
-  for _, ft in ipairs(require('luasnip.util.util').get_snippet_filetypes()) do
-    if self.items_cache[ft] then
+  if luasnip.choice_active() then
+    ---@type LuaSnip.ChoiceNode
+    local active_choice = luasnip.session.active_choice_nodes[ctx.bufnr]
+    for i, choice in ipairs(active_choice.choices) do
+      local text = choice.static_text and choice:get_static_text()[1] or ''
+      table.insert(items, {
+        label = text,
+        kind = kind_snippet,
+        insertText = text,
+        insertTextFormat = vim.lsp.protocol.InsertTextFormat.PlainText,
+        data = { snip_id = active_choice.parent.snippet.id, choice_index = i },
+      })
+    end
+    callback({ is_incomplete_forward = false, is_incomplete_backward = false, items = items })
+    return
+  end
+
+  local events = require('luasnip.util.events')
+
+  -- Else, gather snippets from relevant filetypes, including extensions
+  for _, ft in ipairs(luasnip.get_snippet_filetypes()) do
+    if self.items_cache[ft] and #self.items_cache[ft] > 0 then
       for _, item in ipairs(self.items_cache[ft]) do
         table.insert(items, lib.tbl.copy(item))
       end
       goto continue
     end
 
-    -- cache not yet available for this filetype
-    self.items_cache[ft] = {}
+    -- Cache not yet available for this filetype
+    self.items_cache[ft] = nil
+
     -- Gather filetype snippets and, optionally, autosnippets
-    local snippets = require('luasnip').get_snippets(ft, { type = 'snippets' })
-    if self.config.show_autosnippets then
-      local autosnippets = require('luasnip').get_snippets(ft, { type = 'autosnippets' })
+    local snippets = luasnip.get_snippets(ft, { type = 'snippets' })
+    if self.opts.show_autosnippets then
+      local autosnippets = luasnip.get_snippets(ft, { type = 'autosnippets' })
       for _, s in ipairs(autosnippets) do
-        add_luasnip_callback(s, 'enter', require('blink.cmp').hide)
+        add_luasnip_callback(s, events.enter, cmp.hide)
       end
       snippets = lib.tbl.copy(snippets)
       vim.list_extend(snippets, autosnippets)
@@ -101,7 +204,10 @@ function source:get_completions(ctx, callback)
       max_priority = math.max(max_priority, snip.effective_priority or 0)
     end
 
+    local ft_items = {}
     for _, snip in ipairs(snippets) do
+      ---@cast snip LuaSnip.Snippet
+
       -- Convert priority of 1000 (with max of 8000) to string like "00007000|||asd" for sorting
       -- This will put high priority snippets at the top of the list, and break ties based on the trigger
       local inversed_priority = max_priority - (snip.effective_priority or 0)
@@ -109,44 +215,61 @@ function source:get_completions(ctx, callback)
 
       --- @type lsp.CompletionItem
       local item = {
-        kind = require('blink.cmp.types').CompletionItemKind.Snippet,
+        kind = kind_snippet,
         label = snip.regTrig and snip.name or snip.trigger,
-        insertText = self.config.prefer_doc_trig and snip.docTrig or snip.trigger,
         insertTextFormat = vim.lsp.protocol.InsertTextFormat.PlainText,
         sortText = sort_text,
-        data = { snip_id = snip.id, show_condition = snip.show_condition },
-        labelDetails = snip.dscr and self.config.use_label_description and {
+        ---@type blink.cmp.LuasnipItemData
+        data = {
+          snip_id = snip.id,
+          show_condition = snip.show_condition,
+          raw_text = get_insert_text(snip),
+        },
+        labelDetails = snip.dscr and self.opts.use_label_description and {
           description = table.concat(snip.dscr, ' '),
         } or nil,
       }
-      -- populate snippet cache for this filetype
-      table.insert(self.items_cache[ft], item)
-      -- while we're at it, also populate completion items for this request
+      -- Populate snippet cache for this filetype
+      table.insert(ft_items, item)
+      -- While we're at it, also populate completion items for this request
       table.insert(items, lib.tbl.copy(item))
     end
+
+    self.items_cache[ft] = ft_items
 
     ::continue::
   end
 
   -- Filter items based on show_condition, if configured
-  if self.config.use_show_condition then
+  if self.opts.use_show_condition then
     local line_to_cursor = ctx.line:sub(0, ctx.cursor[2] - 1)
     items = vim.tbl_filter(function(item) return item.data.show_condition(line_to_cursor) end, items)
+  end
+
+  -- Compute insertText respecting indent
+  -- TODO: Ideally, handle this in resolve()
+  local indent = ctx.line:match('^%s*') or ''
+  local prefix = '\n' .. indent
+  for _, item in ipairs(items) do
+    local data = item.data --[[@as blink.cmp.LuasnipItemData]]
+    item.insertText = data.raw_text:gsub('\n', prefix)
   end
 
   callback({
     is_incomplete_forward = false,
     is_incomplete_backward = false,
     items = items,
-    context = ctx,
   })
 end
 
+---@param item blink.cmp.CompletionItem
+---@param callback fun(resolved_item?: lsp.CompletionItem)
 function source:resolve(item, callback)
-  local snip = require('luasnip').get_id_snippet(item.data.snip_id)
+  local snip = luasnip.get_id_snippet(item.data.snip_id)
 
   local resolved_item = vim.deepcopy(item)
 
+  ---@type string|string[]|nil
   local detail = snip:get_docstring()
   if type(detail) == 'table' then detail = table.concat(detail, '\n') end
   resolved_item.detail = detail
@@ -161,35 +284,31 @@ function source:resolve(item, callback)
   callback(resolved_item)
 end
 
+---@param ctx blink.cmp.Context
+---@param item blink.cmp.CompletionItem
 function source:execute(ctx, item)
-  local luasnip = require('luasnip')
-  local snip = luasnip.get_id_snippet(item.data.snip_id)
-
-  -- if trigger is a pattern, expand "pattern" instead of actual snippet
-  if snip.regTrig then
-    local docTrig = self.config.prefer_doc_trig and snip.docTrig
-    snip = snip:get_pattern_expand_helper()
-
-    if docTrig then
-      add_luasnip_callback(snip, 'pre_expand', function(snip, _)
-        if #snip.insert_nodes == 0 then
-          snip.insert_nodes[0].static_text = { docTrig }
-        else
-          local matches = { string.match(docTrig, snip.trigger) }
-          for i, match in ipairs(matches) do
-            local idx = i ~= #matches and i or 0
-            snip.insert_nodes[idx].static_text = { match }
-          end
-        end
-      end)
-    end
+  if item.data.choice_index then
+    luasnip.set_choice(item.data.choice_index)
+    return
   end
 
-  -- get (0, 0) indexed cursor position
-  local cursor = ctx.get_cursor()
+  local snip = luasnip.get_id_snippet(item.data.snip_id)
+
+  local events = require('luasnip.util.events')
+  if snip.regTrig then
+    local docTrig = snip.docTrig
+    snip = snip:get_pattern_expand_helper()
+    if docTrig then add_luasnip_callback(snip, events.pre_expand, function(s) regex_callback(s, docTrig) end) end
+  else
+    add_luasnip_callback(snip, events.pre_expand, function(s) choice_callback(s, events) end)
+  end
+
+  local cursor = ctx.get_cursor() --[[@as LuaSnip.BytecolBufferPosition]]
   cursor[1] = cursor[1] - 1
 
-  local range = require('blink.cmp.lib.text_edits').get_from_item(item).range
+  local range = text_edits.get_from_item(item).range
+
+  ---@type LuaSnip.BufferRegion
   local clear_region = {
     from = { range.start.line, range.start.character },
     to = cursor,
@@ -200,17 +319,15 @@ function source:execute(ctx, item)
   local range_text = line:sub(range.start.character + 1, cursor[2])
 
   local expand_params = snip:matches(line_to_cursor, {
-    fallback_match = range_text ~= line_to_cursor and range_text,
+    fallback_match = range_text ~= line_to_cursor and range_text or nil,
   })
 
   if expand_params ~= nil then
     if expand_params.clear_region ~= nil then
       clear_region = expand_params.clear_region
     elseif expand_params.trigger ~= nil then
-      clear_region = {
-        from = { cursor[1], cursor[2] - #expand_params.trigger },
-        to = cursor,
-      }
+      clear_region.from = { cursor[1], cursor[2] - #expand_params.trigger }
+      clear_region.to = cursor
     end
   end
 


### PR DESCRIPTION
Some refactoring on this source for easier maintenance with better annotations. 

- Support latest LuaSnip (branch `main`) 
- Auto-show completion window for node choices (similar to builtin snippet)
- Ghost text "improved" to be more like other snippet engines or LSPs:
  - Support multiline snippets,
  - Dynamic node are represented by `...` 
  - Respect current user indent 
  - Fallback to the label/trigger
- `opts.prefer_doc_trig` removed, this is now always enabled.
- Annotations from https://github.com/L3MON4D3/LuaSnip/pull/1396 (non-blocking for merge). 

---

DEMO (ghost text and node choices)

https://github.com/user-attachments/assets/7d8bdca8-22a6-4546-8496-724e1871ef4d