### PR TITLE
fix(snippets): ensure proper espcaping of special chars

### DIFF
--- a/lua/blink/cmp/sources/snippets/default/registry.lua
+++ b/lua/blink/cmp/sources/snippets/default/registry.lua
@@ -178,6 +178,11 @@ function registry:expand_vars(snippet, cache_key)
       end
 
       if replacement then
+        -- Escape special chars according to the snippet grammar EBNF conventions
+        replacement = replacement:gsub('\\', '\\\\') -- Escape backslashes first!
+        replacement = replacement:gsub('%$', '\\$')
+        replacement = replacement:gsub('}', '\\}')
+
         -- Escape % characters (otherwise fails with strings like `%20`)
         local escaped = replacement:gsub('%%', '%%%%')
 


### PR DESCRIPTION
Previously, when working with the built-in snippet engine, placeholders like `TM_*` or `CLIPBOARD` were populated blindly without escaping special characters. This caused parsing failures, especially for LaTeX snippets with extensive use of these chars.

This change ensures proper escaping according to LSP snippet grammar EBNF conventions.

Closes #2072
Related #2028
