### PR TITLE
fix(snippets): filter out incompatible builtin snippets

### DIFF
--- a/lua/blink/cmp/sources/snippets/default/registry.lua
+++ b/lua/blink/cmp/sources/snippets/default/registry.lua
@@ -10,11 +10,11 @@
 local registry = {
   builtin_vars = require('blink.cmp.sources.snippets.default.builtin'),
 }
-
+local user_config = vim.fn.stdpath('config')
 local utils = require('blink.cmp.sources.snippets.utils')
 local default_config = {
   friendly_snippets = true,
-  search_paths = { vim.fn.stdpath('config') .. '/snippets' },
+  search_paths = { user_config .. '/snippets' },
   global_snippets = { 'all' },
   extended_filetypes = {},
   --- @type string?
@@ -62,9 +62,10 @@ function registry:get_snippets_for_ft(filetype)
   for _, f in ipairs(files) do
     local contents = utils.read_file(f)
     if contents then
+      local is_user_snippet = vim.startswith(f, user_config)
       local snippets = utils.parse_json_with_error_msg(f, contents)
       for _, key in ipairs(vim.tbl_keys(snippets)) do
-        local snippet = utils.read_snippet(snippets[key], key)
+        local snippet = utils.read_snippet(snippets[key], key, filetype, is_user_snippet)
         for _, snippet_def in pairs(snippet) do
           table.insert(loaded_snippets, snippet_def)
         end

--- a/lua/blink/cmp/sources/snippets/default/registry.lua
+++ b/lua/blink/cmp/sources/snippets/default/registry.lua
@@ -11,12 +11,13 @@ local registry = {
   builtin_vars = require('blink.cmp.sources.snippets.default.builtin'),
 }
 
+local user_config = vim.fn.stdpath('config')
 local utils = require('blink.cmp.sources.snippets.utils')
 
 ---@type blink.cmp.SnippetsOpts
 local default_config = {
   friendly_snippets = true,
-  search_paths = { vim.fn.stdpath('config') .. '/snippets' },
+  search_paths = { user_config .. '/snippets' },
   global_snippets = { 'all' },
   extended_filetypes = {},
   --- @type string?
@@ -64,9 +65,10 @@ function registry:get_snippets_for_ft(filetype)
   for _, f in ipairs(files) do
     local contents = utils.read_file(f)
     if contents then
+      local is_user_snippet = vim.startswith(f, user_config)
       local snippets = utils.parse_json_with_error_msg(f, contents)
       for _, key in ipairs(vim.tbl_keys(snippets)) do
-        local snippet = utils.read_snippet(snippets[key], key)
+        local snippet = utils.read_snippet(snippets[key], key, filetype, is_user_snippet)
         for _, snippet_def in pairs(snippet) do
           table.insert(loaded_snippets, snippet_def)
         end

--- a/lua/blink/cmp/sources/snippets/utils.lua
+++ b/lua/blink/cmp/sources/snippets/utils.lua
@@ -1,3 +1,4 @@
+local lsp_snippet_grammar = require('vim.lsp._snippet_grammar')
 local logger = require('blink.cmp.logger')
 
 local utils = {
@@ -32,19 +33,21 @@ end
 function utils.safe_parse(input)
   if utils.parse_cache[input] then return utils.parse_cache[input] end
 
-  local safe, parsed = pcall(vim.lsp._snippet_grammar.parse, input)
+  local safe, parsed = pcall(lsp_snippet_grammar.parse, input)
   if not safe then return nil end
 
   utils.parse_cache[input] = parsed
   return parsed
 end
 
----@type fun(snippet: blink.cmp.Snippet, fallback: string): table
-function utils.read_snippet(snippet, fallback)
-  local snippets = {}
+---@type fun(snippet: blink.cmp.Snippet, fallback: string, filetype: string, is_user_snippet: boolean): table
+function utils.read_snippet(snippet, fallback, filetype, is_user_snippet)
   local prefix = snippet.prefix or fallback
+  local body = utils.validate_body(snippet.body, prefix, filetype, is_user_snippet)
+  if body == nil then return {} end
+
+  local snippets = {}
   local description = snippet.description or fallback
-  local body = snippet.body
 
   if type(description) == 'table' then description = vim.fn.join(description, '') end
 
@@ -91,25 +94,47 @@ function utils.add_current_line_indentation(text)
   return table.concat(lines, '\n')
 end
 
-function utils.get_tab_stops(snippet)
-  local expanded_snippet = require('blink.cmp.sources.snippets.utils').safe_parse(snippet)
-  if not expanded_snippet then return end
+---@param body string|string[]
+---@param prefix string
+---@param filetype string
+---@param is_user_snippet boolean
+---@return string|string[]|nil
+function utils.validate_body(body, prefix, filetype, is_user_snippet)
+  if type(body) == 'table' then body = table.concat(body, '\n') end
 
-  local tabstops = {}
-  local grammar = require('vim.lsp._snippet_grammar')
-  local line = 1
-  local character = 1
-  for _, child in ipairs(expanded_snippet.data.children) do
-    local lines = tostring(child) == '' and {} or vim.split(tostring(child), '\n')
-    line = line + math.max(#lines - 1, 0)
-    character = #lines == 0 and character or #lines > 1 and #lines[#lines] or (character + #lines[#lines])
-    if child.type == grammar.NodeType.Placeholder or child.type == grammar.NodeType.Tabstop then
-      table.insert(tabstops, { index = child.data.tabstop, line = line, character = character })
+  -- Fix snippet from friendly snippets source, whenever possible
+  -- stylua: ignore
+  if not is_user_snippet then
+    body = body
+      :gsub(':\\${', ':${')                 -- unescape :${
+      :gsub(':${(%w)\\}', ':${%1}')         -- unescape :${..\\}
+      :gsub('\\}}', '}}')                   -- unescape }}
+      :gsub('\\([%(%))])', '%1')            -- unescape parentheses
+      :gsub(' \\([%(%))])\\', ' %1\\')      -- unescape parens before backslash
+      :gsub('([%s{%(%[])%$%${', '%1\\$${')  -- escape $$ after whitespace/brackets
+      :gsub('$: ', '\\$: ')                 -- escape $ before colon-space
+      :gsub('(".*%w)%$(")', '%1\\$%2')      -- escape dollar sign, e.g. "foo$" -> "foo\$"
+      :gsub('$\\{', '\\${')                 -- wrong backslash position
+      :gsub('(\\?)%$%W*(%$[%w{]+)%W*%$', function(e, a) return (e == '\\' and e or '\\') .. '$' .. a end)
+      :gsub('(%${%d+|)([^}]+)(|})', function(s, o, e) return s .. o:gsub('\\', '\\\\') .. e end)          -- Escape \ in options, e.g. \Huge -> \\Huge
+
+    if filetype == 'terraform' then
+      body = body
+        :gsub('= "\\${', '= "${')
+        :gsub('= %["\\${', '= ["${')
+        :gsub('(%${[^}]+})', function(e) return e:gsub('[%.%[%]-]', '_') end) -- replace all dots/brackets/dash in placeholders (not allowed)
     end
   end
 
-  table.sort(tabstops, function(a, b) return a.index < b.index end)
-  return tabstops
+  if not utils.safe_parse(body) then
+    if is_user_snippet then
+      prefix = type(prefix) == 'table' and table.concat(prefix, ',') or prefix
+      logger:notify(vim.log.levels.WARN, 'Discard snippet `' .. prefix .. '` (' .. filetype .. ')", parsing failed!')
+    end
+    return nil
+  end
+
+  return body:find('\n') and vim.split(body, '\n', { plain = true }) or body
 end
 
 return utils

--- a/lua/blink/cmp/sources/snippets/utils.lua
+++ b/lua/blink/cmp/sources/snippets/utils.lua
@@ -1,4 +1,5 @@
 local logger = require('blink.cmp.logger')
+local lsp_snippet_grammar = require('vim.lsp._snippet_grammar')
 
 local utils = {
   parse_cache = {},
@@ -34,7 +35,7 @@ end
 function utils.safe_parse(input)
   if utils.parse_cache[input] then return utils.parse_cache[input] end
 
-  local safe, parsed = pcall(vim.lsp._snippet_grammar.parse, input)
+  local safe, parsed = pcall(lsp_snippet_grammar.parse, input)
   if not safe then return nil end
 
   utils.parse_cache[input] = parsed
@@ -43,12 +44,16 @@ end
 
 ---@param snippet blink.cmp.Snippet
 ---@param fallback string
+---@param filetype string
+---@param is_user_snippet boolean
 ---@return table
-function utils.read_snippet(snippet, fallback)
-  local snippets = {}
+function utils.read_snippet(snippet, fallback, filetype, is_user_snippet)
   local prefix = snippet.prefix or fallback
+  local body = utils.validate_body(snippet.body, prefix, filetype, is_user_snippet)
+  if body == nil then return {} end
+
+  local snippets = {}
   local description = snippet.description or fallback
-  local body = snippet.body
 
   if type(description) == 'table' then description = vim.fn.join(description, '') end
 
@@ -93,6 +98,57 @@ function utils.add_current_line_indentation(text)
   end
 
   return table.concat(lines, '\n')
+end
+
+---@param body string|string[]
+---@param prefix string
+---@param filetype string
+---@param is_user_snippet boolean
+---@return string|string[]|nil
+function utils.validate_body(body, prefix, filetype, is_user_snippet)
+  if type(body) == 'table' then body = table.concat(body, '\n') end
+
+  -- Fix snippet from friendly snippets source, whenever possible
+  -- stylua: ignore
+  if not is_user_snippet then
+    body = body
+      :gsub(':\\${', ':${')                 -- unescape :${
+      :gsub(':${(%w)\\}', ':${%1}')         -- unescape :${..\\}
+      :gsub('\\}}', '}}')                   -- unescape }}
+      :gsub('\\([%(%))])', '%1')            -- unescape parentheses
+      :gsub(' \\([%(%))])\\', ' %1\\')      -- unescape parens before backslash
+      :gsub('([%s{%(%[])%$%${', '%1\\$${')  -- escape $$ after whitespace/brackets
+      :gsub('$: ', '\\$: ')                 -- escape $ before colon-space
+      :gsub('(".*%w)%$(")', '%1\\$%2')      -- escape dollar sign, e.g. "foo$" -> "foo\$"
+      :gsub('$\\{', '\\${')                 -- wrong backslash position
+      :gsub('(\\?)%$%W*(%$[%w{]+)%W*%$', function(e, a) return (e == '\\' and e or '\\') .. '$' .. a end)
+      :gsub('(%${%d+|)([^}]+)(|})', function(s, o, e) return s .. o:gsub('\\', '\\\\') .. e end)          -- Escape \ in options, e.g. \Huge -> \\Huge
+
+    if filetype == 'terraform' then
+      body = body
+        :gsub('= "\\${', '= "${')
+        :gsub('= %["\\${', '= ["${')
+        :gsub('(%${[^}]+})', function(e) return e:gsub('[%.%[%]-]', '_') end) -- replace all dots/brackets/dash in placeholders (not allowed)
+    end
+  end
+
+  if not utils.safe_parse(body) then
+    if is_user_snippet then
+      local str_prefix = ''
+      if type(prefix) == 'table' then
+        str_prefix = table.concat(prefix, ',')
+      else
+        str_prefix = prefix
+      end
+      logger:notify(
+        vim.log.levels.WARN,
+        'Discard snippet `' .. str_prefix .. '` (' .. filetype .. ')", parsing failed!'
+      )
+    end
+    return nil
+  end
+
+  return body:find('\n') and vim.split(body, '\n', { plain = true }) or body
 end
 
 return utils

--- a/lua/blink/cmp/sources/snippets/utils.lua
+++ b/lua/blink/cmp/sources/snippets/utils.lua
@@ -1,9 +1,41 @@
 local logger = require('blink.cmp.logger')
-local lsp_snippet_grammar = require('vim.lsp._snippet_grammar')
+local lsp_snippet_grammar = vim.lsp._snippet_grammar
 
 local utils = {
   parse_cache = {},
 }
+
+--- @param body string
+--- @return string|string[]
+local function normalize_body(body) return body:find('\n') and vim.split(body, '\n', { plain = true }) or body end
+
+--- Attempt snippet transformations for malformed body
+--- @param body string
+--- @param filetype string
+--- @return string
+local function repair_body(body, filetype)
+  body = body
+    :gsub(':\\${', ':${') -- unescape :${
+    :gsub(':${(%w)\\}', ':${%1}') -- unescape :${..\\}
+    :gsub('\\}}', '}}') -- unescape }}
+    :gsub('\\([%(%))])', '%1') -- unescape parentheses
+    :gsub(' \\([%(%))])\\', ' %1\\') -- unescape parens before backslash
+    :gsub('([%s{%(%[])%$%${', '%1\\$${') -- escape $$ after whitespace/brackets
+    :gsub('$: ', '\\$: ') -- escape $ before colon-space
+    :gsub('(".*%w)%$(")', '%1\\$%2') -- escape dollar sign, e.g. "foo$" -> "foo\$"
+    :gsub('$\\{', '\\${') -- wrong backslash position
+    :gsub('(\\?)%$%W*(%$[%w{]+)%W*%$', function(e, a) return (e == '\\' and e or '\\') .. '$' .. a end)
+    :gsub('(%${%d+|)([^}]+)(|})', function(s, o, e) return s .. o:gsub('\\', '\\\\') .. e end) -- Escape \ in options, e.g. \Huge -> \\Huge
+
+  if filetype == 'terraform' then
+    body = body
+      :gsub('= "\\${', '= "${')
+      :gsub('= %["\\${', '= ["${')
+      :gsub('(%${[^}]+})', function(e) return e:gsub('[%.%[%]-]', '_') end) -- replace all dots/brackets/dash in placeholders (not allowed)
+  end
+
+  return body
+end
 
 --- Parses the json file and notifies the user if there's an error
 ---@param path string
@@ -106,49 +138,23 @@ end
 ---@param is_user_snippet boolean
 ---@return string|string[]|nil
 function utils.validate_body(body, prefix, filetype, is_user_snippet)
-  if type(body) == 'table' then body = table.concat(body, '\n') end
-
-  -- Fix snippet from friendly snippets source, whenever possible
-  -- stylua: ignore
-  if not is_user_snippet then
-    body = body
-      :gsub(':\\${', ':${')                 -- unescape :${
-      :gsub(':${(%w)\\}', ':${%1}')         -- unescape :${..\\}
-      :gsub('\\}}', '}}')                   -- unescape }}
-      :gsub('\\([%(%))])', '%1')            -- unescape parentheses
-      :gsub(' \\([%(%))])\\', ' %1\\')      -- unescape parens before backslash
-      :gsub('([%s{%(%[])%$%${', '%1\\$${')  -- escape $$ after whitespace/brackets
-      :gsub('$: ', '\\$: ')                 -- escape $ before colon-space
-      :gsub('(".*%w)%$(")', '%1\\$%2')      -- escape dollar sign, e.g. "foo$" -> "foo\$"
-      :gsub('$\\{', '\\${')                 -- wrong backslash position
-      :gsub('(\\?)%$%W*(%$[%w{]+)%W*%$', function(e, a) return (e == '\\' and e or '\\') .. '$' .. a end)
-      :gsub('(%${%d+|)([^}]+)(|})', function(s, o, e) return s .. o:gsub('\\', '\\\\') .. e end)          -- Escape \ in options, e.g. \Huge -> \\Huge
-
-    if filetype == 'terraform' then
-      body = body
-        :gsub('= "\\${', '= "${')
-        :gsub('= %["\\${', '= ["${')
-        :gsub('(%${[^}]+})', function(e) return e:gsub('[%.%[%]-]', '_') end) -- replace all dots/brackets/dash in placeholders (not allowed)
-    end
-  end
-
-  if not utils.safe_parse(body) then
-    if is_user_snippet then
-      local str_prefix = ''
-      if type(prefix) == 'table' then
-        str_prefix = table.concat(prefix, ',')
-      else
-        str_prefix = prefix
-      end
-      logger:notify(
-        vim.log.levels.WARN,
-        'Discard snippet `' .. str_prefix .. '` (' .. filetype .. ')", parsing failed!'
-      )
-    end
+  if type(body) == 'table' then
+    body = table.concat(body, '\n')
+  elseif type(body) ~= 'string' then
     return nil
   end
 
-  return body:find('\n') and vim.split(body, '\n', { plain = true }) or body
+  if utils.safe_parse(body) then return normalize_body(body) end
+
+  body = repair_body(body, filetype)
+  if utils.safe_parse(body) then return normalize_body(body) end
+
+  if is_user_snippet then
+    local str_prefix = type(prefix) == 'table' and table.concat(prefix, ',') or prefix
+    logger:notify(vim.log.levels.WARN, 'Discard snippet `' .. str_prefix .. '` (' .. filetype .. '), parsing failed!')
+  end
+
+  return nil
 end
 
 return utils


### PR DESCRIPTION
When using the built-in snippet engine (`vim.snippet`), we now attempt to repair malformed snippet bodies coming from the registry and discard them if they still fail to parse. User-defined snippets that cannot be repaired trigger a warning.

I benchmarked on my machine the affected filetypes, either repaired and/or discarded snippets, using snippets from friendly-snippets. The overhead is generally small, with Terraform being the main outlier due to its large snippet set (+600).


Filetype | Repaired | Discarded | PR (ms) | Main (ms) | Δ (ms)
-- | -- | -- | -- | -- | --
angular | 0 | 2 | 15.09 | 14.02 | +1.07
asciidoc | 0 | 1 | 14.65 | 14.41 | +0.24
blade | 0 | 4 | 16.88 | 15.96 | +0.92
c | 0 | 1 | 14.02 | 12.12 | +1.90
cobol | 0 | 6 | 18.99 | 18.71 | +0.28
django | 0 | 12 | 17.20 | 14.56 | +2.64
django-rest | 0 | 11 | 13.03 | 12.25 | +0.78
edge | 0 | 12 | 12.99 | 15.65 | −2.66
fortran | 0 | 28 | 14.66 | 12.65 | +2.01
fsh | 0 | 7 | 11.93 | 12.18 | −0.25
haskell | 0 | 9 | 11.96 | 11.27 | +0.69
javascriptreact | 0 | 1 | 25.80 | 24.41 | +1.39
make | 0 | 2 | 11.13 | 11.19 | −0.06
norg | 2 | 0 | 12.84 | 11.98 | +0.86
org | 1 | 2 | 12.38 | 11.42 | +0.96
php | 0 | 13 | 12.66 | 11.30 | +1.36
plaintex | 2 | 10 | 19.31 | 17.99 | +1.32
powershell | 9 | 7 | 14.75 | 13.00 | +1.75
ps1 | 9 | 7 | 14.92 | 12.87 | +2.05
python | 0 | 18 | 13.04 | 13.38 | −0.34
reason | 0 | 3 | 11.49 | 10.84 | +0.65
rescript | 0 | 3 | 12.16 | 12.85 | −0.69
rmd | 0 | 1 | 15.80 | 13.36 | +2.44
rspec | 0 | 6 | 12.01 | 11.37 | +0.64
ruby | 0 | 1 | 13.19 | 13.12 | +0.07
rust | 0 | 1 | 14.74 | 12.48 | +2.26
svelte | 5 | 1 | 19.70 | 18.69 | +1.01
swift | 1 | 0 | 11.96 | 11.62 | +0.34
systemverilog | 0 | 4 | 16.71 | 15.39 | +1.32
tcl | 1 | 0 | 13.09 | 12.69 | +0.40
terraform | 33 | 6 | 36.82 | 26.22 | +10.60
tex | 2 | 10 | 19.22 | 15.46 | +3.76
twig | 0 | 6 | 14.24 | 12.94 | +1.30
typescript | 0 | 1 | 12.65 | 12.15 | +0.50
typescriptreact | 0 | 2 | 23.07 | 19.57 | +3.50
unity | 0 | 3 | 13.86 | 13.22 | +0.64
yaml | 0 | 1 | 18.75 | 15.53 | +3.22



Closes #2028
