### PR TITLE
refactor(ghost_text): handle multibyte characters and reduce render calls

### DIFF
--- a/lua/blink/cmp/completion/init.lua
+++ b/lua/blink/cmp/completion/init.lua
@@ -82,10 +82,12 @@ function completion.setup()
 
   -- setup ghost text
   if config.completion.ghost_text.enabled then
-    list.select_emitter:on(
-      function(event) require('blink.cmp.completion.windows.ghost_text').show_preview(event.items, event.idx) end
-    )
-    list.hide_emitter:on(function() require('blink.cmp.completion.windows.ghost_text').clear_preview() end)
+    local ghost_text = function() return require('blink.cmp.completion.windows.ghost_text') end
+    list.show_emitter:on(function(event) ghost_text().show_preview(event.context, event.items, 1) end)
+    list.select_emitter:on(function(event)
+      if list.is_explicitly_selected then ghost_text().show_preview(event.context, event.items, event.idx) end
+    end)
+    list.hide_emitter:on(function() ghost_text().clear_preview() end)
   end
 
   -- run 'resolve' on the item ahead of time to avoid delays

--- a/lua/blink/cmp/completion/windows/ghost_text/utils.lua
+++ b/lua/blink/cmp/completion/windows/ghost_text/utils.lua
@@ -1,7 +1,6 @@
 local utils = {}
 
 function utils.is_cmdline() return vim.api.nvim_get_mode().mode == 'c' end
-function utils.is_cmdwin() return vim.fn.win_gettype() == 'command' end
 
 function utils.is_noice()
   return utils.is_cmdline()
@@ -14,7 +13,7 @@ end
 function utils.redraw_if_needed()
   if utils.is_cmdline() then
     local bufnr = utils.get_buf() or 0
-    if vim.api.nvim_buf_is_valid(bufnr) then vim.api.nvim__redraw({ buf = utils.get_buf(), flush = true }) end
+    if vim.api.nvim_buf_is_valid(bufnr) then vim.api.nvim__redraw({ buf = bufnr, flush = true }) end
   end
 end
 


### PR DESCRIPTION
Fixes ghost text display with multibyte characters showing as gibberish. Was using byte offsets instead of character counts, now properly uses `strchars()` and `strcharpart()` for UTF-8 handling.

<details> <summary>Demo</summary>
Before: 

https://github.com/user-attachments/assets/82d66dd1-afd5-4c5e-a669-29fb49f1b1de

After:

https://github.com/user-attachments/assets/b1233b82-070a-4589-89fd-894d1bc99752

</details>

Also addresses a few fixes for noice.nvim ; the ghost text did not appear in cmdline for some context, e.g. `:cd<Space>` and an extra redraw was making the search highlighted text blinking.

Refactored to keep only the event-driven architecture:
- Removed decoration provider in favor of explicit list events
- Pass context object to avoid repeated mode/line lookups
- Drop `TextChangedI` but retained `CursorMovedI` autocmd to prevent text shaking during typing.

Overall this translate in a small performance improvements. The draw calls are reduced by 22-29% and total CPU time reduced by 9-95% depending on operation.

<details> <summary>Performance benchmarks details</summary>


Typing `vim.fn.getcmdtype` with slow typing, fast typing, and extended 500-iteration test.

### Draw Preview Performance

| Branch | Test Type | Calls | Total Time | Avg per Call | vs Main |
|--------|-----------|-------|------------|--------------|---------|
| **Main** | Slow | 56 | 11.29ms | 0.20ms | baseline |
| **Main** | Fast | 45 | 5.79ms | 0.13ms | baseline |
| **Main** | 500 iterations | 500 | 31.22ms | 0.06ms | baseline |
| **PR** | Slow | 40 | 9.25ms | 0.23ms | **29% fewer calls, 18% faster** |
| **PR** | Fast | 35 | 5.07ms | 0.14ms | **22% fewer calls, 12% faster** |
| **PR** | 500 iterations | 500 | 28.35ms | 0.06ms | **9% faster** |

### Show Preview Performance

| Branch | Test Type | Calls | Total Time | Avg per Call | vs Main |
|--------|-----------|-------|------------|--------------|---------|
| **Main** | Slow | 24 | 2.35ms | 0.10ms | baseline |
| **Main** | Fast | 21 | 1.76ms | 0.08ms | baseline |
| **Main** | 500 iterations | 500 | 21.49ms | 0.04ms | baseline |
| **PR** | Slow | 24 | 0.13ms | 0.01ms | **94% faster** |
| **PR** | Fast | 21 | 0.09ms | <0.01ms | **95% faster** |
| **PR** | 500 iterations | 500 | 2.34ms | <0.01ms | **89% faster** |

</details>