### PR TITLE
fix(window): make popup windows unmodifiable

### DIFF
--- a/lua/blink/cmp/lib/window/docs.lua
+++ b/lua/blink/cmp/lib/window/docs.lua
@@ -42,7 +42,9 @@ function docs.render_detail_and_documentation(opts)
   -- skip original separator in doc_lines, so we can highlight it later
   vim.list_extend(combined_lines, doc_lines, doc_already_has_separator and 2 or 1)
 
+  vim.api.nvim_set_option_value('modifiable', true, { buf = opts.bufnr })
   vim.api.nvim_buf_set_lines(opts.bufnr, 0, -1, true, combined_lines)
+  vim.api.nvim_set_option_value('modifiable', false, { buf = opts.bufnr })
   vim.api.nvim_set_option_value('modified', false, { buf = opts.bufnr })
 
   -- Highlight with treesitter

--- a/lua/blink/cmp/lib/window/init.lua
+++ b/lua/blink/cmp/lib/window/init.lua
@@ -136,6 +136,7 @@ function win:open()
   vim.api.nvim_set_option_value('cursorline', false, { win = self.id })
   vim.api.nvim_set_option_value('scrolloff', self.config.scrolloff, { win = self.id })
   vim.api.nvim_set_option_value('filetype', self.config.filetype, { buf = self.buf })
+  vim.api.nvim_set_option_value('modifiable', false, { buf = self.buf })
 
   self.cursor_line:update(self.id)
   if self.scrollbar then self.scrollbar:update(self.id) end


### PR DESCRIPTION
Make windows generated by blink.cmp unmodifiable. It's useful for other plugins filter out the windows they don't want to render, e.g., winbar. Because the completion documentations actually modify the contents of the documentation window. Therefore, we also have to temporally change modifiable property during update. It's pretty much the same as #1889.