### PR TITLE
Fixed help text autocompletion error

### DIFF
--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -56,7 +56,7 @@ end
 --- @param t table
 --- @return table
 function utils.flatten(t)
-  if type(t) == "string" then return {t} end
+  if type(t) == 'string' then return { t } end
   if t[1] == nil then return t end
 
   local flattened = {}


### PR DESCRIPTION
Fixed help text autocompletion error.
would occur at :h usage after typing the first character

I presume it worked at some point in the past and wasn't tested after one refactor or another

Thanks for the plugin, it's nice and fast 