### PR TITLE
fix(signature): Update active parameter to use line and col range

### DIFF
--- a/lua/blink/cmp/signature/window.lua
+++ b/lua/blink/cmp/signature/window.lua
@@ -73,17 +73,29 @@ function signature.open_with_signature_help(context, signature_help)
     sources.get_signature_help_trigger_characters().trigger_characters
   )
   if active_highlight ~= nil then
-    -- TODO: nvim 0.11+ returns the start and end line which we should use
-    local start_col = vim.fn.has('nvim-0.11.0') == 1 and active_highlight[2] or active_highlight[1]
-    local end_col = vim.fn.has('nvim-0.11.0') == 1 and active_highlight[4] or active_highlight[2]
-
-    vim.api.nvim_buf_set_extmark(
-      signature.win:get_buf(),
-      require('blink.cmp.config').appearance.highlight_ns,
-      0,
-      start_col,
-      { end_col = end_col, hl_group = 'BlinkCmpSignatureHelpActiveParameter' }
-    )
+    if vim.fn.has('nvim-0.11.0') == 1 then
+      local start_line = active_highlight[1] - 1
+      local start_col = active_highlight[2]
+      local end_line = active_highlight[3] - 1
+      local end_col = active_highlight[4]
+      vim.api.nvim_buf_set_extmark(
+        signature.win:get_buf(),
+        require('blink.cmp.config').appearance.highlight_ns,
+        start_line,
+        start_col,
+        { end_line = end_line, end_col = end_col, hl_group = 'BlinkCmpSignatureHelpActiveParameter' }
+      )
+    else
+      local start_col = active_highlight[1]
+      local end_col = active_highlight[2]
+      vim.api.nvim_buf_set_extmark(
+        signature.win:get_buf(),
+        require('blink.cmp.config').appearance.highlight_ns,
+        0,
+        start_col,
+        { end_col = end_col, hl_group = 'BlinkCmpSignatureHelpActiveParameter' }
+      )
+    end
   end
 
   signature.win:open()


### PR DESCRIPTION
Partially addresses: #2295 

As noted in window.lua nvim 11.0 returns start and end lines for `vim.lsp.util.convert_signature_help_to_markdown_lines`. I have implemented a simple logic to handle this. I've tested it locally with a few LSP's and it seems to work without issue. It could be made more concise if you prefer but I felt this approach had good clarity of intent. Pretty minor issue so feel free to implement yourself/another way. Commit notes below.

Thanks!

- Single check of vim.fn.has('nvim.11.0')
- Relatively verbose implementation for clarity.
- could easily refactor to a single nvim_buf_set_extmark call with only the variables changed. (I have not tested this)