### PR TITLE
fix: comments

### DIFF
--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -310,7 +310,7 @@ function cmp.hide_signature()
   return true
 end
 
---- Scroll the documentation window up
+--- Scroll the signature window up
 --- @param count? number
 function cmp.scroll_signature_up(count)
   local sig = require('blink.cmp.signature.window')
@@ -320,7 +320,7 @@ function cmp.scroll_signature_up(count)
   return true
 end
 
---- Scroll the documentation window down
+--- Scroll the signature window down
 --- @param count? number
 function cmp.scroll_signature_down(count)
   local sig = require('blink.cmp.signature.window')


### PR DESCRIPTION
some functions were referred to as relating to documentation when they actually relate to signatures