### PR TITLE
Support for FreeBSD x86_64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,10 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-linux-android
             artifact_name: target/aarch64-linux-android/release/libblink_cmp_fuzzy.so
+          # FreeBSD
+          - os: ubuntu-latest
+            target: x86_64-unknown-freebsd
+            artifact_name: target/x86_64-unknown-freebsd/release/libblink_cmp_fuzzy.so
 
           ## macOS builds
           - os: macos-latest

--- a/lua/blink/cmp/fuzzy/download/files.lua
+++ b/lua/blink/cmp/fuzzy/download/files.lua
@@ -39,7 +39,7 @@ function files.get_checksum_for_file(path)
   return async.task.new(function(resolve, reject)
     local os = system.get_info()
     local args
-    if os == 'linux' then
+    if os == 'linux' or os == 'freebsd' then
       args = { 'sha256sum', path }
     elseif os == 'mac' or os == 'osx' then
       args = { 'shasum', '-a', '256', path }

--- a/lua/blink/cmp/fuzzy/download/system.lua
+++ b/lua/blink/cmp/fuzzy/download/system.lua
@@ -15,6 +15,9 @@ system.triples = {
     arm = function(libc) return 'aarch64-unknown-linux-' .. libc end,
     x64 = function(libc) return 'x86_64-unknown-linux-' .. libc end,
   },
+  freebsd = {
+    x64 = 'x86_64-unknown-freebsd',
+  },
 }
 
 --- Gets the operating system and architecture of the current system
@@ -22,6 +25,9 @@ system.triples = {
 function system.get_info()
   local os = jit.os:lower()
   if os == 'osx' then os = 'mac' end
+
+  if os == 'bsd' and vim.loop.os_uname().sysname:lower() == 'freebsd' then os = 'freebsd' end
+
   local arch = jit.arch:lower():match('arm') and 'arm' or jit.arch:lower():match('x64') and 'x64' or nil
   return os, arch
 end


### PR DESCRIPTION
- I think this is needed to support FreeBSD as platform
- It compiles without problem with `cross`
- aarch64 is not supported (yet) because stdlib is level 3 for Rust
- This could close #940 and #2220 