### PR TITLE
docs: information about how to use `filter_snippets`

### DIFF
--- a/doc/blink-cmp.txt
+++ b/doc/blink-cmp.txt
@@ -1887,25 +1887,7 @@ use `extended_filetypes`.
       }
     }
 <
-To filter which snippets are shown, use `filter_snippets` which provides the filetype
-and name of the snippets file. This function returns `true` if the snippet
-should be included in completion results, and `false` if it should be filtered out.
 
->lua
-    sources = {
-      providers = {
-        snippets = {
-          opts = {
-	    -- disable friendly-snippets frameworks
-            filter_snippets = function(ft, file)
-	      return not (string.match(file, "friendly.snippets") and string.match(file, "framework"))
-	    end,
-            }
-          }
-        }
-      }
-    }
-<
 
 CUSTOM SNIPPETS ~
 


### PR DESCRIPTION
This PR includes simple doc changes to explain how to use the `filter_snippets` mechanism for `friendly-snippets` as introduced in PR #996 as it hasn't been documented to my knowledge and this is a helpful feature to surface more easily.

Let me know if the wording or location should be changed + any other feedback. Thank you for the great work!