### PR TITLE
feat(lazy): add a `lazy.lua` package descriptor for leaner `lazy,nvim`-based installation

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -70,7 +70,6 @@ Note: By default, Blink will attempt to use the rust implementation of the fuzzy
     -- See the fuzzy documentation for more information
     fuzzy = { implementation = "prefer_rust_with_warning" }
   },
-  opts_extend = { "sources.default" }
 }
 ```
 

--- a/lazy.lua
+++ b/lazy.lua
@@ -1,0 +1,13 @@
+return {
+  'saghen/blink.cmp',
+  event = 'InsertEnter',
+  cmd = 'BlinkCmp',
+  dependencies = {
+    -- ensure optional dependencies are loaded first if already installed
+    { 'rafamadriz/friendly-snippets', optional = true },
+    { 'L3MON4D3/LuaSnip', optional = true },
+    { 'echasnovski/mini.snippets', optional = true },
+  },
+  opts = {},
+  opts_extend = { 'sources.default' },
+}


### PR DESCRIPTION
Hello 👋🏼 

Thanks for this plugin.

Here's a small enhancement for `lazy.nvim`-based installation: this PR adds a [`lazy.lua` package descriptor](https://lazy.folke.io/packages#lazy), which:
- declares the lazy-loading `event` and `cmd`
- sets `opts_extend` by default (no need for the user to add it to its configuration anymore)
- Declare optional dependencies so if they are already present somewhere in the user config, they will be loaded first, even if the user forgot to add them to the `dependencies` block.