### PR TITLE
fix(nix): specify linker args for the Darwin build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,12 @@
             cargoLock = { lockFile = ./Cargo.lock; };
             buildInputs = with pkgs; lib.optionals stdenv.hostPlatform.isAarch64 [ rust-jemalloc-sys ]; # revisit once https://github.com/NixOS/nix/issues/12426 is solved
             nativeBuildInputs = with pkgs; [ git ];
+            env = {
+              # Allow undefined symbols on Darwin - they will be provided by Neovim's LuaJIT runtime
+              RUSTFLAGS = with pkgs;
+                lib.optionalString
+                stdenv.hostPlatform.isDarwin "-C link-arg=-undefined -C link-arg=dynamic_lookup";
+            };
           };
 
           blink-cmp = pkgs.vimUtils.buildVimPlugin {


### PR DESCRIPTION
Use the same linker args as defined in the cargo config file.

Based on the nixpkgs fix by @khaneliman:
https://github.com/NixOS/nixpkgs/commit/876a05aa448239e421a7c6b4c799fc469fe0200d

See the related issue in nixpkgs:
https://github.com/NixOS/nixpkgs/pull/464350

Resolves #2334.