### PR TITLE
fix(accept): restore completion trigger after accept

### DIFF
--- a/lua/blink/cmp/completion/list.lua
+++ b/lua/blink/cmp/completion/list.lua
@@ -51,6 +51,7 @@
 
 --- @class blink.cmp.CompletionListAcceptOpts : blink.cmp.CompletionListSelectAndAcceptOpts
 --- @field index? number The index of the item to accept, if not provided, the currently selected item will be accepted
+--- @field is_accept? boolean Whether this is an explicit user acceptance (default: true)
 
 --- @class blink.cmp.CompletionListShowEvent
 --- @field items blink.cmp.CompletionItem[]
@@ -348,14 +349,17 @@ end
 
 function list.accept(opts)
   opts = opts or {}
+
   local item = list.items[opts.index or list.selected_item_idx]
   if item == nil then return false end
 
   list.undo_preview()
+
   require('blink.cmp.completion.accept')(list.context, item, function()
     list.accept_emitter:emit({ item = item, context = list.context })
     if opts.callback then opts.callback() end
-  end)
+  end, opts)
+
   return true
 end
 

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -109,7 +109,7 @@ function cmp.show_and_insert_or_accept_single(opts)
 
   -- If the candidate list has been filtered down to exactly one item, accept it.
   if #list.items == 1 then
-    vim.schedule(function() list.accept({ index = 1, callback = opts.callback }) end)
+    vim.schedule(function() list.accept({ index = 1, is_accept = false, callback = opts.callback }) end)
     return true
   end
 


### PR DESCRIPTION
After accepting a completion item, the menu stopped showing when either `completion.trigger.show_on_trigger_character` or `completion.trigger.show_on_accept_on_trigger_character` was set to `false`.

This regression was introduced in commit 54cc521 due to a fast-path in auto-accept for single-item completions.

Leverage on `is_accept` logic to distinguish user vs automatic accepts, so trigger-character behavior works correctly.

Closes #2355
