### PR TITLE
fix: disable formatoptions 't' during completion to prevent wrap issues

### DIFF
--- a/lua/blink/cmp/completion/windows/menu.lua
+++ b/lua/blink/cmp/completion/windows/menu.lua
@@ -23,6 +23,7 @@
 
 local config = require('blink.cmp.config').completion.menu
 local event_emitter = require('blink.cmp.lib.event_emitter')
+local utils = require('blink.cmp.lib.utils')
 
 --- @type blink.cmp.CompletionMenu
 --- @diagnostic disable-next-line: missing-fields
@@ -109,6 +110,11 @@ end
 function menu.open()
   if menu.win:is_open() then return end
 
+  -- Disable auto text wrapping (formatoptions 't' and 'c') to prevent issues
+  -- with preview undo when text wrapping occurs during completion.
+  -- These options will be restored when the menu closes.
+  utils.disable_auto_wrap()
+
   menu.win:open()
   menu.win:set_option_value('cursorline', menu.selected_item_idx ~= nil)
   if menu.selected_item_idx ~= nil then
@@ -124,6 +130,9 @@ function menu.close()
   if not menu.win:is_open() then return end
 
   menu.win:close()
+
+  utils.restore_auto_wrap()
+
   menu.close_emitter:emit()
 end
 

--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -146,6 +146,62 @@ function utils.with_no_autocmds(cb)
   return result_or_err
 end
 
+--- Disables auto text wrapping by removing formatoptions 't' and 'c'.
+--- Records which options were active in buffer variables so they can be
+--- restored later by restore_auto_wrap(). Should be paired with restore_auto_wrap().
+function utils.disable_auto_wrap()
+  local formatoptions = vim.opt.formatoptions:get()
+  if formatoptions.t then
+    vim.b.blink_cmp_restore_formatoptions_t = true
+    vim.opt.formatoptions:remove('t')
+  end
+  if formatoptions.c then
+    vim.b.blink_cmp_restore_formatoptions_c = true
+    vim.opt.formatoptions:remove('c')
+  end
+end
+
+--- Restores auto text wrapping (formatoptions 't' and 'c') previously disabled
+--- by disable_auto_wrap(). Uses pcall to ensure formatoptions are restored even
+--- if an error occurs. If text exceeded textwidth while wrapping was disabled,
+--- schedules a reformat of the current line.
+function utils.restore_auto_wrap()
+  local restore_t = vim.b.blink_cmp_restore_formatoptions_t
+  local restore_c = vim.b.blink_cmp_restore_formatoptions_c
+
+  local success, err = pcall(function()
+    if restore_t then
+      vim.opt.formatoptions:append('t')
+      vim.b.blink_cmp_restore_formatoptions_t = nil
+    end
+    if restore_c then
+      vim.opt.formatoptions:append('c')
+      vim.b.blink_cmp_restore_formatoptions_c = nil
+    end
+  end)
+
+  if not success then error(err) end
+
+  -- Schedule a check to reformat the line if needed.
+  -- Since 't' or 'c' was disabled during completion, text may have exceeded
+  -- textwidth without triggering auto-wrap. We check after the current
+  -- event loop iteration to ensure any pending input has been processed.
+  if restore_t or restore_c then
+    vim.schedule(function()
+      local textwidth = vim.bo.textwidth
+      if textwidth > 0 and vim.api.nvim_get_mode().mode == 'i' then
+        local current_line = vim.api.nvim_get_current_line()
+        if #current_line > textwidth then
+          -- Trigger reformat of current line using internal formatting
+          vim.cmd('normal! gww')
+          -- Return to insert mode at the end of the line content
+          vim.cmd('startinsert!')
+        end
+      end
+    end)
+  end
+end
+
 --- Disable redraw in neovide for the duration of the callback
 --- Useful for preventing the cursor from jumping to the top left during `vim.fn.complete`
 --- @generic T


### PR DESCRIPTION
When formatoptions includes 't' (auto-wrap text), text can be wrapped to a new line during completion preview, causing undo_preview to fail with 'start_col must be less than or equal to end_col' error.

This fix temporarily disables the 't' option when the completion menu opens and restores it when the menu closes. Additionally, when the menu closes, if the current line exceeds textwidth, it triggers a reformat to ensure proper text wrapping occurs after completion ends.

This works exactly like Vim's default behavior.

Fixes #1445 