### PR TITLE
fix(download): return error for unknown system_triple

### DIFF
--- a/lua/blink/cmp/fuzzy/download/files.lua
+++ b/lua/blink/cmp/fuzzy/download/files.lua
@@ -45,6 +45,8 @@ function files.get_checksum_for_file(path)
       args = { 'shasum', '-a', '256', path }
     elseif os == 'windows' then
       args = { 'certutil', '-hashfile', path, 'SHA256' }
+    else
+      return reject('Unable to calculate checksum for file (unsupported system)')
     end
 
     vim.system(args, {}, function(out)

--- a/lua/blink/cmp/fuzzy/download/system.lua
+++ b/lua/blink/cmp/fuzzy/download/system.lua
@@ -97,7 +97,7 @@ function system.get_triple()
 
     local os, arch = system.get_info()
     local triples = system.triples[os]
-    if triples == nil then return end
+    if triples == nil then return resolve() end
 
     if os == 'linux' then
       if vim.fn.has('android') == 1 then return resolve(triples.android) end


### PR DESCRIPTION
Following commit cdbe9436b29788edcecb309a340e905b6b4bbbcb, the async task to get `system_triple` is not ended properly for unsupported OS/Arch (`system_triple == nil`) in function `system.get_triple`.

- `fuzzy/download/system.lua`: end async task for unknown `system_triple`
- `fuzzy/download/files.lua`: return error when calculating checksum on unsupported system

Fix saghen/blink.cmp#2387

---

**Tests OK on OpenBSD/amd64** (unsupported system to download/build Rust fuzzy matcher) with  config `implementation` = `prefer_rust`, `prefer_rust_with_warning` and `lua`.

With config `implementation = prefer_rust_with_warning`, Blink messages are: 
```sh
 blink.cmp  Downloading pre-built binary
 blink.cmp  Your system is not supported by  pre-built binaries . Try building from source via  build = 'cargo build --release'  in your lazy.nvim spec and re-installing (requires Rust nightly)
 blink.cmp  Unable to calculate checksum for file (unsupported system)
 blink.cmp  Falling back to Lua implementation due to error while downloading pre-built binary, set fuzzy.implementation to  "prefer_rust"  or  "lua"  to disable this warning. See :messages for details.
```

With config `implementation = prefer_rust`, Blink messages with no warnings are : 
```sh
 blink.cmp  Downloading pre-built binary
 blink.cmp  Your system is not supported by  pre-built binaries . Try building from source via  build = 'cargo build --release'  in your lazy.nvim spec and re-installing (requires Rust nightly)
```

**Tests OK on Linux/amd64** with config `implementation` = `prefer_rust`, `prefer_rust_with_warning` and `lua`.