### PR TITLE
feat(trigger): add `completion.trigger.debounce_ms` option

### DIFF
--- a/lua/blink/cmp/config/completion/trigger.lua
+++ b/lua/blink/cmp/config/completion/trigger.lua
@@ -1,4 +1,5 @@
 --- @class (exact) blink.cmp.CompletionTriggerConfig
+--- @field debounce_ms number When > 0, debounces the show_emitter emission by this many milliseconds. The timer resets on each trigger, so the pipeline only runs after the user pauses. Default: 0
 --- @field prefetch_on_insert boolean When true, will prefetch the completion items when entering insert mode. WARN: buggy, not recommended unless you'd like to help develop prefetching
 --- @field show_in_snippet boolean When false, will not show the completion window when in a snippet
 --- @field show_on_keyword boolean When true, will show the completion window after typing any of alphanumerics, `-` or `_`
@@ -17,6 +18,7 @@ local validate = require('blink.cmp.config.utils').validate
 local trigger = {
   --- @type blink.cmp.CompletionTriggerConfig
   default = {
+    debounce_ms = 0,
     prefetch_on_insert = false,
     show_in_snippet = true,
     show_on_keyword = true,
@@ -35,6 +37,7 @@ local trigger = {
 
 function trigger.validate(config)
   validate('completion.trigger', {
+    debounce_ms = { config.debounce_ms, 'number' },
     prefetch_on_insert = { config.prefetch_on_insert, 'boolean' },
     show_in_snippet = { config.show_in_snippet, 'boolean' },
     show_on_backspace = { config.show_on_backspace, 'boolean' },


### PR DESCRIPTION
## Why?

When `show_on_keyword = true`, the full completion pipeline (trigger → sources → fuzzy → render) runs on every keystroke via `trigger.show()`. This causes noticeable stuttering during fast typing. The existing `completion.menu.auto_show_delay_ms` only delays the window opening — the computation pipeline still runs every keystroke.

Setting `show_on_keyword = false` eliminates the stutter but also disables keyword-triggered completions entirely.

## What?

- Add `completion.trigger.debounce_ms` config option (default: `0`, no behavioral change)
- When `debounce_ms > 0`, debounces the `show_emitter` emission inside `trigger.show()` — the timer resets on each trigger, so the downstream pipeline (sources → fuzzy → render) only runs after the user pauses
- Context is always created immediately on each keystroke — only the downstream emission is deferred
- `trigger.hide()` cancels any pending debounce timer

## Notes

- Closes #2400
- Default of `0` means zero behavioral change for existing users

Example config:
```lua
completion = {
  trigger = {
    show_on_keyword = true,
    debounce_ms = 200,
  },
}
```