### PR TITLE
ci: update GH actions

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,12 +16,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
 
       - name: Build
         run: npm ci && npm run build

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -36,7 +36,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/panvimdoc.yaml
+++ b/.github/workflows/panvimdoc.yaml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository == 'Saghen/blink.cmp'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: kdheepak/panvimdoc@main
         with:
           vimdoc: blink-cmp

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,7 @@ jobs:
             artifact_name: target/x86_64-pc-windows-msvc/release/blink_cmp_fuzzy.dll
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -90,7 +90,7 @@ jobs:
           mv "${{ matrix.artifact_name }}" "${{ matrix.target }}.dll"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.target }}
           path: ${{ matrix.target }}.*
@@ -103,7 +103,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: Generate checksums
         run: |
@@ -128,12 +128,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
 
       - name: Build
         run: npm ci && npm run build:release

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -17,7 +17,7 @@ jobs:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/stylua.yaml
+++ b/.github/workflows/stylua.yaml
@@ -25,7 +25,7 @@ jobs:
     name: Check lua files using Stylua
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Update GH actions  to the latest main version:
- actions/checkout (v6)
- actions/setup-node (v6)
- actions/upload-artifact (v7)
- actions/download-artifact (v8)