### PR TITLE
ci: in Release workflow, fix build on FreeBSD/aarch64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,10 +63,13 @@ jobs:
       - name: Install Rust
         shell: bash
         run: |
-          rustup toolchain install stable
-          rustup default stable
           if [ -z "${{ matrix.build_std }}" ] || [ "${{ matrix.build_std }}" = "false" ]; then
+            rustup toolchain install stable
+            rustup default stable
             rustup target add ${{ matrix.target }}
+          else
+            rustup toolchain install nightly
+            rustup default nightly
           fi
 
       - name: Build for Linux


### PR DESCRIPTION
Use rust nightly toolchain for build on FreeBSD/aarch64 (support added in PR #2380).

Fix saghen/blink.cmp#2414