### PR TITLE
Add `hex-cmp` plugin for community sources

### DIFF
--- a/doc/configuration/sources.md
+++ b/doc/configuration/sources.md
@@ -135,3 +135,4 @@ Here is a non-exhaustive list of third-party plugins providing additional comple
 - [lazydev](https://github.com/folke/lazydev.nvim) by `folke`: [LuaLS](https://luals.github.io)
 - [minuet-ai.nvim](https://github.com/milanglacier/minuet-ai.nvim) by `milanglacier`: AI
 - [vim-dadbod-completion](https://github.com/kristijanhusak/vim-dadbod-completion) by `kristijanhusak`: [vim-dadbod](https://github.com/tpope/vim-dadbod)
+- [hex-cmp](https://github.com/dbernheisel/hex-cmp) by `dbernheisel`: [Hex.pm](https://hex.pm) package completion for Elixir `mix.exs` files.


### PR DESCRIPTION
hex-cmp provides Elixir package completion for `mix.exs` files.