### PR TITLE
fix(auto-wrap): use :startinsert without exclamation mark

### DIFF
--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -195,7 +195,7 @@ function utils.restore_auto_wrap()
           -- Trigger reformat of current line using internal formatting
           vim.cmd('normal! gww')
           -- Return to insert mode at the end of the line content
-          vim.cmd('startinsert!')
+          vim.cmd('startinsert')
         end
       end
     end)


### PR DESCRIPTION
I did a bad modification on my last PR #2378 : After the `:normal! gww` had done, I used `:startinsert!` to come back to insert mode, which is "A" in normal mode instead of "i". That is not correct. I fixed it with `:startinsert` now. Really small modification, sorry for another PR to fix that.