### PR TITLE
fix: disable formatoptions 'a' during completion and wrap text around paragraph if and only if it was set

### DIFF
--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -190,25 +190,6 @@ function utils.restore_auto_wrap()
   end)
 
   if not success then error(err) end
-
-  -- Schedule a check to reformat the line if needed.
-  -- Since 't' or 'c' was disabled during completion, text may have exceeded
-  -- textwidth without triggering auto-wrap. We check after the current
-  -- event loop iteration to ensure any pending input has been processed.
-  if restore_a then
-    vim.schedule(function()
-      local textwidth = vim.bo.textwidth
-      if textwidth > 0 and vim.api.nvim_get_mode().mode == 'i' then
-        local current_line = vim.api.nvim_get_current_line()
-        if #current_line > textwidth then
-          -- Trigger reformat of current paragraph using internal formatting
-          vim.cmd('normal! gqap')
-          -- Return to insert mode
-          vim.cmd('startinsert')
-        end
-      end
-    end)
-  end
 end
 
 --- Disable redraw in neovide for the duration of the callback


### PR DESCRIPTION
https://github.com/saghen/blink.cmp/pull/2378 forgot to account for formatoptions `a`, which according to `:h fo-table` does the following:
```
Automatic formatting of paragraphs.  Every time text is inserted or
deleted the paragraph will be reformatted.
```
The aforementioned pull request introduced another regression than https://github.com/saghen/blink.cmp/pull/2426, which is that using `vim.cmd('normal! gww')` will push all words exceeding the `textdwidth` on a new line, so the following happens:

https://github.com/user-attachments/assets/350fd42c-8d59-4d49-ba09-0981e88d9198

The thing is formatoptions `t` and `c` only take effect if exceeding the line length at the current cursor position, so in the example above, if I were to try without the plugin but with formatoptions set to `t`, then nothing would get pushed to the next line until I start typing 'happening', unless the `a` formatoption is set; but in this case, it would reformat the whole paragraph instead. And formatting the whole paragraph is precisely what would fix the issue described above.