### PR TITLE
feat(path): expand env vars enclosed in braces

### DIFF
--- a/lua/blink/cmp/sources/path/lib.lua
+++ b/lua/blink/cmp/sources/path/lib.lua
@@ -21,7 +21,7 @@ function lib.dirname(opts, context)
     return vim.fn.resolve(buf_dirname .. '/' .. dirname)
   end
   if prefix:match('~/$') then return vim.fn.resolve(vim.fn.expand('~') .. '/' .. dirname) end
-  local env_var_name = prefix:match('%$([%a_]+)/$')
+  local env_var_name = prefix:match('%${([%a_]+)}/$') or prefix:match('%$([%a_]+)/$')
   if env_var_name then
     local env_var_value = vim.fn.getenv(env_var_name)
     if env_var_value ~= vim.NIL then return vim.fn.resolve(env_var_value .. '/' .. dirname) end


### PR DESCRIPTION
When doing path completion, blink.cmp expands strings that match the Lua pattern `%$([%a_]+)/$` as environment variables. This means, for example, if I type `$HOME/`, blink.cmp begins completion in the `/home/rhelder` directory. If I type `${HOME}/`, however, blink.cmp doesn't recognize `${HOME}` as an environment variable and doesn't expand it (instead, blink.cmp interprets the trailing `/` as saying that I'm in the root directory).

For certain use cases, this greatly limits the usefulness of blink.cmp's path completion (and the path completion provided by other plugins – nvim-cmp's path completion source, for example, also doesn't recognize strings of the form `${HOME}` as environment variables). When shell scripting, for example, I follow the Google style guide's recommendation that [variable names be enclosed in braces](https://github.com/google/styleguide/blob/gh-pages/shellguide.md#s5.6-variable-expansion). In practice, it turns out that paths are prefixed by environment variables so often that blink.cmp's path completion is not useful to me most of the time when I'm shell scripting (and when I'm configuring my shell – yes, I know it's insane to wrap variable names in braces in your shell config, but I like the consistency).

Because blink.cmp already recognizes the shell expression `$HOME`, I recommend that blink.cmp also recognize the shell expression `${HOME}`, for consistency. In this PR, I just call `match()` on `prefix` twice, first for the more specific pattern `%${([%a_]+)}/$` and then for the pattern `%$([%a_]+)/$`. Pattern matching on short strings is fast in Lua, so I don't think adding the second call to `match()` is costly compared to the benefit of matching environment variables of the form `${HOME}`. (I also think calling `match()` twice is preferable to calling `match()` once with the probably fine, but less precise, pattern `%${?([%a_]+)}?/$`, or something like that.)

(This is a separate topic, but `%a` should be `%w` in these patterns, because numbers are allowed in environment variable names. I can append a commit to this PR, or open a new PR, depending on your preference.)

Thanks for your work on blink.cmp, and I hope this PR can be helpful!