### PR TITLE
fix(path): expand env vars whose names contain numbers

### DIFF
--- a/lua/blink/cmp/sources/path/lib.lua
+++ b/lua/blink/cmp/sources/path/lib.lua
@@ -21,7 +21,7 @@ function lib.dirname(opts, context)
     return vim.fn.resolve(buf_dirname .. '/' .. dirname)
   end
   if prefix:match('~/$') then return vim.fn.resolve(vim.fn.expand('~') .. '/' .. dirname) end
-  local env_var_name = prefix:match('%${([%a_]+)}/$') or prefix:match('%$([%a_]+)/$')
+  local env_var_name = prefix:match('%${([%w_]+)}/$') or prefix:match('%$([%w_]+)/$')
   if env_var_name then
     local env_var_value = vim.fn.getenv(env_var_name)
     if env_var_value ~= vim.NIL then return vim.fn.resolve(env_var_value .. '/' .. dirname) end


### PR DESCRIPTION
Here is the additional fix I referenced in #2439:

Environment variable names can contain numbers, so we should match alphanumeric  characters, not just letters, when checking whether or not the prefix  contains an environment variable. So in the same lines of code, I have replaced `%a` with `%w`.

Thanks again for your work (and for merging my last PR!), and again I hope this can be helpful.