### PR TITLE
fix: use os.get_info for parsing checksum

### DIFF
--- a/lua/blink/cmp/fuzzy/download/files.lua
+++ b/lua/blink/cmp/fuzzy/download/files.lua
@@ -58,6 +58,7 @@ function files.get_checksum_for_file(cmd)
       if out.code ~= 0 then return reject('Failed to calculate checksum of pre-built binary: ' .. out.stderr) end
 
       local stdout = out.stdout or ''
+      local os = system.get_info()
       if os == 'windows' then stdout = vim.split(stdout, '\r\n')[2] end
       -- Specific format 'SHA256 (<file>) = <SHA256 hash>'
       if os == 'openbsd' then stdout = stdout:match('= (%x+)') end


### PR DESCRIPTION
With the new version 1.10, I was getting an error when downloading the pre-built binary on Windows x86_64:

```
 blink.cmp  .../lazy/blink.cmp/lua/blink/cap/fuzzy/download/files.lua:78: Checksum of pre-built binary does not match. Expected "d3e355f3d1eb5107952e578166d4e391f826d1b4a
7ba04888e9a85c13be562d4", got "SHA256"
```

This was due to a missing `local os = system.get_info()` that is used to parse out systems with different SHA256 commands than UNIX. Therefore, the `os == 'windows'` check was not actually happening.

Feel free to move around the line, thank you so much for another great release!
