### PR TITLE
docs: add support on Windows for aarch64

### DIFF
--- a/doc/configuration/fuzzy.md
+++ b/doc/configuration/fuzzy.md
@@ -20,7 +20,7 @@ Prebuilt binaries are available for the following systems:
 - Linux (musl): x86_64 and aarch64
 - Linux (android / Termux): aarch64
 - macOS: x86_64 and aarch64
-- Windows: x86_64
+- Windows: x86_64 and aarch64
 - FreeBSD: x86_64 and aarch64
 - OpenBSD: x86_64 and aarch64
 


### PR DESCRIPTION
Support for aarch64 architecture on Windows added in PR #2421 