### PR TITLE
fix(lsp): normalize `vim.NIL` values in completion responses

### DIFF
--- a/lua/blink/cmp/sources/lib/utils.lua
+++ b/lua/blink/cmp/sources/lib/utils.lua
@@ -1,6 +1,24 @@
 local utils = {}
 local cmdline_constants = require('blink.cmp.sources.cmdline.constants')
 
+--- Normalize `vim.NIL` to `nil` recursively.
+--- Neovim decodes JSON `null` as `vim.NIL` since 40aef0d but this could break assumptions in downstream code expecting plain `nil`.
+--- @param value lsp.CompletionItem[]|lsp.CompletionItem
+--- @return lsp.CompletionItem[]|lsp.CompletionItem
+function utils.normalize_nil(value)
+  if type(value) ~= 'table' then return value end
+
+  for k, v in pairs(value) do
+    if v == vim.NIL then
+      value[k] = nil
+    elseif type(v) == 'table' then
+      utils.normalize_nil(v)
+    end
+  end
+
+  return value
+end
+
 --- Safely parses a command-line string.
 --- Skips parsing for known incomplete expressions that cause nvim_parse_cmd() to emit errors even inside pcall(). Not exhaustive.
 --- @param line string

--- a/lua/blink/cmp/sources/lsp/completion.lua
+++ b/lua/blink/cmp/sources/lsp/completion.lua
@@ -1,5 +1,6 @@
 local async = require('blink.cmp.lib.async')
 local cache = require('blink.cmp.sources.lsp.cache')
+local utils = require('blink.cmp.sources.lib.utils')
 
 local CompletionTriggerKind = vim.lsp.protocol.CompletionTriggerKind
 --- @param context blink.cmp.Context
@@ -37,6 +38,8 @@ local known_defaults = {
 --- @return blink.cmp.CompletionResponse
 local function process_response(context, client, res)
   local items = res.items or res
+  items = utils.normalize_nil(items)
+
   local default_edit_range = res.itemDefaults and res.itemDefaults.editRange
   for _, item in ipairs(items) do
     item.client_id = client.id

--- a/lua/blink/cmp/sources/lsp/init.lua
+++ b/lua/blink/cmp/sources/lsp/init.lua
@@ -1,4 +1,5 @@
 local async = require('blink.cmp.lib.async')
+local utils = require('blink.cmp.sources.lib.utils')
 
 --- Wraps client to support both 0.11 and 0.10 without deprecation warnings
 --- @param client vim.lsp.Client
@@ -103,6 +104,8 @@ function lsp:resolve(item, callback)
       callback(item)
       return
     end
+
+    resolved_item = utils.normalize_nil(resolved_item)
 
     -- Snippet with no detail, fill in the detail with the snippet
     if resolved_item.detail == nil and resolved_item.insertTextFormat == vim.lsp.protocol.InsertTextFormat.Snippet then


### PR DESCRIPTION
Supersedes #2454

Neovim decodes JSON `null` as `vim.NIL` (since 40aef0d), which breaks assumptions in downstream codebase expecting `nil` (e.g. documentation, labelDetails.description, etc).

Recursively normalize LSP responses to convert `vim.NIL` to `nil`.

Closes #2456
