### PR TITLE
fix: include dapui buffers on enable exceptions

### DIFF
--- a/lua/blink/cmp/config/init.lua
+++ b/lua/blink/cmp/config/init.lua
@@ -139,7 +139,7 @@ function M.enabled()
   if vim.b.completion == false then return false end
 
   -- Exceptions
-  if user_enabled and vim.bo.filetype == 'dap-repl' then return true end
+  if user_enabled and (vim.bo.filetype == 'dap-repl' or vim.startswith(vim.bo.filetype, 'dapui_')) then return true end
 
   return user_enabled and vim.bo.buftype ~= 'prompt' and vim.b.completion ~= false
 end


### PR DESCRIPTION
When using the `blink-cmp-dap` source, the completion will not trigger on `dapui_watches` buffers. As the plugin includes enable exceptions for the `dap-repl` filetype, i would suppose that the intent is to handle those cases for dap sources by default. This commit includes dapui buffers on enabling exceptions, matching the enable logic for either [mayromr/blink-cmp-dap](https://github.com/mayromr/blink-cmp-dap) or [rcarriga/cmp-dap](https://github.com/rcarriga/cmp-dap).