### PR TITLE
fix: skip show when providers unchanged

### DIFF
--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -68,16 +68,7 @@ function cmp.show(opts)
 
     -- Skip when passing the same list of providers
     local ctx = require('blink.cmp.completion.list').context
-    if ctx and #ctx.providers == #opts.providers then
-      local same = true
-      for i, v in ipairs(opts.providers) do
-        if ctx.providers[i] ~= v then
-          same = false
-          break
-        end
-      end
-      if same then return false end
-    end
+    if ctx and vim.deep_equal(ctx.providers, opts.providers) then return false end
   end
 
   require('blink.cmp.completion.windows.menu').force_auto_show()

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -63,9 +63,22 @@ function cmp.is_documentation_visible() return require('blink.cmp.completion.win
 function cmp.show(opts)
   opts = opts or {}
 
-  -- TODO: when passed a list of providers, we should check if we're already showing the menu
-  -- with that list of providers
-  if require('blink.cmp.completion.windows.menu').win:is_open() and not (opts and opts.providers) then return false end
+  if require('blink.cmp.completion.windows.menu').win:is_open() then
+    if not opts.providers then return false end
+
+    -- Skip when passing the same list of providers
+    local ctx = require('blink.cmp.completion.list').context
+    if ctx and #ctx.providers == #opts.providers then
+      local same = true
+      for i, v in ipairs(opts.providers) do
+        if ctx.providers[i] ~= v then
+          same = false
+          break
+        end
+      end
+      if same then return false end
+    end
+  end
 
   require('blink.cmp.completion.windows.menu').force_auto_show()
 


### PR DESCRIPTION
If the menu is already open and `cmp.show()` is called with the same provider list, early-return instead of re-triggering completion.

This implements the existing TODO and avoids unnecessary recomputation.

Closes #2478
