### PR TITLE
Support manual trigger and relative paths in path source

### DIFF
--- a/lua/blink/cmp/sources/path/init.lua
+++ b/lua/blink/cmp/sources/path/init.lua
@@ -50,6 +50,8 @@ function path:get_completions(context, callback)
   local lib = require('blink.cmp.sources.path.lib')
 
   local dirname = lib.dirname(self.opts, context)
+  if not dirname then dirname = lib.dirname_relaxed(self.opts, context) end
+  if not dirname and context.trigger and context.trigger.kind == 'manual' then dirname = self.opts.get_cwd(context) end
   if not dirname then return callback({ is_incomplete_forward = false, is_incomplete_backward = false, items = {} }) end
 
   local include_hidden = self.opts.show_hidden_files_by_default

--- a/lua/blink/cmp/sources/path/lib.lua
+++ b/lua/blink/cmp/sources/path/lib.lua
@@ -51,6 +51,23 @@ function lib.dirname(opts, context)
   return nil
 end
 
+--- Relaxed dirname extraction for relative paths like "lua/plugins/" that the strict regex rejects.
+--- Unlike dirname(), this does not require a leading "/" or "./" prefix.
+--- Returns nil if no relative path is found (does not fall back to cwd).
+--- @param opts blink.cmp.PathOpts
+--- @param context blink.cmp.Context
+function lib.dirname_relaxed(opts, context)
+  local line_before_cursor = context.line:sub(1, context.bounds.start_col - (context.bounds.length == 0 and 1 or 0))
+
+  local rel_path = line_before_cursor:match('([%w%._%-][%w%._%-/]*/)[%w%._%-]*$')
+  if rel_path then
+    local buf_dirname = opts.get_cwd(context)
+    return vim.fn.resolve(buf_dirname .. '/' .. rel_path)
+  end
+
+  return nil
+end
+
 --- @param context blink.cmp.Context
 --- @param dirname string
 --- @param include_hidden boolean
@@ -125,6 +142,11 @@ function lib.get_text_edit_ranges(context)
   local next_letter_is_slash = context.line:sub(context.cursor[2] + 1, context.cursor[2] + 1) == '/'
 
   local last_part_idx = lib.get_last_path_part(line_before_cursor)
+
+  -- Clamp to context.bounds so we never replace text before the current word
+  -- (e.g. when manually triggered without a path prefix)
+  local bounds_start = context.bounds.start_col
+  if last_part_idx < bounds_start then last_part_idx = bounds_start end
 
   -- TODO: return the insert and replace ranges, instead of only the insert range
   return {

--- a/lua/blink/cmp/sources/path/lib.lua
+++ b/lua/blink/cmp/sources/path/lib.lua
@@ -123,10 +123,27 @@ function path_lib.get_text_edit_ranges(context)
 
   local last_part_idx = path_lib.get_last_path_part(line_before_cursor)
 
-  -- Clamp to context.bounds so we never replace text before the current word
-  -- (e.g. when manually triggered without a path prefix)
-  local bounds_start = context.bounds.start_col
-  if last_part_idx < bounds_start then last_part_idx = bounds_start end
+  -- For manual triggers, clamp to context.bounds so we never replace text
+  -- before the current word, then expand backward to include path-like
+  -- characters (since '.' is both a trigger char and a valid path char,
+  -- get_last_path_part may stop too early)
+  if context.trigger and context.trigger.kind == 'manual' then
+    local bounds_start = context.bounds.start_col
+    if last_part_idx < bounds_start then last_part_idx = bounds_start end
+
+    local i = last_part_idx - 1
+    while i > 0 do
+      local c = line_before_cursor:sub(i, i)
+      if c == '/' or c == '\\' then
+        break
+      elseif c:match('[%w%._-]') then
+        last_part_idx = i
+        i = i - 1
+      else
+        break
+      end
+    end
+  end
 
   -- TODO: return the insert and replace ranges, instead of only the insert range
   return {

--- a/lua/blink/cmp/sources/path/lib.lua
+++ b/lua/blink/cmp/sources/path/lib.lua
@@ -53,6 +53,23 @@ function path_lib.dirname(opts, context)
   return nil
 end
 
+--- Relaxed dirname extraction for relative paths like "lua/plugins/" that the strict regex rejects.
+--- Unlike dirname(), this does not require a leading "/" or "./" prefix.
+--- Returns nil if no relative path is found (does not fall back to cwd).
+--- @param opts blink.cmp.PathOpts
+--- @param context blink.cmp.Context
+function path_lib.dirname_relaxed(opts, context)
+  local line_before_cursor = context.line:sub(1, context.bounds.start_col - (context.bounds.length == 0 and 1 or 0))
+
+  local rel_path = line_before_cursor:match('([%w%._%-][%w%._%-/]*/)[%w%._%-]*$')
+  if rel_path then
+    local buf_dirname = opts.get_cwd(context)
+    return vim.fn.resolve(buf_dirname .. '/' .. rel_path)
+  end
+
+  return nil
+end
+
 --- @param context blink.cmp.Context
 --- @param dirname string
 --- @param include_hidden boolean
@@ -105,6 +122,11 @@ function path_lib.get_text_edit_ranges(context)
   local next_letter_is_slash = context.line:sub(context.cursor[2] + 1, context.cursor[2] + 1) == '/'
 
   local last_part_idx = path_lib.get_last_path_part(line_before_cursor)
+
+  -- Clamp to context.bounds so we never replace text before the current word
+  -- (e.g. when manually triggered without a path prefix)
+  local bounds_start = context.bounds.start_col
+  if last_part_idx < bounds_start then last_part_idx = bounds_start end
 
   -- TODO: return the insert and replace ranges, instead of only the insert range
   return {


### PR DESCRIPTION
## Problem

`cmp.show({ providers = { 'path' } })` does nothing when there's no path prefix (like `./` or `/`) before the cursor. This was reported in #966 — manual trigger should bypass the strict path regex, since the user is explicitly requesting path completion.

Additionally, relative paths without a leading `./` (e.g. `lua/plugins/`) are never completed, even though they're valid and common in many codebases.

## Usage example

```lua
-- Keymap to manually trigger path completion anywhere
keymap = {
  ['<C-f>'] = { function(cmp) cmp.show({ providers = { 'path' } }) end },
}
```

Before this change, this keymap only works when the cursor is preceded by ./, /, or similar prefixes. After this change, it shows completions from the buffer's directory regardless of context.

`<C-f>` is chosen deliberately to keep it distinct from Neovim's native `<C-x><C-f>` path completion — they behave differently and should remain separate keys, so users can pick whichever they prefer without conflict.


## Changes

**1. `lib.dirname_relaxed()`** — a fallback that matches relative paths like `lua/plugins/` or `src/components/` without requiring a `./` or `/` prefix. Returns nil if no path-like text is found (never over-triggers on arbitrary text).

**2. Manual trigger cwd fallback** — when manually triggered and no path context exists at all, falls back to the buffer's directory. This only applies to explicit `cmp.show()` calls, not auto-show.

**3. Text edit range clamping** — `get_text_edit_ranges` now clamps `last_part_idx` to `context.bounds` to prevent replacing text before the current word. Without this, manual trigger on a line with no `/` would cause the text edit to start from column 0, deleting unrelated text.

## Why `dirname_relaxed` runs unconditionally (not gated by trigger kind)

We considered limiting it to `manual` and `trigger_character` only, but decided against it:

- If the text before the cursor already matches a relative path pattern, showing path completions is the correct behavior regardless of how completion was triggered. The user is clearly editing a path.
- It also solves the continuation problem: after selecting a directory (e.g. `lua/`) from a manual trigger, the trailing `/` fires as a trigger character. Without relaxed matching, `dirname()` rejects `lua/` (no `./` prefix) and completion stops. With unconditional fallback, directory drilling works seamlessly.
- The performance concern is minimal — `dirname_relaxed` only runs when `dirname()` already returned nil, and it's a single Lua pattern match.

## Tested scenarios

- Manual trigger via `cmp.show({ providers = { 'path' } })` on empty context shows files from buffer's directory
- Manual trigger with partial text (e.g. `init`) filters results correctly
- Selecting a directory continues completion into that directory
- Existing `./`, `/`, `~/` path completion behavior unchanged
- Relative paths like `lua/` trigger completion automatically
- No text deletion when navigating the completion list
- No spurious path completion on non-path text

Fixes #966


