### PR TITLE
fix: menu.queue_auto_show vim.schedule race

### DIFF
--- a/lua/blink/cmp/completion/windows/menu.lua
+++ b/lua/blink/cmp/completion/windows/menu.lua
@@ -171,14 +171,11 @@ function menu.queue_auto_show(context, items)
   if menu.auto_show.timer:is_active() and menu.auto_show.timer_key == timer_key then return end
 
   menu.auto_show.timer_key = timer_key
-  -- TODO: this can race:
-  --  - timer fires, scheduling the function
-  --  - timer stopped by reset_auto_show()
-  --  - scheduled function runs (race!!)
   menu.auto_show.timer:start(
     delay_ms,
     0,
     vim.schedule_wrap(function()
+      if menu.auto_show.timer_key ~= timer_key then return end
       menu.open()
       menu.update_position()
     end)


### PR DESCRIPTION
Hey, I noticed that sometimes the completion menu does not get closed after exiting insert mode and I was suspecting that this is due to my usage of  `auto_show_delay_ms = 100`.

I would create an issue that has reproducible steps but I just can't reproduce it after trying, it just happens rarely sometimes and it's annoying, I close it with `<c-w>o` but still.

Looked at the code and this `TODO: this can race` I found suspicious, so trying to fix it here.

Maybe I'm looking at it naively but this seems like a simple fix so I wonder why the author didn't fix this `TODO:`
