### PR TITLE
ci: update cross-platform-actions/action action for OpenBSD build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,7 +119,7 @@ jobs:
           persist-credentials: false
 
       - name: Build on OpenBSD/${{ matrix.arch }}
-        uses: cross-platform-actions/action@v0.32.0
+        uses: cross-platform-actions/action@v1.0.0
         with:
           operating_system: openbsd
           architecture: ${{ matrix.arch }}


### PR DESCRIPTION
Cross Platform Action release 1.0.0: https://github.com/cross-platform-actions/action/releases/tag/v1.0.0