### PR TITLE
ci: update action-gh-release action to v3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,7 +172,7 @@ jobs:
           done
 
       - name: Upload Release Assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
softprops/action-gh-release action release v3.0.0: https://github.com/softprops/action-gh-release/releases/tag/v3.0.0