### PR TITLE
fix(omni): attempt to resolve script-local functions

### DIFF
--- a/lua/blink/cmp/sources/complete_func.lua
+++ b/lua/blink/cmp/sources/complete_func.lua
@@ -40,7 +40,25 @@ function Source:enabled()
   return not vim.tbl_contains({ nil, '' }, self.opts.complete_func()) and nvim.get_mode().mode == 'i'
 end
 
----Invoke an complete_func handling `v:lua.*`
+---@param func string
+---@return string
+local function resolve_script_local_function(func)
+  local local_name = func:match('^s:(.+)$') or func:match('^<SID>(.+)$')
+  if not local_name then return func end
+
+  local option_info = vim.api.nvim_get_option_info2('omnifunc', { buf = 0 })
+  if option_info.last_set_sid <= 0 then return func end
+
+  local script_info = vim.fn.getscriptinfo({ sid = option_info.last_set_sid })[1]
+  if not script_info.functions then return func end
+
+  local resolved_name = ('<SNR>%d_%s'):format(option_info.last_set_sid, local_name)
+  if vim.tbl_contains(script_info.functions, resolved_name) then return resolved_name end
+
+  return func
+end
+
+---Invoke an complete_func handling `v:lua.*` and script-local Vimscript.
 ---@return (table<{ words: blink.cmp.CompleteFuncWords, refresh: string }> | blink.cmp.CompleteFuncWords) | integer
 ---@overload fun(func: string, findstart: 1, base: ''): integer
 ---@overload fun(func: string, findstart: 0, base: string): table<{ words: blink.cmp.CompleteFuncWords, refresh: string }> | blink.cmp.CompleteFuncWords
@@ -54,6 +72,7 @@ local function invoke_complete_func(func, findstart, base)
     if match then
       return vim.fn.luaeval(string.format('%s(_A[1], _A[2], _A[3])', match), args)
     else
+      func = resolve_script_local_function(func)
       return nvim.call_function(func, args)
     end
   end)


### PR DESCRIPTION
## Problem

Recently, neovim [added helptags completion](https://github.com/neovim/neovim/commit/f908fe446243a30b76cbc7b1786eae514fa8ec1c) via omnifunc, but it doesn't show up with blink.

## Solution

Detect if the omnifunc is a script local function and tries to resolve it by when it starts with `s:` or `<SID>`.

Some notes:
- The [`:help <SID>`](https://neovim.io/doc/user/map/#%3CSID%3E) seems to say that `vim.fn.expand('<SID>')` will resolve correctly with the script id, but it didn't seem to work for me.
- As such, it seems that by tracing the script that set `omnifunc`, we are able to get the script id and call the function with it, which gets the correct completions.
- Another possible solution is to make this completion function global like all the other completions are, I can just send a patch to vim if that's preferred and close this, I'm planning on sending a patch anyways (edit: added [here](https://github.com/vim/vim/pull/20024))