### PR TITLE
docs: add `cmp-wezterm` community source

### DIFF
--- a/doc/configuration/sources.md
+++ b/doc/configuration/sources.md
@@ -130,6 +130,7 @@ Here is a non-exhaustive list of third-party plugins providing additional comple
 - [blink-nerdfont.nvim](https://github.com/MahanRahmati/blink-nerdfont.nvim) by `MahanRahmati`: [Nerd Fonts](https://www.nerdfonts.com)
 - [blink-ripgrep](https://github.com/mikavilpas/blink-ripgrep.nvim) by `mikavilpas`: Ripgrep
 - [cmp-pandoc-references](https://github.com/jmbuhr/cmp-pandoc-references) by `jmbuhr`: Bibliography, reference and cross-ref items
+- [cmp-wezterm](https://github.com/delphinus/cmp-wezterm) by `delphinus`: [WezTerm](https://wezterm.org) terminal (also works with `nvim-cmp`)
 - [css-vars.nvim](https://github.com/jdrupal-dev/css-vars.nvim) by `jdrupal-dev`: CSS variables
 - [ecolog.nvim](https://github.com/ph1losof/ecolog.nvim) by `ph1losof`: Environment variables
 - [gitmoji.nvim](https://github.com/Dynge/gitmoji.nvim) by `Dynge`: [gitmojis](https://gitmoji.dev)


### PR DESCRIPTION
## Feature Description

Hi @saghen, thanks for the plugin. I'd like to add [`delphinus/cmp-wezterm`](https://github.com/delphinus/cmp-wezterm) to the community sources list. It started as an `nvim-cmp` source and now also provides a native `blink.cmp` source via `module = "blink-cmp-wezterm"`, so users can use the same package with either completion framework.

A `blink-cmp-wezterm` entry by `junkblocker` already exists. Differences from the existing entry:

- Filters by current tab / current window via `all_tabs` / `all_windows` options
- Cancellation support — `get_completions` returns a cancel fn that SIGTERMs in-flight `wezterm cli` subprocesses when the completion list is destroyed
- Pane location (`win:tab:id`) shown in `labelDetails`
- Also works with `nvim-cmp` (single dependency for users who use both)

Would appreciate the addition!