### PR TITLE
fix: provide tags for git tags

### DIFF
--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -153,7 +153,7 @@ function cmp.download(opts)
         .. platform.lib_extension
       local git_commit = lib.native.git_commit(filename)
       local library_path = lib.native.library_path('blink_cmp_fuzzy', git_commit)
-      return lib.native.download_async(url, library_path, callback):map(function()
+      return lib.native.download_async(url, library_path):map(function()
         if not lib.native.load('blink_cmp_fuzzy', lib.native.git_commit(filename)) then
           error('Failed to load downloaded blink.cmp precompiled library')
         end

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -153,6 +153,11 @@ function cmp.download(opts)
         .. platform.lib_extension
       local git_commit = lib.native.git_commit(filename)
       local library_path = lib.native.library_path('blink_cmp_fuzzy', git_commit)
+      if vim.uv.fs_stat(library_path) then
+        local tempfile = library_path .. '.' .. tostring(vim.uv.hrtime())
+        vim.uv.fs_rename(library_path, tempfile)
+        vim.uv.fs_unlink(tempfile)
+      end
       return lib.native.download_async(url, library_path):map(function()
         if not lib.native.load('blink_cmp_fuzzy', lib.native.git_commit(filename)) then
           error('Failed to load downloaded blink.cmp precompiled library')

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -153,11 +153,6 @@ function cmp.download(opts)
         .. platform.lib_extension
       local git_commit = lib.native.git_commit(filename)
       local library_path = lib.native.library_path('blink_cmp_fuzzy', git_commit)
-      if vim.uv.fs_stat(library_path) then
-        local tempfile = library_path .. '.' .. tostring(vim.uv.hrtime())
-        vim.uv.fs_rename(library_path, tempfile)
-        vim.uv.fs_unlink(tempfile)
-      end
       return lib.native.download_async(url, library_path):map(function()
         if not lib.native.load('blink_cmp_fuzzy', lib.native.git_commit(filename)) then
           error('Failed to load downloaded blink.cmp precompiled library')

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -139,8 +139,8 @@ function cmp.download(opts)
 
       logger:notify(vim.log.levels.INFO, 'Downloading blink.cmp precompiled library')
 
-      local filename = debug.getinfo(1, 'S').source:sub(2)
-      local git_tag = lib.native.git_tag(filename, opts.match)
+      local current_file_path = debug.getinfo(1, 'S').source:sub(2)
+      local git_tag = lib.native.git_tag(current_file_path, opts.match)
       if git_tag == nil then error('Missing git tag, have you pinned the version?') end
 
       local platform = lib.native.platform()
@@ -151,10 +151,10 @@ function cmp.download(opts)
         .. '/'
         .. platform.triple
         .. platform.lib_extension
-      local git_commit = lib.native.git_commit(filename)
+      local git_commit = lib.native.git_commit(current_file_path)
       local library_path = lib.native.library_path('blink_cmp_fuzzy', git_commit)
       return lib.native.download_async(url, library_path):map(function()
-        if not lib.native.load('blink_cmp_fuzzy', lib.native.git_commit(filename)) then
+        if not lib.native.load('blink_cmp_fuzzy', lib.native.git_commit(current_file_path)) then
           error('Failed to load downloaded blink.cmp precompiled library')
         end
         logger:notify(vim.log.levels.INFO, 'Successfully loaded downloaded blink.cmp precompiled library')

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -139,7 +139,8 @@ function cmp.download(opts)
 
       logger:notify(vim.log.levels.INFO, 'Downloading blink.cmp precompiled library')
 
-      local git_tag = lib.native.git_tag(debug.getinfo(1, 'S').source:sub(2), opts.match)
+      local filename = debug.getinfo(1, 'S').source:sub(2)
+      local git_tag = lib.native.git_tag(filename, opts.match)
       if git_tag == nil then error('Missing git tag, have you pinned the version?') end
 
       local platform = lib.native.platform()
@@ -150,10 +151,10 @@ function cmp.download(opts)
         .. '/'
         .. platform.triple
         .. platform.lib_extension
-      local git_commit = lib.native.git_commit(debug.getinfo(1, 'S').source:sub(2))
+      local git_commit = lib.native.git_commit(filename)
       local library_path = lib.native.library_path('blink_cmp_fuzzy', git_commit)
       return lib.native.download_async(url, library_path, callback):map(function()
-        if not lib.native.load('blink_cmp_fuzzy', lib.native.git_commit(debug.getinfo(1, 'S').source:sub(2))) then
+        if not lib.native.load('blink_cmp_fuzzy', lib.native.git_commit(filename)) then
           error('Failed to load downloaded blink.cmp precompiled library')
         end
         logger:notify(vim.log.levels.INFO, 'Successfully loaded downloaded blink.cmp precompiled library')

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -129,7 +129,7 @@ function cmp.build(opts)
 end
 
 --- Downloads the precompiled library if it's not already available
---- @param opts? { force?: boolean }
+--- @param opts? { force?: boolean, match?: string }
 --- @return blink.lib.Task
 function cmp.download(opts)
   return lib.task
@@ -139,7 +139,7 @@ function cmp.download(opts)
 
       logger:notify(vim.log.levels.INFO, 'Downloading blink.cmp precompiled library')
 
-      local git_tag = lib.native.git_tag(debug.getinfo(1, 'S').source:sub(2))
+      local git_tag = lib.native.git_tag(debug.getinfo(1, 'S').source:sub(2), opts.match)
       if git_tag == nil then error('Missing git tag, have you pinned the version?') end
 
       local platform = lib.native.platform()


### PR DESCRIPTION
`opts.fuzzy.prebuilt_binaries` is removed on latest commit

This commit trying to make this work:
```
require('blink.cmp').download({ force = true, tags = '*' }):wait(60000)
```

Require https://github.com/saghen/blink.lib/pull/9.
