### PR TITLE
fix(config): allow function for ghost text enabled

### DIFF
--- a/lua/blink/cmp/config/completion/ghost_text.lua
+++ b/lua/blink/cmp/config/completion/ghost_text.lua
@@ -8,7 +8,7 @@
 
 local config = require('blink.lib.config')
 return {
-  enabled = { false, 'boolean' },
+  enabled = { false, { 'boolean', 'function' } },
   show_with_selection = { true, 'boolean' },
   show_without_selection = { false, 'boolean' },
   show_with_menu = { true, 'boolean' },


### PR DESCRIPTION
## Summary

Allow `completion.ghost_text.enabled` to accept functions in the config schema.

The runtime already supports this:

```lua
if type(config.enabled) == 'function' then return config.enabled() end
```

and the Lua annotation already documents:

```lua
---@field enabled boolean | fun(): boolean
```

but the schema only allowed `boolean`, causing validation errors for dynamic configs.

## Verification

- `git diff HEAD~1..HEAD --check`
- `stylua --check lua/blink/cmp/config/completion/ghost_text.lua`
- Headless Neovim validation with `completion.ghost_text.enabled = function() return true end`
