### PR TITLE
feat(nix): refactor and some minor improvements

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -40,15 +40,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          extra-conf: |
-            accept-flake-config = true
 
       - name: Check the flake
         run: nix flake check
-
-      - name: Build the library
-        run: nix build .#blink-fuzzy-lib
-
-      - name: Build the plugin in nix
-        run: nix build .#blink-cmp

--- a/flake.lock
+++ b/flake.lock
@@ -2,80 +2,40 @@
   "nodes": {
     "blink-lib": {
       "inputs": {
-        "flake-parts": [
-          "flake-parts"
-        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1777065460,
-        "narHash": "sha256-Wr7r7445c2bjuG8tjrHR6kCBh7xsk/0hQ4HW2yW3YeA=",
+        "lastModified": 1777670812,
+        "narHash": "sha256-3XsqX4CGj8VI5tGLWJoUiyo+u7AyNp2IO9hEwQsF1I8=",
         "owner": "saghen",
         "repo": "blink.lib",
-        "rev": "dda2666685a5ac3598166577d2e34f1fff6b1637",
+        "rev": "f29d8bac6549bc1e7d699c83f680823d7def98bd",
         "type": "github"
       },
       "original": {
         "owner": "saghen",
         "repo": "blink.lib",
-        "type": "github"
-      }
-    },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777425547,
-        "narHash": "sha256-d57AbflkNfZNoFaZDzssEq1RfPoM9dLtOGI2O+N/68Q=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "ebc08544afa77957cc348ba72dc490ec73b87f68",
-        "type": "github"
+        "lastModified": 1777268161,
+        "narHash": "sha256-e1tDUQMbFCxCnke314UpghgRqg3FJLtcXFfq/WTRLYI=",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre987561.1c3fe55ad329/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
     "root": {
       "inputs": {
         "blink-lib": "blink-lib",
-        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,81 +2,89 @@
   description = "Performant, batteries-included completion plugin for Neovim";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
 
     blink-lib.url = "github:saghen/blink.lib";
     blink-lib.inputs.nixpkgs.follows = "nixpkgs";
-    blink-lib.inputs.flake-parts.follows = "flake-parts";
   };
 
-  outputs =
-    inputs@{ flake-parts, nixpkgs, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [
-        "x86_64-linux"
-        "x86_64-darwin"
-        "aarch64-linux"
-        "aarch64-darwin"
-      ];
+  outputs = {
+    nixpkgs,
+    blink-lib,
+    self,
+    ...
+  }: let
+    inherit (nixpkgs) lib;
+    inherit (lib.attrsets) genAttrs mapAttrs' nameValuePair;
+    inherit (lib.fileset) fileFilter toSource unions;
+    inherit (lib.lists) optional;
 
-      perSystem =
-        {
-          self',
-          inputs',
-          pkgs,
-          lib,
-          ...
-        }:
-        {
-          packages =
-            let
-              fs = lib.fileset;
-              nixFs = fs.fileFilter (file: file.hasExt == "nix") ./.;
-              rustFs = fs.unions [
-                (fs.fileFilter (file: lib.hasPrefix "Cargo" file.name) ./.)
-                (fs.fileFilter (file: file.hasExt "rs") ./.)
-                ./.cargo
-              ];
-              nvimFs = fs.difference ./. (
-                fs.unions [
-                  nixFs
-                  rustFs
-                  ./doc
-                  ./repro.lua
-                ]
-              );
-              version = "1.10.0";
-            in
-            {
-              blink-fuzzy-lib = pkgs.rustPlatform.buildRustPackage {
-                pname = "blink-fuzzy-lib";
-                inherit version;
-                src = fs.toSource {
-                  root = ./.;
-                  fileset = rustFs;
-                };
-                cargoLock.lockFile = ./Cargo.lock;
-                buildInputs = with pkgs; lib.optionals stdenv.hostPlatform.isAarch64 [ rust-jemalloc-sys ];
-                nativeBuildInputs = with pkgs; [ git ];
-              };
+    systems = ["x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"];
+    forAllSystems = genAttrs systems;
+    nixpkgsFor = forAllSystems (system:
+      import nixpkgs {
+        inherit system;
+        overlays = [blink-lib.overlays.default];
+      });
 
-              blink-cmp = pkgs.vimUtils.buildVimPlugin {
-                pname = "blink.cmp";
-                inherit version;
-                src = fs.toSource {
-                  root = ./.;
-                  fileset = nvimFs;
-                };
-                dependencies = [ inputs'.blink-lib.packages.blink-lib ];
-                preInstall = ''
-                  mkdir -p lib
-                  ln -s ${self'.packages.blink-fuzzy-lib}/lib/libblink_cmp_fuzzy.* lib/
-                '';
-              };
-
-              default = self'.packages.blink-cmp;
-            };
+    version = "1.10.2";
+    blink-cmp-package = {
+      git,
+      rust-jemalloc-sys,
+      rustPlatform,
+      stdenv,
+      vimPlugins,
+      vimUtils,
+    }:
+      vimUtils.buildVimPlugin {
+        pname = "blink.cmp";
+        inherit version;
+        src = toSource {
+          root = ./.;
+          fileset = unions [
+            (fileFilter (file: file.hasExt "lua") ./lua)
+            ./doc/blink-cmp.txt
+          ];
         };
+
+        dependencies = [
+          (vimPlugins.blink-lib or (throw "vimPlugins.blink-lib not found; did you include its overlay?"))
+        ];
+
+        preInstall = ''
+          mkdir -p lib
+          ln -s $fuzzy_lib/lib/libblink_cmp_fuzzy.* lib/
+        '';
+
+        env.fuzzy_lib = rustPlatform.buildRustPackage {
+          pname = "blink-fuzzy-lib";
+          inherit version;
+          src = toSource {
+            root = ./.;
+            fileset = unions [
+              (fileFilter (file: file.hasExt "rs") ./.)
+              ./Cargo.toml
+              ./Cargo.lock
+              ./.cargo
+            ];
+          };
+          cargoLock.lockFile = ./Cargo.lock;
+          buildInputs = optional stdenv.hostPlatform.isAarch64 rust-jemalloc-sys;
+          nativeBuildInputs = [git];
+        };
+      };
+  in {
+    packages = forAllSystems (system: rec {
+      blink-cmp = nixpkgsFor.${system}.callPackage blink-cmp-package {};
+      default = blink-cmp;
+    });
+
+    overlays.default = final: prev: {
+      vimPlugins = prev.vimPlugins.extend (_: _: {
+        blink-cmp = final.callPackage blink-cmp-package {};
+      });
     };
+
+    checks = forAllSystems (system: mapAttrs' (n: nameValuePair "package-${n}") (removeAttrs self.packages.${system} ["default"]));
+  };
 }


### PR DESCRIPTION
- remove `flake-parts` dependency
- update flake.lock to incorportate https://github.com/saghen/blink.lib/pull/16
- add `overlays.default`. NB that the overlay requires the user to also
  apply `blink-lib.overlays.default` as well - I added a `throw` in case
  it's missing.
- add `checks` (the default `nix flake check` only checks that packages
  evaluate, but don't actually build them)
- use https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz
  instead of github. for whatever reason it's ~10MB smaller