### PR TITLE
feat(keymap)!: move into nested keys table and restore validation

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,6 +30,26 @@ require('blink.cmp').download({ force = true, tags = '*' }):wait(60000)
 
 #### Keymap
 
+- Added nested `keymap.keys` to list all your custom keymaps:
+
+```lua
+-- BEFORE
+keymap = {
+    preset = 'default'
+    ['<C-e>'] = { 'show', 'hide'},
+    -- ...
+}
+
+-- AFTER
+keymap = {
+    preset = 'default'
+    keys = {
+        ['<C-e>'] = { 'show', 'hide'},
+        -- ...
+    },
+}
+```
+
 - Keymaps are now buffer-local for all modes
 
 #### Sources

--- a/doc/configuration/keymap.md
+++ b/doc/configuration/keymap.md
@@ -34,7 +34,9 @@ Special presets:
 ```lua
 keymap = {
   preset = 'none',
-  ['<C-Space>'] = { 'show' }, -- Only one command defined!
+  keys = {
+    ['<C-Space>'] = { 'show' }, -- Only one command defined!
+  }
 },
 ```
 
@@ -43,7 +45,9 @@ keymap = {
 ```lua
 keymap = {
   preset = 'default',
-  ['<C-Space>'] = { 'show' },
+  keys = {
+    ['<C-Space>'] = { 'show' },
+  },
 },
 cmdline = {
     keymap = {
@@ -115,39 +119,40 @@ Example with conditional logic:
  ```lua
 keymap = {
   preset = 'default',
+  keys = {
+    -- Single command
+    ['<C-n>'] = { 'select_next' },
 
-  -- Single command
-  ['<C-n>'] = { 'select_next' },
+    -- Chained commands
+    ['<C-p>'] = { 'select_prev', 'fallback' },
 
-  -- Chained commands
-  ['<C-p>'] = { 'select_prev', 'fallback' },
+    -- Multi-key sequences
+    ['<C-x><C-o>'] = { 'show', 'fallback' },
+    ['jk'] = { 'hide' },
 
-  -- Multi-key sequences
-  ['<C-x><C-o>'] = { 'show', 'fallback' },
-  ['jk'] = { 'hide' },
+    -- Key equivalences (for terminals that support them)
+    ['<C-i>'] = { 'accept', 'snippet_forward', 'fallback' },
+    ['<Tab>'] = { 'select_next', 'fallback' },
 
-  -- Key equivalences (for terminals that support them)
-  ['<C-i>'] = { 'accept', 'snippet_forward', 'fallback' },
-  ['<Tab>'] = { 'select_next', 'fallback' },
+    -- Override preset key
+    ['<C-y>'] = { 'select_and_accept' },
 
-  -- Override preset key
-  ['<C-y>'] = { 'select_and_accept' },
+    -- Disable preset key
+    ['<C-e>'] = false, -- or {}
 
-  -- Disable preset key
-  ['<C-e>'] = false, -- or {}
+    -- Function calling blink.cmp method
+    ['<C-Space>'] = { function(cmp) return cmp.show() end },
+    ['<C-Space>'] = { 'show' }, -- This is equivalent as above
 
-  -- Function calling blink.cmp method
-  ['<C-Space>'] = { function(cmp) return cmp.show() end },
-  ['<C-Space>'] = { 'show' }, -- This is equivalent as above
+    -- Actions with parameters require functions
+    ['<C-space>S'] = { function(cmp) return cmp.show({ providers = { 'snippets' } }) end },
 
-  -- Actions with parameters require functions
-  ['<C-space>S'] = { function(cmp) return cmp.show({ providers = { 'snippets' } }) end },
-
-  -- String returns - feedkeys() with 't' flag (remap enabled)
-  -- User mappings take precedence over built-in behavior
-  ['<C-n>'] = { 'select_next' },
-  -- Here, <C-n> triggers 'select_next' command defined above
-  ['<C-j>'] = { function(cmp) return '<C-n>' end },
+    -- String returns - feedkeys() with 't' flag (remap enabled)
+    -- User mappings take precedence over built-in behavior
+    ['<C-n>'] = { 'select_next' },
+    -- Here, <C-n> triggers 'select_next' command defined above
+    ['<C-j>'] = { function(cmp) return '<C-n>' end },
+  }
 }
  ```
 

--- a/lua/blink/cmp/config/init.lua
+++ b/lua/blink/cmp/config/init.lua
@@ -7,13 +7,21 @@
 --- @field signature blink.cmp.SignatureConfig
 --- @field snippets blink.cmp.SnippetsConfig
 --- @field appearance blink.cmp.AppearanceConfig
---- @field cmdline table TODO:
---- @field term table TODO:
+--- @field cmdline blink.cmp.CmdlineConfig
+--- @field term blink.cmp.TermConfig
+
+--- @class blink.cmp.CmdlineConfig
+--- @field enabled boolean
+--- @field keymap blink.cmp.KeymapConfig
+
+--- @class blink.cmp.TermConfig
+--- @field enabled boolean
+--- @field keymap blink.cmp.KeymapConfig
 
 --- @type blink.cmp.ConfigStrict
 local config = require('blink.lib.config').new({
   enabled = { true, { 'boolean', 'function' } },
-  keymap = require('blink.cmp.config.keymap'),
+  keymap = require('blink.cmp.config.keymap').get('default'),
   completion = require('blink.cmp.config.completion'),
   fuzzy = require('blink.cmp.config.fuzzy'),
   sources = require('blink.cmp.config.sources'),
@@ -24,11 +32,11 @@ local config = require('blink.lib.config').new({
   -- mode specific configs
   cmdline = {
     enabled = { true, 'boolean' },
-    keymap = { { preset = 'cmdline' }, 'table' },
+    keymap = require('blink.cmp.config.keymap').get('cmdline'),
   },
   term = {
     enabled = { true, 'boolean' },
-    keymap = { { preset = 'default' }, 'table' },
+    keymap = require('blink.cmp.config.keymap').get('inherit'),
   },
 }, { global_key = 'blink_cmp', validate = false })
 

--- a/lua/blink/cmp/config/keymap.lua
+++ b/lua/blink/cmp/config/keymap.lua
@@ -159,72 +159,68 @@
 --- When defining your own keymaps without a preset, no keybinds will be assigned automatically.
 --- @class (exact) blink.cmp.KeymapConfig
 --- @field preset? blink.cmp.KeymapPreset
---- @field [string] blink.cmp.KeymapCommand[] | false Table of keys => commands[] or false to disable
+--- @field keys? table<string, blink.cmp.KeymapCommand[]> Map of keys to commands
 
---- @param config blink.cmp.KeymapConfig
---- @param is_mode boolean? Is mode-specific keymap config
-function validate(config, is_mode)
-  assert(config.cmdline == nil, '`keymap.cmdline` has been replaced with `cmdline.keymap`')
-  assert(config.term == nil, '`keymap.term` has been replaced with `term.keymap`')
+local keymap = {}
 
-  local commands = {
-    'fallback',
-    'fallback_to_mappings',
-    'show',
-    'show_and_insert',
-    'show_and_insert_or_accept_single',
-    'hide',
-    'cancel',
-    'accept',
-    'accept_and_enter',
-    'select_and_accept',
-    'select_accept_and_enter',
-    'select_prev',
-    'select_next',
-    'insert_prev',
-    'insert_next',
-    'show_documentation',
-    'hide_documentation',
-    'scroll_documentation_up',
-    'scroll_documentation_down',
-    'show_signature',
-    'hide_signature',
-    'scroll_signature_up',
-    'scroll_signature_down',
-    'snippet_forward',
-    'snippet_backward',
-  }
-  local presets = { 'default', 'cmdline', 'super-tab', 'enter', 'none' }
-  if is_mode then table.insert(presets, 'inherit') end
+local config = require('blink.lib.config')
 
-  local validation_schema = {}
-  for key, value in pairs(config) do
-    -- preset
-    if key == 'preset' then
-      validation_schema[key] = {
-        value,
-        function(preset) return vim.tbl_contains(presets, preset) end,
-        'one of: ' .. table.concat(presets, ', '),
-      }
+local presets = { 'default', 'cmdline', 'super-tab', 'enter', 'none', 'inherit' }
+local commands = {
+  'fallback',
+  'fallback_to_mappings',
+  'show',
+  'show_and_insert',
+  'show_and_insert_or_accept_single',
+  'hide',
+  'cancel',
+  'accept',
+  'accept_and_enter',
+  'select_and_accept',
+  'select_accept_and_enter',
+  'select_prev',
+  'select_next',
+  'insert_prev',
+  'insert_next',
+  'show_documentation',
+  'hide_documentation',
+  'scroll_documentation_up',
+  'scroll_documentation_down',
+  'show_signature',
+  'hide_signature',
+  'scroll_signature_up',
+  'scroll_signature_down',
+  'snippet_forward',
+  'snippet_backward',
+}
 
-    -- key
-    else
-      validation_schema[key] = {
-        value,
-        function(key_commands)
-          if key_commands == false then return true end
-          if type(key_commands) ~= 'table' then return false end
-          for _, command in ipairs(key_commands) do
-            if type(command) ~= 'function' and not vim.tbl_contains(commands, command) then return false end
-          end
-          return true
-        end,
-        'commands must be one of: ' .. table.concat(commands, ', ') .. ' or false to disable',
-      }
-    end
+local keymap_command = config.types.validator('string | function', function(val)
+  if type(val) == 'string' and not vim.tbl_contains(commands, val) then return false, ' unknown command: ' .. val end
+  return type(val) == 'string' or type(val) == 'function'
+end)
+
+local keymap_value = config.types.validator('false | list(string|function)', function(val)
+  if val == false then return true end
+  if not vim.islist(val) then return false end
+
+  for _, cmd in ipairs(val) do
+    local ok, err = config.utils.validate_value(cmd, keymap_command)
+    if not ok then return false, err end
   end
-  require('blink.cmp.config.utils')._validate(validation_schema)
+  return true
+end)
+
+local keymap_notation = config.types.validator(
+  'string (key-notation)',
+  function(val) return type(val) == 'string' and val:match('^<.+>$') or false end
+)
+
+---@param preset blink.cmp.KeymapPreset
+function keymap.get(preset)
+  return {
+    preset = { preset, config.types.enum(presets) },
+    keys = { {}, config.types.map(keymap_notation, keymap_value) },
+  }
 end
 
--- TODO:
-return { { preset = 'default' }, 'table' }
+return keymap

--- a/lua/blink/cmp/keymap/init.lua
+++ b/lua/blink/cmp/keymap/init.lua
@@ -80,15 +80,15 @@ function keymap.get_mappings(keymap_config, mode)
 
   -- Inherit preset from default, if needed
   if mappings.preset == 'inherit' and mode ~= 'default' then
-    mappings = vim.tbl_deep_extend('force', config.keymap, mappings)
+    mappings.keys = vim.tbl_deep_extend('force', config.keymap.keys, mappings.keys or {})
     mappings.preset = config.keymap.preset
   end
 
   -- Remove unused keys, but keep keys set to false or empty tables (to disable them)
   if mode ~= 'default' then
-    for key, commands in pairs(mappings) do
+    for key, commands in pairs(mappings.keys) do
       if key ~= 'preset' and commands ~= false and #commands ~= 0 and not apply.has_insert_command(commands) then
-        mappings[key] = nil
+        mappings.keys[key] = nil
       end
     end
   end
@@ -98,15 +98,15 @@ function keymap.get_mappings(keymap_config, mode)
     local preset_keymap = presets.get(mappings.preset)
     -- Remove 'preset' key from opts to prevent it from being treated as a keymap
     mappings.preset = nil
-    mappings = utils.merge_mappings(preset_keymap, mappings)
+    mappings.keys = utils.merge_mappings(preset_keymap, mappings.keys)
   end
 
   -- Remove keys explicitly disabled by user (set to false or no commands)
   for key, commands in pairs(mappings) do
-    if commands == false or #commands == 0 then mappings[key] = nil end
+    if commands == false or #commands == 0 then mappings.keys[key] = nil end
   end
 
-  return mappings --[[@as table<string, blink.cmp.KeymapCommand[]>]]
+  return mappings.keys --[[@as table<string, blink.cmp.KeymapCommand[]>]]
 end
 
 function keymap.setup()


### PR DESCRIPTION
Adopt `blink.lib.config` for keymap validation in all modes.

Introduces `keymap.keys` to hold all key bindings, keeping `preset` as a separate field:

```lua
keymap = {
  preset = 'default',
  keys = {
    ['<C-n>'] = { ... },
    -- ...
  },
}
```

This simplifies the schema and avoids mixed‑type values, which are error‑prone.

**BREAKING CHANGES**: Users must move all custom keys under `keymap.keys`.

---

Need https://github.com/saghen/blink.lib/pull/17 and https://github.com/saghen/blink.lib/pull/18 for meaningful error messages.
