### PR TITLE
fix: handle Rust cdylib non-lib prefix on Windows-MSVC (closes #2513)

### DIFF
--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -112,12 +112,19 @@ function cmp.build(opts)
       if repo_root == nil then error('Missing git repo root, did you install via a package manager?') end
 
       return lib.native.exec_async(repo_root, { 'cargo', 'build', '--release' }, logger):map(function(_system)
-        -- Rust cdylib output naming: every platform produces `lib<name><ext>`
-        -- *except* Windows-MSVC which produces `<name>.dll` with no prefix.
-        -- See https://doc.rust-lang.org/reference/linkage.html
-        local cargo_lib_prefix = platform.os == 'windows' and '' or 'lib'
+        -- Rust cdylib on Windows-MSVC produces `<name>.dll` (no `lib` prefix);
+        -- other targets produce `lib<name><ext>`. Try both, move whichever cargo produced.
+        local src
+        for _, name in ipairs({ 'libblink_cmp_fuzzy', 'blink_cmp_fuzzy' }) do
+          local candidate = repo_root .. '/target/release/' .. name .. platform.lib_extension
+          if vim.uv.fs_stat(candidate) then
+            src = candidate
+            break
+          end
+        end
+        if not src then error('Built cdylib not found in target/release/') end
         lib.native.mv(
-          repo_root .. '/target/release/' .. cargo_lib_prefix .. 'blink_cmp_fuzzy' .. platform.lib_extension,
+          src,
           lib.native.library_path(
             'blink_cmp_fuzzy',
               -- store without hash for dev builds

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -112,9 +112,12 @@ function cmp.build(opts)
       if repo_root == nil then error('Missing git repo root, did you install via a package manager?') end
 
       return lib.native.exec_async(repo_root, { 'cargo', 'build', '--release' }, logger):map(function(_system)
-        -- TODO: move non-lib prefix for windows msvc
+        -- Rust cdylib output naming: every platform produces `lib<name><ext>`
+        -- *except* Windows-MSVC which produces `<name>.dll` with no prefix.
+        -- See https://doc.rust-lang.org/reference/linkage.html
+        local cargo_lib_prefix = platform.os == 'windows' and '' or 'lib'
         lib.native.mv(
-          repo_root .. '/target/release/libblink_cmp_fuzzy' .. platform.lib_extension,
+          repo_root .. '/target/release/' .. cargo_lib_prefix .. 'blink_cmp_fuzzy' .. platform.lib_extension,
           lib.native.library_path(
             'blink_cmp_fuzzy',
               -- store without hash for dev builds


### PR DESCRIPTION
### What

`cmp.build()` hardcoded the cdylib source path as `target/release/libblink_cmp_fuzzy<ext>`. Rust cdylib on Windows-MSVC produces `<name>.dll` (no `lib` prefix), so the `mv` fails with ENOENT and the build never produces a loadable library. This is consistent with `.github/workflows/release.yaml`, which references the prefix-less filename for both Windows-MSVC target triples.

### Fix

Try both `lib<name>` and `<name>`, move whichever cargo produced. Per review feedback, this handles either name showing up on Windows rather than assuming.

### Verified

On this Windows-MSVC machine with Rust toolchain installed:

```
$ ls target/release/ | grep ^blink_cmp_fuzzy
blink_cmp_fuzzy.d
blink_cmp_fuzzy.dll        <- what cargo produces
blink_cmp_fuzzy.dll.exp
blink_cmp_fuzzy.dll.lib
blink_cmp_fuzzy.pdb

$ test -f target/release/libblink_cmp_fuzzy.dll && echo HIT || echo MISS
MISS                       <- pre-fix: ENOENT in #2513

$ test -f target/release/blink_cmp_fuzzy.dll && echo HIT || echo MISS
HIT                        <- post-fix: found via fallback
```

Lua syntax checked via `nvim --headless -c "lua loadfile(...)"`. End-to-end `cmp.build()` through a real plugin manager not run on this machine — the path math is verified against actual cargo output above.

Closes #2513