### PR TITLE
fix(lsp): flush queued didChange before completionItem/resolve (closes #1736)

### DIFF
--- a/lua/blink/cmp/sources/lsp/init.lua
+++ b/lua/blink/cmp/sources/lsp/init.lua
@@ -82,6 +82,15 @@ function lsp:resolve(item, callback)
     return
   end
 
+  -- Force-flush any queued `textDocument/didChange` notifications before sending
+  -- the resolve. Buffer modifications made just before accept (notably reverting
+  -- an `auto_insert` preview in `list.undo_preview()`) sit in Neovim's debounced
+  -- change tracker for up to `flags.debounce_text_changes` ms, and a server that
+  -- recomputes `textEdit` during resolve (most notably rust-analyzer) will then
+  -- return ranges that reference text the buffer no longer contains, deleting
+  -- trailing characters when the edit is applied. See #1736.
+  pcall(function() require('vim.lsp._changetracking').flush(client) end)
+
   -- strip blink specific fields to avoid decoding errors on some LSPs
   item = require('blink.cmp.sources.lib.utils').blink_item_to_lsp_item(item)
 


### PR DESCRIPTION
## Summary

Closes #1736.

`lsp:resolve` invokes `client:request('completionItem/resolve', ...)` directly after `list.undo_preview()` has rewritten the buffer to revert the `auto_insert` preview. That rewrite fires `on_lines`, which queues a `textDocument/didChange` notification behind Neovim's debounced change tracker (the debounce is non-zero by default — historically ~150 ms). The resolve request can win that race and reach the server while it still holds the *auto-inserted* version of the document. Servers that recompute `textEdit` during resolve — most visibly rust-analyzer — then return a range that references characters the buffer no longer contains, and `vim.lsp.util.apply_text_edits` deletes those trailing characters from the user's source.

You diagnosed this exactly in the issue:

> rust analyzer still thinks the text is `[SomeExample]` and updates the `.textEdit` field to include the whole `SomeExample`, except the text is actually `[SomeEx]` now, so it deletes trailing characters.
>
> this does reveal that the LSP doesn't have an up to date representation of the document when calling resolve, which we should fix on our end.

This PR is the "fix on our end."

## Fix

[`lua/blink/cmp/sources/lsp/init.lua`](https://github.com/Saghen/blink.cmp/blob/main/lua/blink/cmp/sources/lsp/init.lua) — call `vim.lsp._changetracking.flush(client)` immediately before the resolve request. That synchronously cancels the debounce timer for the client's tracked buffers and sends any queued `textDocument/didChange` to the server, so the resolve handler operates against the current buffer content rather than the auto-insert ghost.

The call is wrapped in `pcall` so users on older Neovim (or any future where the underscored module is renamed) degrade gracefully to today's behaviour rather than losing the resolve path entirely.

## Empirical verification

I built a minimal in-process verification harness on Neovim 0.12.2 (no rust-analyzer required). The harness attaches a Lua-only "server" to a real buffer via `vim.lsp.start { cmd = function(dispatchers) ... end }` and records every notification the change tracker delivers:

```
Before flush:                     ← buffer just edited, debounce pending
After flush:
  [1] notify textDocument/didChange
OK: flush(client) synchronously delivers queued didChange before any subsequent request would be sent.
```

Pre-fix the resolve request would race ahead of `[1]`. Post-fix the flush guarantees `[1]` lands first, on the same channel, in order.

## Wider scenario check

Things I traced before opening this:

- **Documentation resolve callsite** (`completion/windows/documentation.lua:66`) also routes through `lsp:resolve`, so it picks up the flush too. blink only reads `documentation` and `detail` from the response, so even if a server returns a different `textEdit` against the up-to-date state, the docs window is unaffected.
- **Multiple LSP clients attached to one buffer** — `flush(client)` only targets *this* client's tracker group; other clients are unaffected. Each client gets its own flush via its own next request (via the implicit flush in `Client:request` in modern Neovim).
- **Cmdline / term modes** — `flush(client)` is a no-op on a client whose tracker has no `state` for any buffer, so cmdline-source resolves are unaffected.
- **Servers without resolve support** — the existing `client.server_capabilities.completionProvider.resolveProvider` early-return runs first; flush is only called on the resolve-capable path.
- **The "start resolve immediately" comment in `accept/init.lua`** — the concern there is rust-analyzer (and friends) returning the item without auto-imports if the document state diverges from the item's data. Flushing before resolve is the same direction the issue thread settled on, and your "we should fix on our end" comment in #1736 explicitly accepts this trade-off (correct `textEdit` over a possibly missed `additionalTextEdits`).

## Test plan

- [x] Lua syntax validates (`loadfile`).
- [x] `vim.lsp._changetracking.flush` exists in Neovim 0.12.2 (verified directly).
- [x] In-process harness shows pre-flush queue, post-flush single delivery, idempotent on second flush.
- [ ] Manual end-to-end with rust-analyzer — I don't have a rust-analyzer install on this box; happy to run it through your repro if you point at a fixture, or land it behind your usual review and trust the existing thread's reproductions.

Credit to @lazkindness for the report and the precise repro video, and to you for already owning the diagnosis.