### PR TITLE
fix(signature): disable dy default

### DIFF
--- a/lua/blink/cmp/config/signature.lua
+++ b/lua/blink/cmp/config/signature.lua
@@ -28,7 +28,7 @@
 
 local config = require('blink.lib.config')
 return {
-  enabled = { true, 'boolean' },
+  enabled = { false, 'boolean' },
   -- TODO: rename as per completion.trigger
   trigger = {
     enabled = { true, 'boolean' },


### PR DESCRIPTION
[The docs say that the feature is disabled by default](https://main.cmp.saghen.dev/configuration/reference.html#signature), but the code currently enables it. Since the feature is still deemed experimental, I believe we should keep it opt-in.