### PR TITLE
fix(cmdline): match forward-slash PATH entries in Windows shellcmd filter

### DIFF
--- a/lua/blink/cmp/sources/cmdline/utils.lua
+++ b/lua/blink/cmp/sources/cmdline/utils.lua
@@ -150,7 +150,7 @@ function utils.get_completions(pattern, type, completion_type)
     if vim.fn.has('win32') == 1 then
       separator = ';'
       -- Remove System32 folder on native Windows
-      filter_fn = function(part) return not part:lower():match('^[a-z]:\\windows\\system32$') end
+      filter_fn = function(part) return not part:lower():match('^[a-z]:[/\\]windows[/\\]system32[/\\]?$') end
     elseif vim.fn.has('wsl') == 1 then
       separator = ':'
       -- Remove all Windows filesystem mounts on WSL


### PR DESCRIPTION
The Win32 mitigation introduced in #1933 only matches `System32` entries written with backslashes (`c:\windows\system32`). On Windows, `PATH` entries are frequently written with forward slashes — set by installers, user edits, or MSYS-style tooling — in which case the filter silently fails and the original `:!` hang reappears.

Example failing entry: `C:/WINDOWS/system32`. After `:lower()` it becomes `c:/windows/system32`, which the current pattern `^[a-z]:\\windows\\system32$` does not match, so the directory is left in `PATH` during completion.