### PR TITLE
ci: add loongarch64 build on linux

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,9 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact_name: target/aarch64-unknown-linux-gnu/release/libblink_cmp_fuzzy.so
+          - os: ubuntu-latest
+            target: loongarch64-unknown-linux-gnu
+            artifact_name: target/loongarch64-unknown-linux-gnu/release/libblink_cmp_fuzzy.so
           # Musl 1.2.3
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
@@ -29,6 +32,9 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             artifact_name: target/aarch64-unknown-linux-musl/release/libblink_cmp_fuzzy.so
+          - os: ubuntu-latest
+            target: loongarch64-unknown-linux-musl
+            artifact_name: target/loongarch64-unknown-linux-musl/release/libblink_cmp_fuzzy.so
           # Android (Termux)
           - os: ubuntu-latest
             target: aarch64-linux-android


### PR DESCRIPTION
While using LazyVim (Neovim) on the LoongArch architecture, I discovered that Mason is unable to install `blink.cmp`. Although I can manually build it myself for use, this is quite inconvenient; I would prefer for `blink.cmp` to be officially released with direct support for the LoongArch architecture.

I have modified the CI configuration and tested the changes in my own repository. I hope you will accept this Pull Request—thank you very much!
GH Actions Test:https://github.com/yetist/blink.cmp/actions/runs/26551787167
Release Test:https://github.com/yetist/blink.cmp/releases/tag/v1.10.3