### PR TITLE
fix: install keymaps for mini.ai visual-to-insert transition

### DIFF
--- a/lua/blink/cmp/keymap/init.lua
+++ b/lua/blink/cmp/keymap/init.lua
@@ -122,7 +122,7 @@ function keymap.setup()
   -- Ensure blink.cmp keymaps are (still) applied
   nvim.create_autocmd('ModeChanged', {
     group = nvim.create_augroup('BlinkCmpKeymap', { clear = true }),
-    pattern = { 'n:i', 'n:c', 'n:t', 'no:i', 'v:s', 'nt:c' },
+    pattern = { 'n:i', 'n:c', 'n:t', 'no:i', 'v:s', 'v:i', 'nt:c' },
     callback = vim.schedule_wrap(keymap.ensure_mappings),
   })
 


### PR DESCRIPTION
  ## Problem

  When using `mini.ai`, running `ci"` inside a string can enter insert mode
  through a `v:i` `ModeChanged` transition instead of the native `no:i`
  transition.

  On a fresh buffer, blink.cmp installs buffer-local keymaps lazily on selected
  `ModeChanged` transitions. Since `v:i` was not included, the first insert-mode
  `<C-Space>` after `ci"` was not mapped yet, so manual completion did not
  trigger.

  ## Fix

  Include `v:i` in the keymap setup `ModeChanged` patterns and call
  `keymap.ensure_mappings` immediately.

  ## Verification

  Observed `mini.ai` `ci"` mode transitions with a `ModeChanged` autocmd:

  ```text
  n:no
  no:n
  n:v
  v:i

  After this change, blink.cmp installs the insert-mode buffer-local mappings
  during the v:i transition, so <C-Space> works immediately in the first
  insert session.
