### PR TITLE
fix(menu): alignment with tabs & virtualedit

### DIFF
--- a/lua/blink/cmp/completion/windows/menu/init.lua
+++ b/lua/blink/cmp/completion/windows/menu/init.lua
@@ -241,11 +241,27 @@ function menu.update_position()
     local cursor_row, cursor_col = unpack(context.get_cursor())
 
     -- use virtcol to avoid misalignment on multibyte characters
-    local virt_cursor_col = vim.fn.virtcol({ cursor_row, cursor_col })
-    local col = vim.fn.virtcol({ cursor_row, context.bounds.start_col - 1 })
-      - alignment_start_col
-      - virt_cursor_col
-      - border_size.left
+    local virt_col_offset = 0
+
+    -- false iff virtualedit is enabled & cursor is in virtual space. Completion can only be triggered
+    -- via show() in this situation (insertion leaves virtual space), and the cursor must either be in
+    -- a tab or beyond the end of line. So it is safe to leave the offset at zero.
+    if vim.fn.getcurpos()[4] == 0 then
+      -- virtualedit changes the behavior of vim.fn.virtcol in a way that makes it impossible to
+      -- return the *last* virtual column of a tab character. Rather than implementing an elaborate
+      -- alternative handler via vim.fn.strdisplaywidth et al., it is easier to temporarily
+      -- disable virtualedit.
+      local old_ve = vim.wo.virtualedit
+      vim.wo.virtualedit = 'none'
+
+      local virt_cursor_col = vim.fn.virtcol({ cursor_row, cursor_col })
+      local virt_start_col = vim.fn.virtcol({ cursor_row, context.bounds.start_col - 1 })
+      virt_col_offset = virt_start_col - virt_cursor_col
+
+      vim.wo.virtualedit = old_ve
+    end
+
+    local col = virt_col_offset - alignment_start_col - border_size.left
 
     if config.draw.align_to == 'cursor' then col = 0 end
 


### PR DESCRIPTION
Fixes #2558

Temporarily disabling `vim.wo.virtualedit` feels a little bit hacky to me. I'm not sure whether this is an acceptable approach or not -- I'm relatively new to nvim plugin programming.

That said, I tried several alternative approaches that were all significantly more complex and brittle when combined with multi-width non-tab characters. This approach here is the only one I could come up with that would reliably work in all situations, including manually triggered completion in virtual regions.