### PR TITLE
feat: don't panic when not running in a git repo

### DIFF
--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -92,10 +92,7 @@ end
 
 -------- Native Library --------
 
-function cmp.get_repo_root()
-  assert(native.repo_root, 'Could not determine project root, is the plugin inside a git repository?')
-  return native.repo_root
-end
+function cmp.get_repo_root() return native.repo_root end
 
 function cmp.library_available() return native:library_available() end
 


### PR DESCRIPTION
everything else handles this gracefully. `blink.lib` checks if `git_repo_root` is empty, `blink.lib.native:resolve` and `blink.lib.native:try_commit_hash` both have fallback for when repo root or commit hash is empty. it's just this assert stopping `blink.cmp` from working.

so i guess this is not a sanity check, but you have some explicit reasons to prohibit `blink.cmp` from being used outside its git repository? why is that?