### PR TITLE
chore: fix type annotation diagnostic warnings

### DIFF
--- a/lua/blink/cmp/completion/accept/init.lua
+++ b/lua/blink/cmp/completion/accept/init.lua
@@ -107,6 +107,7 @@ local function accept(ctx, item, callback)
     :map(function(resolved_item)
       -- Updates the text edit based on the cursor position and converts it to utf-8
       resolved_item = vim.deepcopy(resolved_item)
+      ---@cast resolved_item blink.cmp.CompletionItem
       resolved_item.textEdit = text_edits_lib.get_from_item(resolved_item)
 
       return sources.execute(

--- a/lua/blink/cmp/completion/accept/preview.lua
+++ b/lua/blink/cmp/completion/accept/preview.lua
@@ -1,7 +1,7 @@
 local nvim = require('blink.lib.nvim')
 
 --- @param item blink.cmp.CompletionItem
---- @return { text_edit: lsp.TextEdit, cursor?: integer[] } undo_text_edit, integer[]? undo_cursor_pos The text edit to apply and the original cursor
+--- @return lsp.TextEdit, blink.cmp.CursorPos?
 local function preview(item)
   local text_edits_lib = require('blink.cmp.lib.text_edits')
   local text_edit = text_edits_lib.get_from_item(item)

--- a/lua/blink/cmp/completion/brackets/kind.lua
+++ b/lua/blink/cmp/completion/brackets/kind.lua
@@ -3,16 +3,18 @@ local utils = require('blink.cmp.completion.brackets.utils')
 --- @param ctx blink.cmp.Context
 --- @param filetype string
 --- @param item blink.cmp.CompletionItem
---- @return 'added' | 'check_semantic_token' | 'skipped', lsp.TextEdit | lsp.InsertReplaceEdit, number
+--- @return 'added' | 'check_semantic_token' | 'skipped', lsp.TextEdit | lsp.InsertReplaceEdit, integer
 local function add_brackets(ctx, filetype, item)
   local text_edit = item.textEdit
   assert(text_edit ~= nil, 'Got nil text edit while adding brackets via kind')
-  local brackets_for_filetype = utils.get_for_filetype(filetype, item)
 
   -- skip if we're not in default mode
   if ctx.mode ~= 'default' then return 'skipped', text_edit, 0 end
 
-  -- if there's already the correct brackets in front, skip but indicate the cursor should move in front of the bracket
+  local brackets_for_filetype = utils.get_for_filetype(filetype, item)
+
+  -- if there's already the correct brackets in front, skip but indicate the
+  -- cursor should move in front of the bracket
   -- TODO: what if the brackets_for_filetype[1] == '' or ' ' (haskell/ocaml)?
   -- TODO: should this check semantic tokens and still move the cursor in that case?
   if utils.has_brackets_in_front(text_edit, brackets_for_filetype[1]) then
@@ -21,7 +23,7 @@ local function add_brackets(ctx, filetype, item)
   end
 
   -- if the item already contains the brackets, conservatively skip adding brackets
-  -- todo: won't work for snippets when the brackets_for_filetype is { '{', '}' }
+  -- TODO: won't work for snippets when the brackets_for_filetype is { '{', '}' }
   -- I've never seen a language like that though
   if brackets_for_filetype[1] ~= ' ' and text_edit.newText:match('[\\' .. brackets_for_filetype[1] .. ']') ~= nil then
     return 'skipped', text_edit, 0
@@ -33,6 +35,8 @@ local function add_brackets(ctx, filetype, item)
   if not utils.can_have_brackets(item, brackets_for_filetype) then return 'check_semantic_token', text_edit, 0 end
 
   text_edit = vim.deepcopy(text_edit)
+  ---@cast text_edit lsp.TextEdit|lsp.InsertReplaceEdit
+
   -- For snippets, we add the cursor position between the brackets as the last placeholder
   if item.insertTextFormat == vim.lsp.protocol.InsertTextFormat.Snippet then
     local placeholders = utils.snippets_extract_placeholders(text_edit.newText)

--- a/lua/blink/cmp/completion/brackets/semantic.lua
+++ b/lua/blink/cmp/completion/brackets/semantic.lua
@@ -1,4 +1,3 @@
-local lib = require('blink.lib')
 local nvim = require('blink.lib.nvim')
 local task = require('blink.lib.task')
 local config = require('blink.cmp.config').completion.accept.auto_brackets
@@ -11,7 +10,8 @@ local utils = require('blink.cmp.completion.brackets.utils')
 --- @field callback fun(added: boolean)
 
 local semantic = {
-  timer = lib.timer.new(),
+  --- @type uv.uv_timer_t
+  timer = assert(vim.uv.new_timer(), 'Failed to create timer for semantic token resolution'),
   --- @type blink.cmp.SemanticRequest?
   request = nil,
 }

--- a/lua/blink/cmp/completion/brackets/semantic.lua
+++ b/lua/blink/cmp/completion/brackets/semantic.lua
@@ -98,7 +98,7 @@ function semantic.add_brackets_via_semantic_token(ctx, filetype, item)
     } --[[@as blink.cmp.SemanticRequest]]
 
     -- semantic tokens debounced, so manually request a refresh to avoid latency
-    highlighter:send_request()
+    highlighter:send_request(client.id)
 
     -- first check if a semantic token already exists at the current cursor position
     -- we get the token 1 character before the cursor (`bar|` would check `r`)

--- a/lua/blink/cmp/completion/brackets/semantic.lua
+++ b/lua/blink/cmp/completion/brackets/semantic.lua
@@ -11,6 +11,7 @@ local utils = require('blink.cmp.completion.brackets.utils')
 
 local semantic = {
   --- @type uv.uv_timer_t
+  --- FIXME: Figure out why lib.timer.new() causes a race condition
   timer = assert(vim.uv.new_timer(), 'Failed to create timer for semantic token resolution'),
   --- @type blink.cmp.SemanticRequest?
   request = nil,

--- a/lua/blink/cmp/completion/brackets/semantic.lua
+++ b/lua/blink/cmp/completion/brackets/semantic.lua
@@ -1,18 +1,18 @@
+local lib = require('blink.lib')
 local nvim = require('blink.lib.nvim')
 local task = require('blink.lib.task')
 local config = require('blink.cmp.config').completion.accept.auto_brackets
 local utils = require('blink.cmp.completion.brackets.utils')
 
 --- @class blink.cmp.SemanticRequest
---- @field cursor integer[]
+--- @field cursor blink.cmp.CursorPos
 --- @field item blink.cmp.CompletionItem
 --- @field filetype string
 --- @field callback fun(added: boolean)
 
 local semantic = {
-  --- @type uv_timer_t
-  timer = assert(vim.uv.new_timer(), 'Failed to create timer for semantic token resolution'),
-  --- @type blink.cmp.SemanticRequest | nil
+  timer = lib.timer.new(),
+  --- @type blink.cmp.SemanticRequest?
   request = nil,
 }
 
@@ -22,12 +22,12 @@ nvim.create_autocmd('LspTokenUpdate', {
 
 function semantic.finish_request()
   if semantic.request == nil then return end
+
   semantic.request.callback(true)
   semantic.request = nil
   semantic.timer:stop()
 end
 
---- @param tokens STTokenRange[]
 function semantic.process_request(tokens)
   local request = semantic.request
   if request == nil then return end
@@ -68,16 +68,17 @@ end
 --- @param ctx blink.cmp.Context
 --- @param filetype string
 --- @param item blink.cmp.CompletionItem
---- @return blink.lib.Task
+--- @return blink.lib.Task<boolean>
 function semantic.add_brackets_via_semantic_token(ctx, filetype, item)
   return task.new(function(resolve)
     if not utils.should_run_resolution(ctx, filetype, 'semantic_token') then return resolve(false) end
 
     assert(item.textEdit ~= nil, 'Got nil text edit while adding brackets via semantic tokens')
+    assert(item.client_id ~= nil, 'Got nil client_id while adding brackets via semantic tokens')
     local client = vim.lsp.get_client_by_id(item.client_id)
     if client == nil then return resolve() end
 
-    local capabilities = client.server_capabilities.semanticTokensProvider
+    local capabilities = client.server_capabilities and client.server_capabilities.semanticTokensProvider
     if not capabilities or not capabilities.legend or (not capabilities.range and not capabilities.full) then
       return resolve(false)
     end
@@ -92,7 +93,7 @@ function semantic.add_brackets_via_semantic_token(ctx, filetype, item)
       filetype = filetype,
       item = item,
       callback = resolve,
-    }
+    } --[[@as blink.cmp.SemanticRequest]]
 
     -- semantic tokens debounced, so manually request a refresh to avoid latency
     highlighter:send_request()
@@ -108,7 +109,7 @@ function semantic.add_brackets_via_semantic_token(ctx, filetype, item)
 
     -- listen for LspTokenUpdate events until timeout
     semantic.timer:start(config.semantic_token_resolution.timeout_ms, 0, semantic.finish_request)
-  end)
+  end) --[[@as blink.lib.Task<boolean>]]
 end
 
 return semantic.add_brackets_via_semantic_token

--- a/lua/blink/cmp/completion/brackets/semantic.lua
+++ b/lua/blink/cmp/completion/brackets/semantic.lua
@@ -28,6 +28,7 @@ function semantic.finish_request()
   semantic.timer:stop()
 end
 
+--- @param tokens STTokenRangeInspect[]
 function semantic.process_request(tokens)
   local request = semantic.request
   if request == nil then return end

--- a/lua/blink/cmp/completion/brackets/utils.lua
+++ b/lua/blink/cmp/completion/brackets/utils.lua
@@ -33,6 +33,7 @@ end
 function utils.should_run_resolution(ctx, filetype, resolution_method)
   -- resolution method specific
   if not config[resolution_method .. '_resolution'].enabled then return false end
+  ---@type string[]
   local resolution_blocked_filetypes = config[resolution_method .. '_resolution'].blocked_filetypes
   if vim.tbl_contains(resolution_blocked_filetypes, filetype) then return false end
 
@@ -50,7 +51,7 @@ function utils.should_run_resolution(ctx, filetype, resolution_method)
     and not vim.tbl_contains(brackets.blocked_filetypes, filetype)
 end
 
---- @param text_edit lsp.TextEdit | lsp.InsertReplaceEdit
+--- @param text_edit lsp.TextEdit
 --- @param bracket string
 --- @return boolean
 function utils.has_brackets_in_front(text_edit, bracket)

--- a/lua/blink/cmp/completion/init.lua
+++ b/lua/blink/cmp/completion/init.lua
@@ -82,8 +82,6 @@ function completion.setup()
 
     list.select_emitter:on(function(event)
       menu().set_selected_item_idx(event.idx)
-
-      if not event.item then return end
       require('blink.cmp.completion.windows.documentation').auto_show_item(event.context, event.item)
     end)
   end

--- a/lua/blink/cmp/completion/init.lua
+++ b/lua/blink/cmp/completion/init.lua
@@ -92,7 +92,10 @@ function completion.setup()
   local ghost_text = function() return require('blink.cmp.completion.windows.ghost_text') end
 
   local menu = require('blink.cmp.completion.windows.menu')
-  menu.open_emitter:on(function() ghost_text().show_preview(menu.context, menu.items, menu.selected_item_idx) end)
+  menu.open_emitter:on(function()
+    assert(menu.context, 'A context is required to display the ghost text')
+    ghost_text().show_preview(menu.context, menu.items, menu.selected_item_idx)
+  end)
 
   list.show_emitter:on(function(event) ghost_text().show_preview(event.context, event.items, 1) end)
   list.select_emitter:on(function(event) ghost_text().show_preview(event.context, event.items, event.idx) end)

--- a/lua/blink/cmp/completion/init.lua
+++ b/lua/blink/cmp/completion/init.lua
@@ -82,9 +82,9 @@ function completion.setup()
 
     list.select_emitter:on(function(event)
       menu().set_selected_item_idx(event.idx)
-      local item = event.item or list.items[1]
-      if item == nil then return end
-      require('blink.cmp.completion.windows.documentation').auto_show_item(event.context, item)
+
+      if not event.item then return end
+      require('blink.cmp.completion.windows.documentation').auto_show_item(event.context, event.item)
     end)
   end
 

--- a/lua/blink/cmp/completion/init.lua
+++ b/lua/blink/cmp/completion/init.lua
@@ -1,3 +1,4 @@
+local lib = require('blink.lib')
 local config = require('blink.cmp.config')
 local completion = {}
 
@@ -64,7 +65,7 @@ function completion.setup()
   if config.completion.menu.enabled then
     local menu = function() return require('blink.cmp.completion.windows.menu') end
 
-    local loading_timer = vim.uv.new_timer()
+    local loading_timer = lib.timer.new()
     trigger.show_emitter:on(function(event)
       if event.context.trigger.kind ~= 'manual' then return end
       loading_timer:start(500, 0, vim.schedule_wrap(function() menu().open_loading(event.context) end))
@@ -81,7 +82,9 @@ function completion.setup()
 
     list.select_emitter:on(function(event)
       menu().set_selected_item_idx(event.idx)
-      require('blink.cmp.completion.windows.documentation').auto_show_item(event.context, event.item)
+      local item = event.item or list.items[1]
+      if item == nil then return end
+      require('blink.cmp.completion.windows.documentation').auto_show_item(event.context, item)
     end)
   end
 
@@ -102,7 +105,7 @@ function completion.setup()
     -- when selection.preselect == false, we still want to prefetch the first item
     local item = event.item or list.items[1]
     if item == nil then return end
-    require('blink.cmp.completion.prefetch')(event.context, event.item)
+    require('blink.cmp.completion.prefetch')(event.context, item)
   end)
 end
 

--- a/lua/blink/cmp/completion/list.lua
+++ b/lua/blink/cmp/completion/list.lua
@@ -357,15 +357,20 @@ end
 
 function list.accept(opts)
   opts = opts or {}
-  local idx = opts.index or list.selected_item_idx or 1
-  local item = list.items[idx]
-  if item == nil then return false end
+
+  if not list.context then return false end
+
+  local idx = opts.index or list.selected_item_idx
+  if not idx then return false end
+
+  local item = assert(list.items[idx])
 
   list.undo_preview()
   require('blink.cmp.completion.accept')(list.context, item, function()
     list.accept_emitter:emit({ item = item, context = list.context })
     if opts.callback then opts.callback() end
   end)
+
   return true
 end
 

--- a/lua/blink/cmp/completion/list.lua
+++ b/lua/blink/cmp/completion/list.lua
@@ -164,7 +164,7 @@ end
 
 ---------- Selection ----------
 
-function list.get_selected_item() return list.items[list.selected_item_idx or 1] end
+function list.get_selected_item() return list.selected_item_idx and list.items[list.selected_item_idx] end
 
 function list.get_selection_mode(ctx)
   assert(ctx ~= nil, 'Context must be set before getting selection mode')

--- a/lua/blink/cmp/completion/list.lua
+++ b/lua/blink/cmp/completion/list.lua
@@ -363,7 +363,8 @@ function list.accept(opts)
   local idx = opts.index or list.selected_item_idx
   if not idx then return false end
 
-  local item = assert(list.items[idx])
+  local item = list.items[idx]
+  if not item then return false end
 
   list.undo_preview()
   require('blink.cmp.completion.accept')(list.context, item, function()

--- a/lua/blink/cmp/completion/list.lua
+++ b/lua/blink/cmp/completion/list.lua
@@ -8,8 +8,9 @@
 ---
 --- @field context? blink.cmp.Context
 --- @field items blink.cmp.CompletionItem[]
---- @field selected_item_idx? number
---- @field preview_undo? { text_edit: lsp.TextEdit, cursor_before?: integer[], cursor_after: integer[] }
+--- @field selected_item_idx? integer
+--- @field is_explicitly_selected boolean
+--- @field preview_undo? { text_edit: lsp.TextEdit, cursor_before?: blink.cmp.CursorPos, cursor_after: blink.cmp.CursorPos }
 ---
 --- @field show fun(context: blink.cmp.Context, items: table<string, blink.cmp.CompletionItem[]>)
 --- @field fuzzy fun(context: blink.cmp.Context, items: table<string, blink.cmp.CompletionItem[]>): blink.cmp.CompletionItem[]
@@ -17,19 +18,19 @@
 ---
 --- @field get_selected_item fun(): blink.cmp.CompletionItem?
 --- @field get_selection_mode fun(context: blink.cmp.Context): { preselect: boolean, auto_insert: boolean }
---- @field get_item_idx_in_list fun(item?: blink.cmp.CompletionItem): number?
---- @field select fun(idx?: number, opts?: { auto_insert?: boolean, is_explicit_selection?: boolean }): boolean
+--- @field get_item_idx_in_list fun(item?: blink.cmp.CompletionItem): integer?
+--- @field select fun(idx?: integer, opts?: { auto_insert?: boolean, is_explicit_selection?: boolean }): boolean
 --- @field select_next fun(opts?: blink.cmp.CompletionListSelectOpts): boolean
 --- @field select_prev fun(opts?: blink.cmp.CompletionListSelectOpts): boolean
 --- @field can_select fun(opts?: blink.cmp.CompletionListSelectOpts): boolean
---- @field jump_by fun(dir: number, opts?: blink.cmp.CompletionListSelectOpts): boolean
+--- @field jump_by fun(dir: integer, opts?: blink.cmp.CompletionListSelectOpts): boolean
 ---
 --- @field undo_preview fun()
 --- @field apply_preview fun(item: blink.cmp.CompletionItem)
 --- @field accept fun(opts?: blink.cmp.CompletionListAcceptOpts): boolean Applies the currently selected item, returning true if it succeeded
 
 --- @class blink.cmp.CompletionListSelectOpts
---- @field count? number The number of items to jump by, defaults to 1
+--- @field count? integer The number of items to jump by, defaults to 1
 --- @field jump_by? blink.cmp.CompletionListJumpBy Jump to the item whose specified property differs from the current one.
 --- @field auto_insert? boolean Insert the completion item automatically when selecting it
 --- @field on_ghost_text? boolean Run when ghost text is visible, instead of only when the menu is visible
@@ -50,7 +51,7 @@
 --- @field force? boolean Force accept without visual feedback (no menu, no ghost text visible)
 
 --- @class blink.cmp.CompletionListAcceptOpts : blink.cmp.CompletionListSelectAndAcceptOpts
---- @field index? number The index of the item to accept, if not provided, the currently selected item will be accepted
+--- @field index? integer The index of the item to accept, if not provided, the currently selected item will be accepted
 
 --- @class blink.cmp.CompletionListShowEvent
 --- @field items blink.cmp.CompletionItem[]
@@ -60,7 +61,7 @@
 --- @field context blink.cmp.Context
 
 --- @class blink.cmp.CompletionListSelectEvent
---- @field idx? number
+--- @field idx? integer
 --- @field item? blink.cmp.CompletionItem
 --- @field items blink.cmp.CompletionItem[]
 --- @field context blink.cmp.Context
@@ -88,9 +89,9 @@ local list = {
 
 ---------- State ----------
 
-function list.show(context, items_by_source)
+function list.show(ctx, items_by_source)
   -- reset state for new context
-  local is_new_context = not list.context or list.context.id ~= context.id
+  local is_new_context = not list.context or list.context.id ~= ctx.id
   if is_new_context then
     list.preview_undo = nil
     list.is_explicitly_selected = false
@@ -98,8 +99,8 @@ function list.show(context, items_by_source)
 
   -- if the keyword changed, the list is no longer explicitly selected
   local bounds_equal = list.context ~= nil
-    and list.context.bounds.start_col == context.bounds.start_col
-    and list.context.bounds.length == context.bounds.length
+    and list.context.bounds.start_col == ctx.bounds.start_col
+    and list.context.bounds.length == ctx.bounds.length
   if not bounds_equal then list.is_explicitly_selected = false end
 
   local previous_selected_item = list.get_selected_item()
@@ -109,13 +110,13 @@ function list.show(context, items_by_source)
   list.undo_preview()
 
   -- update the context/list and emit
-  list.context = context
-  list.items = list.fuzzy(context, items_by_source)
+  list.context = ctx
+  list.items = list.fuzzy(ctx, items_by_source)
 
   if #list.items == 0 then
-    list.hide_emitter:emit({ context = context })
+    list.hide_emitter:emit({ context = ctx })
   else
-    list.show_emitter:emit({ items = list.items, context = context })
+    list.show_emitter:emit({ items = list.items, context = ctx })
   end
 
   -- context may have changed during emitters (like hide), so skip selection logic for gone context
@@ -126,54 +127,54 @@ function list.show(context, items_by_source)
   if list.is_explicitly_selected and previous_item_idx ~= nil and previous_item_idx <= 10 then
     list.select(previous_item_idx)
   -- respect the context's initial selected item idx
-  elseif context.initial_selected_item_idx ~= nil then
-    list.select(context.initial_selected_item_idx, { is_explicit_selection = true })
+  elseif ctx.initial_selected_item_idx ~= nil then
+    list.select(ctx.initial_selected_item_idx, { is_explicit_selection = true })
   -- otherwise, use the default selection
   else
     list.select(
-      list.get_selection_mode(context).preselect and 1 or nil,
+      list.get_selection_mode(ctx).preselect and 1 or nil,
       { auto_insert = false, is_explicit_selection = false }
     )
   end
 end
 
-function list.fuzzy(context, items_by_source)
+function list.fuzzy(ctx, items_by_source)
   local fuzzy = require('blink.cmp.fuzzy')
   local filtered_items = fuzzy.fuzzy(
-    context.get_line(),
-    context.get_cursor()[2],
+    ctx.get_line(),
+    ctx.get_cursor()[2],
     items_by_source,
     require('blink.cmp.config').completion.keyword.range
   )
 
   -- apply the per source max_items
-  filtered_items = require('blink.cmp.sources.lib').apply_max_items_for_completions(context, filtered_items)
+  filtered_items = require('blink.cmp.sources.lib').apply_max_items_for_completions(ctx, filtered_items)
 
   -- apply the global max_items
   return lib.list.slice(filtered_items, 1, list.config.max_items)
 end
 
 function list.hide()
-  local context = list.context
+  local ctx = list.context
   list.context = nil
   list.items = {}
   list.selected_item_idx = nil
-  list.hide_emitter:emit({ context = context })
+  list.hide_emitter:emit({ context = ctx })
 end
 
 ---------- Selection ----------
 
-function list.get_selected_item() return list.items[list.selected_item_idx] end
+function list.get_selected_item() return list.items[list.selected_item_idx or 1] end
 
-function list.get_selection_mode(context)
-  assert(context ~= nil, 'Context must be set before getting selection mode')
+function list.get_selection_mode(ctx)
+  assert(ctx ~= nil, 'Context must be set before getting selection mode')
 
   local preselect = list.config.selection.preselect
-  if type(preselect) == 'function' then preselect = preselect(context) end
+  if type(preselect) == 'function' then preselect = preselect(ctx) end
   --- @cast preselect boolean
 
   local auto_insert = list.config.selection.auto_insert
-  if type(auto_insert) == 'function' then auto_insert = auto_insert(context) end
+  if type(auto_insert) == 'function' then auto_insert = auto_insert(ctx) end
   --- @cast auto_insert boolean
 
   return { preselect = preselect, auto_insert = auto_insert }
@@ -181,6 +182,7 @@ end
 
 function list.get_item_idx_in_list(item)
   if item == nil then return end
+
   return lib.list.find_idx(list.items, function(i) return i.label == item.label and item.source_id == i.source_id end)
 end
 
@@ -198,7 +200,6 @@ function list.select(idx, opts)
     if auto_insert and item ~= nil then list.apply_preview(item) end
   end)
 
-  --- @diagnostic disable-next-line: assign-type-mismatch
   list.is_explicitly_selected = opts.is_explicit_selection == nil and true or opts.is_explicit_selection
   list.selected_item_idx = idx
   list.select_emitter:emit({ idx = idx, item = item, items = list.items, context = list.context })
@@ -356,7 +357,8 @@ end
 
 function list.accept(opts)
   opts = opts or {}
-  local item = list.items[opts.index or list.selected_item_idx]
+  local idx = opts.index or list.selected_item_idx or 1
+  local item = list.items[idx]
   if item == nil then return false end
 
   list.undo_preview()

--- a/lua/blink/cmp/completion/prefetch.lua
+++ b/lua/blink/cmp/completion/prefetch.lua
@@ -5,7 +5,7 @@ local lib = require('blink.lib')
 
 --- @type integer?
 local last_context_id = nil
---- @type blink.lib.Task<T>?
+--- @type blink.lib.Task<blink.cmp.CompletionItem>?
 local last_request = nil
 local timer = lib.timer.new()
 

--- a/lua/blink/cmp/completion/prefetch.lua
+++ b/lua/blink/cmp/completion/prefetch.lua
@@ -1,9 +1,13 @@
 -- Run `resolve` on the item ahead of time to avoid delays
 -- when accepting the item or showing documentation
 
+local lib = require('blink.lib')
+
+--- @type integer?
 local last_context_id = nil
+--- @type blink.lib.Task<T>?
 local last_request = nil
-local timer = vim.uv.new_timer()
+local timer = lib.timer.new()
 
 --- @param context blink.cmp.Context
 --- @param item blink.cmp.CompletionItem

--- a/lua/blink/cmp/completion/trigger/context.lua
+++ b/lua/blink/cmp/completion/trigger/context.lua
@@ -4,31 +4,31 @@ local nvim = require('blink.lib.nvim')
 
 --- @class blink.cmp.ContextBounds
 --- @field line string
---- @field line_number number
---- @field start_col number
---- @field length number
+--- @field line_number integer
+--- @field start_col integer
+--- @field length integer
 
 --- @class blink.cmp.Context
 --- @field mode blink.cmp.Mode
---- @field id number
---- @field bufnr number
---- @field cursor number[]
+--- @field id integer
+--- @field bufnr integer
+--- @field cursor blink.cmp.CursorPos
 --- @field line string
 --- @field term blink.cmp.ContextTerm
 --- @field bounds blink.cmp.ContextBounds
 --- @field trigger blink.cmp.ContextTrigger
 --- @field providers string[]
---- @field initial_selected_item_idx? number
---- @field timestamp number
+--- @field initial_selected_item_idx? integer
+--- @field timestamp integer
 ---
 --- @field new fun(opts: blink.cmp.ContextOpts): blink.cmp.Context
 --- @field get_keyword fun(): string
---- @field within_query_bounds fun(self: blink.cmp.Context, cursor: number[], include_start_bound?: boolean): boolean
+--- @field within_query_bounds fun(self: blink.cmp.Context, cursor: blink.cmp.CursorPos, include_start_bound?: boolean): boolean
 ---
 --- @field get_mode fun(): blink.cmp.Mode
---- @field get_cursor fun(): number[]
---- @field set_cursor fun(cursor: number[])
---- @field get_line fun(num?: number): string
+--- @field get_cursor fun(): blink.cmp.CursorPos
+--- @field set_cursor fun(cursor: blink.cmp.CursorPos)
+--- @field get_line fun(num?: integer): string
 --- @field get_bounds fun(range: blink.cmp.CompletionKeywordRange): blink.cmp.ContextBounds
 --- @field get_term_command fun(): blink.cmp.ContextTermCommand?
 
@@ -44,16 +44,16 @@ local nvim = require('blink.lib.nvim')
 --- @class blink.cmp.ContextTermCommand
 --- @field found_escape_code boolean Whether the FTCS_COMMAND_START escape sequence was found when querying for the command on the current line. This will always be false when the cursor isn't in a prompt, such as when a command is running.
 --- @field text string The command in the current line, without the shell prompt if found_escape_code = true, up to the cursor. Note that for multiline commands, it will always provide you with the content of the last line. This is because there is no way to distinguish the starting point of a single line command from a multiline one using terminal escape sequences
---- @field start_col number 0-indexed column of the command in the current line, or 0 if the terminal or shell does not support the FTCS_COMMAND_START escape sequence
+--- @field start_col integer 0-indexed column of the command in the current line, or 0 if the terminal or shell does not support the FTCS_COMMAND_START escape sequence
 
 --- @class blink.cmp.ContextOpts
---- @field id number
+--- @field id integer
 --- @field providers string[]
 --- @field initial_trigger_kind blink.cmp.CompletionTriggerKind
 --- @field initial_trigger_character? string
 --- @field trigger_kind blink.cmp.CompletionTriggerKind
 --- @field trigger_character? string
---- @field initial_selected_item_idx? number
+--- @field initial_selected_item_idx? integer
 
 --- @type blink.cmp.Context
 --- @diagnostic disable-next-line: missing-fields
@@ -89,10 +89,8 @@ function context.get_keyword()
   return string.sub(context.get_line(), range.start_col, range.start_col + range.length - 1)
 end
 
---- @param cursor number[]
---- Whether to include the start boundary as inside of the query
---- E.g. start_col = 1 (one indexed), cursor[2] = 0 (zero indexed) would be considered within the query bounds with this flag enabled.
---- @param include_start_bound? boolean
+--- @param cursor blink.cmp.CursorPos
+--- @param include_start_bound? boolean Whether to include the start boundary as inside of the query. E.g. start_col = 1 (one indexed), cursor[2] = 0 (zero indexed) would be considered within the query bounds with this flag enabled.
 --- @return boolean
 function context:within_query_bounds(cursor, include_start_bound)
   local row, col = cursor[1], cursor[2]
@@ -125,7 +123,10 @@ end
 
 function context.set_cursor(cursor)
   local mode = context.get_mode()
-  if vim.tbl_contains({ 'default', 'term', 'cmdwin' }, mode) then return nvim.win_set_cursor(0, cursor) end
+  if vim.tbl_contains({ 'default', 'term', 'cmdwin' }, mode) then
+    nvim.win_set_cursor(0, cursor)
+    return
+  end
 
   assert(mode == 'cmdline', 'Unsupported mode for setting cursor: ' .. mode)
   assert(cursor[1] == 1, 'Cursor must be on the first line in cmdline mode')
@@ -143,7 +144,7 @@ function context.get_line(num)
 
   -- This method works for normal buffers and the terminal prompt
   if num == nil then num = context.get_cursor()[1] - 1 end
-  return nvim.buf_get_lines(0, num, num + 1, false)[1]
+  return nvim.buf_get_lines(0, num, num + 1, false)[1] or ''
 end
 
 --- Gets characters around the cursor and returns the range, 0-indexed
@@ -191,6 +192,7 @@ function context.get_term_command()
 
   local command_start_mark = extmarks[1]
   local command_start_col = command_start_mark[3] + 1
+
   return {
     found_escape_code = true,
     text = string.sub(line, command_start_col, string.len(line)),

--- a/lua/blink/cmp/completion/trigger/init.lua
+++ b/lua/blink/cmp/completion/trigger/init.lua
@@ -19,8 +19,6 @@
 --- @field show_if_on_trigger_character fun(opts?: { is_accept?: boolean })
 --- @field show fun(opts?: blink.cmp.CompletionTriggerShowOptions): blink.cmp.Context?
 --- @field hide fun()
---- @field within_query_bounds fun(cursor: blink.cmp.CursorPos): boolean
---- @field get_bounds fun(regex: vim.regex, line: string, cursor: blink.cmp.CursorPos): blink.cmp.ContextBounds
 
 --- @class blink.cmp.CompletionTriggerShowOptions
 --- @field trigger_kind blink.cmp.CompletionTriggerKind

--- a/lua/blink/cmp/completion/trigger/init.lua
+++ b/lua/blink/cmp/completion/trigger/init.lua
@@ -7,7 +7,7 @@
 --- @field buffer_events blink.cmp.BufferEvents
 --- @field cmdline_events blink.cmp.CmdlineEvents
 --- @field term_events blink.cmp.TermEvents
---- @field current_context_id number
+--- @field current_context_id integer
 --- @field context? blink.cmp.Context
 --- @field show_emitter blink.cmp.EventEmitter<{ context: blink.cmp.Context }>
 --- @field hide_emitter blink.cmp.EventEmitter<{}>
@@ -19,8 +19,8 @@
 --- @field show_if_on_trigger_character fun(opts?: { is_accept?: boolean })
 --- @field show fun(opts?: blink.cmp.CompletionTriggerShowOptions): blink.cmp.Context?
 --- @field hide fun()
---- @field within_query_bounds fun(cursor: number[]): boolean
---- @field get_bounds fun(regex: vim.regex, line: string, cursor: number[]): blink.cmp.ContextBounds
+--- @field within_query_bounds fun(cursor: blink.cmp.CursorPos): boolean
+--- @field get_bounds fun(regex: vim.regex, line: string, cursor: blink.cmp.CursorPos): blink.cmp.ContextBounds
 
 --- @class blink.cmp.CompletionTriggerShowOptions
 --- @field trigger_kind blink.cmp.CompletionTriggerKind
@@ -28,7 +28,7 @@
 --- @field force? boolean
 --- @field send_upstream? boolean
 --- @field providers? string[]
---- @field initial_selected_item_idx? number
+--- @field initial_selected_item_idx? integer
 
 local root_config = require('blink.cmp.config')
 local config = root_config.completion.trigger
@@ -182,10 +182,7 @@ function trigger.activate()
   end
 end
 
-function trigger.resubscribe()
-  ---@diagnostic disable-next-line: missing-fields
-  trigger.buffer_events:resubscribe({ on_char_added = on_char_added })
-end
+function trigger.resubscribe() trigger.buffer_events:resubscribe({ on_char_added = on_char_added }) end
 
 function trigger.is_trigger_character(char, is_show_on_x)
   local sources = require('blink.cmp.sources.lib')
@@ -242,7 +239,7 @@ end
 function trigger.show(opts)
   if vim.fn.pumvisible() == 1 or not require('blink.cmp').is_enabled() then return trigger.hide() end
 
-  opts = opts or {}
+  opts = opts or {} --[[@as blink.cmp.CompletionTriggerShowOptions]]
 
   -- already triggered at this position, ignore
   local mode = context.get_mode()

--- a/lua/blink/cmp/completion/windows/documentation.lua
+++ b/lua/blink/cmp/completion/windows/documentation.lua
@@ -1,16 +1,17 @@
 --- @class blink.cmp.CompletionDocumentationWindow
 --- @field win blink.cmp.Window
---- @field last_context_id? number
---- @field auto_show_timer uv.uv_timer_t?
+--- @field last_context_id? integer
+--- @field auto_show_timer uv.uv_timer_t
 --- @field shown_item? blink.cmp.CompletionItem
 ---
 --- @field auto_show_item fun(context: blink.cmp.Context, item: blink.cmp.CompletionItem)
 --- @field show_item fun(context: blink.cmp.Context, item: blink.cmp.CompletionItem)
 --- @field update_position fun()
---- @field scroll_up fun(amount: number): boolean
---- @field scroll_down fun(amount: number): boolean
+--- @field scroll_up fun(amount: integer): boolean
+--- @field scroll_down fun(amount: integer): boolean
 --- @field close fun()
 
+local lib = require('blink.lib')
 local nvim = require('blink.lib.nvim')
 local config = require('blink.cmp.config').completion.documentation
 local win_config = config.window
@@ -37,7 +38,7 @@ local docs = {
     scrolloff = 0,
   }),
   last_context_id = nil,
-  auto_show_timer = vim.uv.new_timer(),
+  auto_show_timer = lib.timer.new(),
 }
 
 menu.position_update_emitter:on(function() docs.update_position() end)
@@ -64,45 +65,46 @@ function docs.show_item(context, item)
   -- TODO: only resolve if documentation does not exist
   sources
     .resolve(context, item)
-    ---@param item blink.cmp.CompletionItem
-    :map(function(item)
-      local valid_documentation = type(item.documentation) == 'table' or type(item.documentation) == 'string'
-      local valid_detail = type(item.detail) == 'string'
+    :map(function(resolved_item)
+      ---@cast resolved_item blink.cmp.CompletionItem
+      local valid_documentation = type(resolved_item.documentation) == 'table'
+        or type(resolved_item.documentation) == 'string'
+      local valid_detail = type(resolved_item.detail) == 'string'
 
       if not valid_documentation and not valid_detail then
         docs.close()
         return
       end
 
-      if docs.shown_item ~= item then
+      if docs.shown_item ~= resolved_item then
         local docs_buf = docs.win:get_buf()
         --- @type blink.cmp.RenderDetailAndDocumentationOpts
         local default_render_opts = {
           bufnr = docs_buf,
-          detail = item.detail,
-          documentation = item.documentation,
-          max_width = docs.win.config.max_width,
+          detail = resolved_item.detail,
+          documentation = resolved_item.documentation,
+          max_width = docs.win.config.max_width or docs.win:get_content_width(),
           use_treesitter_highlighting = config and config.treesitter_highlighting,
         }
-        local default_impl = function(opts)
-          require('blink.cmp.lib.window.docs').render_detail_and_documentation(
-            vim.tbl_extend('force', default_render_opts, opts or {})
-          )
-        end
-
         -- allow the provider to override the drawing optionally
         -- TODO: should the default_implementation be the configured draw function instead of the built-in?
-        local draw = type(item.documentation) == 'table' and item.documentation.draw or config.draw
+        local draw = type(resolved_item.documentation) == 'table' and resolved_item.documentation.draw or config.draw
+
         nvim.set_option_value('modifiable', true, { buf = docs_buf })
         draw({
-          item = item,
+          item = resolved_item,
           window = docs.win,
           config = config,
-          default_implementation = default_impl,
+          default_implementation = function(opts)
+            opts = opts or {}
+            ---@type blink.cmp.RenderDetailAndDocumentationOpts
+            opts = vim.tbl_extend('force', default_render_opts, opts)
+            require('blink.cmp.lib.window.docs').render_detail_and_documentation(opts)
+          end,
         })
         nvim.set_option_value('modifiable', false, { buf = docs_buf })
       end
-      docs.shown_item = item
+      docs.shown_item = resolved_item
 
       if menu.win:get_win() then
         docs.win:open()
@@ -110,11 +112,11 @@ function docs.show_item(context, item)
         docs.update_position()
       end
     end)
-    :catch(function(err) logger:notify(vim.log.levels.ERROR, err) end)
+    :catch(function(err) logger:notify(vim.log.levels.ERROR, tostring(err)) end)
 end
 
 -- TODO: compensate for wrapped lines
---- @param amount number
+--- @param amount integer
 --- @return boolean
 function docs.scroll_up(amount)
   local winnr = docs.win:get_win()
@@ -128,7 +130,7 @@ function docs.scroll_up(amount)
 end
 
 -- TODO: compensate for wrapped lines
---- @param amount number
+--- @param amount integer
 --- @return boolean
 function docs.scroll_down(amount)
   local winnr = docs.win:get_win()
@@ -151,6 +153,8 @@ function docs.update_position()
   if not menu_winnr then return end
 
   local menu_win_config = nvim.win_get_config(menu_winnr)
+  assert(menu_win_config.row)
+
   local menu_win_height = menu.win:get_height()
   local menu_border_size = menu.win:get_border_size()
   local cursor_win_row = vim.fn.winline()
@@ -216,7 +220,7 @@ function docs.update_position()
   }
 
   local position = positions[pos.direction]
-  if position then
+  if position ~= nil then
     docs.win:set_win_config({ relative = 'win', win = menu_winnr, row = position.row, col = position.col })
   end
 end

--- a/lua/blink/cmp/completion/windows/documentation.lua
+++ b/lua/blink/cmp/completion/windows/documentation.lua
@@ -3,8 +3,8 @@
 --- @field auto_show_timer uv.uv_timer_t
 --- @field shown_item? blink.cmp.CompletionItem
 ---
---- @field auto_show_item fun(context: blink.cmp.Context, item: blink.cmp.CompletionItem)
---- @field show_item fun(context: blink.cmp.Context, item: blink.cmp.CompletionItem)
+--- @field auto_show_item fun(context: blink.cmp.Context, item?: blink.cmp.CompletionItem)
+--- @field show_item fun(context: blink.cmp.Context, item?: blink.cmp.CompletionItem)
 --- @field update_position fun()
 --- @field scroll_up fun(amount: integer): boolean
 --- @field scroll_down fun(amount: integer): boolean

--- a/lua/blink/cmp/completion/windows/documentation.lua
+++ b/lua/blink/cmp/completion/windows/documentation.lua
@@ -1,6 +1,5 @@
 --- @class blink.cmp.CompletionDocumentationWindow
 --- @field win blink.cmp.Window
---- @field last_context_id? integer
 --- @field auto_show_timer uv.uv_timer_t
 --- @field shown_item? blink.cmp.CompletionItem
 ---
@@ -37,7 +36,6 @@ local docs = {
     filetype = 'blink-cmp-documentation',
     scrolloff = 0,
   }),
-  last_context_id = nil,
   auto_show_timer = lib.timer.new(),
 }
 

--- a/lua/blink/cmp/completion/windows/documentation.lua
+++ b/lua/blink/cmp/completion/windows/documentation.lua
@@ -218,9 +218,7 @@ function docs.update_position()
   }
 
   local position = positions[pos.direction]
-  if position ~= nil then
-    docs.win:set_win_config({ relative = 'win', win = menu_winnr, row = position.row, col = position.col })
-  end
+  docs.win:set_win_config({ relative = 'win', win = menu_winnr, row = position.row, col = position.col })
 end
 
 function docs.close()

--- a/lua/blink/cmp/completion/windows/ghost_text/init.lua
+++ b/lua/blink/cmp/completion/windows/ghost_text/init.lua
@@ -34,12 +34,12 @@ function ghost_text.is_open() return ghost_text.extmark_id ~= nil end
 --- redraw it when the cursor moves/text changes
 --- @param context blink.cmp.Context
 --- @param items blink.cmp.CompletionItem[]
---- @param selection_idx? number
+--- @param selection_idx? integer
 function ghost_text.show_preview(context, items, selection_idx)
   -- check if we're supposed to show
+  local has_selection = selection_idx ~= nil
   if
-    not config.show_with_selection and selection_idx ~= nil
-    or not config.show_without_selection and selection_idx == nil
+    (has_selection and not config.show_with_selection) or (not has_selection and not config.show_without_selection)
   then
     ghost_text.clear_preview()
     return
@@ -47,7 +47,7 @@ function ghost_text.show_preview(context, items, selection_idx)
 
   -- cmdline without noice not supported
   local ghost_text_buf = utils.get_buf()
-  if ghost_text_buf == nil or not nvim.buf_is_valid(ghost_text_buf) then return end
+  if not ghost_text_buf or not nvim.buf_is_valid(ghost_text_buf) then return end
 
   -- nothing to show, clear the preview
   local selected_item = items[selection_idx or 1]
@@ -67,11 +67,11 @@ end
 --- and otherwise ignores the request
 function ghost_text.draw_preview()
   -- check if we should be showing
-  if
-    not ghost_text.enabled()
-    or (not config.show_with_menu and menu.win:is_open())
-    or (not config.show_without_menu and not menu.win:is_open())
-  then
+  local menu_open = menu.win:is_open()
+  local should_show_preview = ghost_text.enabled()
+    and ((menu_open and config.show_with_menu) or (not menu_open and config.show_without_menu))
+
+  if not should_show_preview then
     ghost_text.clear_preview()
     return
   end
@@ -79,7 +79,7 @@ function ghost_text.draw_preview()
   -- check if the state is valid
   if not ghost_text.selected_item or not ghost_text.context then return end
   local buf = utils.get_buf()
-  if buf == nil or not nvim.buf_is_valid(buf) then return end
+  if not buf or not nvim.buf_is_valid(buf) then return end
 
   -- get the text to draw
   local text_edit = text_edits_lib.get_from_item(ghost_text.selected_item)

--- a/lua/blink/cmp/completion/windows/ghost_text/utils.lua
+++ b/lua/blink/cmp/completion/windows/ghost_text/utils.lua
@@ -1,3 +1,5 @@
+---@diagnostic disable: unresolved-require
+
 local nvim = require('blink.lib.nvim')
 
 local utils = {}
@@ -34,7 +36,9 @@ end
 function utils.get_offset()
   if utils.is_cmdline() then
     if not utils.is_noice() then return 0 end
-    return require('noice.ui.cmdline').position.cursor - (vim.fn.getcmdpos() - 1)
+    ---@type integer
+    local cursor_pos = require('noice.ui.cmdline').position.cursor
+    return cursor_pos - (vim.fn.getcmdpos() - 1)
   end
   return 0
 end

--- a/lua/blink/cmp/completion/windows/menu/init.lua
+++ b/lua/blink/cmp/completion/windows/menu/init.lua
@@ -157,23 +157,14 @@ end
 ---------------
 
 function menu.queue_auto_show(context, items)
-  local is_auto_show_enabled
-  if type(menu.auto_show.enabled) == 'function' then
-    is_auto_show_enabled = menu.auto_show.enabled(context, items)
-  else
-    is_auto_show_enabled = menu.auto_show.enabled
-  end
+  assert(type(menu.auto_show.enabled) == 'function')
+  local is_auto_show_enabled = menu.auto_show.enabled(context, items)
   if not is_auto_show_enabled then return end
 
   -- getting completions can take a while, so we factor in how long it's been since the context was created
-  local auto_show_delay_ms
-  if type(menu.auto_show.delay_ms) == 'function' then
-    auto_show_delay_ms = menu.auto_show.delay_ms(context, items)
-  else
-    auto_show_delay_ms = menu.auto_show.delay_ms
-  end
+  assert(type(menu.auto_show.delay_ms) == 'function')
+  local auto_show_delay_ms = menu.auto_show.delay_ms(context, items)
   local delay_ms = math.max(0, auto_show_delay_ms - (vim.uv.now() - context.timestamp))
-  ---@cast delay_ms integer
 
   -- no delay, show immediately
   -- only start a new timer if the cursor has moved or the id has changed.

--- a/lua/blink/cmp/completion/windows/menu/init.lua
+++ b/lua/blink/cmp/completion/windows/menu/init.lua
@@ -2,8 +2,9 @@
 --- @field win blink.cmp.Window
 --- @field items blink.cmp.CompletionItem[]
 --- @field renderer blink.cmp.Renderer
---- @field selected_item_idx? number
+--- @field selected_item_idx? integer
 --- @field context blink.cmp.Context?
+--- @field auto_show blink.cmp.CompletionMenuAutoShow
 --- @field open_emitter blink.cmp.EventEmitter<{}>
 --- @field close_emitter blink.cmp.EventEmitter<{}>
 --- @field position_update_emitter blink.cmp.EventEmitter<{}>
@@ -12,7 +13,7 @@
 --- @field open_loading fun(context: blink.cmp.Context)
 --- @field open fun()
 --- @field close fun()
---- @field set_selected_item_idx fun(idx?: number)
+--- @field set_selected_item_idx fun(idx?: integer)
 ---
 --- @field queue_auto_show fun(context: blink.cmp.Context, items: blink.cmp.CompletionItem[])
 --- @field force_auto_show fun()
@@ -20,6 +21,12 @@
 ---
 --- @field update_position fun()
 --- @field redraw_if_needed fun()
+
+--- @class blink.cmp.CompletionMenuAutoShow
+--- @field enabled boolean | fun(context: blink.cmp.Context, items: blink.cmp.CompletionItem[]): boolean
+--- @field delay_ms integer | fun(context: blink.cmp.Context, items: blink.cmp.CompletionItem[]): integer
+--- @field timer uv.uv_timer_t
+--- @field timer_key string
 
 local lib = require('blink.lib')
 local nvim = require('blink.lib.nvim')
@@ -119,7 +126,9 @@ function menu.open()
 
   menu.win:open()
   menu.win:set_option_value('cursorline', menu.selected_item_idx ~= nil)
-  if menu.selected_item_idx ~= nil then nvim.win_set_cursor(menu.win:get_win(), { menu.selected_item_idx, 0 }) end
+
+  local menu_winnr = assert(menu.win:get_win())
+  if menu.selected_item_idx ~= nil then nvim.win_set_cursor(menu_winnr, { menu.selected_item_idx, 0 }) end
 
   menu.open_emitter:emit()
 end
@@ -148,10 +157,23 @@ end
 ---------------
 
 function menu.queue_auto_show(context, items)
-  if not menu.auto_show.enabled(context, items) then return end
+  local is_auto_show_enabled
+  if type(menu.auto_show.enabled) == 'function' then
+    is_auto_show_enabled = menu.auto_show.enabled(context, items)
+  else
+    is_auto_show_enabled = menu.auto_show.enabled
+  end
+  if not is_auto_show_enabled then return end
 
   -- getting completions can take a while, so we factor in how long it's been since the context was created
-  local delay_ms = math.max(0, menu.auto_show.delay_ms(context, items) - (vim.uv.now() - context.timestamp))
+  local auto_show_delay_ms
+  if type(menu.auto_show.delay_ms) == 'function' then
+    auto_show_delay_ms = menu.auto_show.delay_ms(context, items)
+  else
+    auto_show_delay_ms = menu.auto_show.delay_ms
+  end
+  local delay_ms = math.max(0, auto_show_delay_ms - (vim.uv.now() - context.timestamp))
+  ---@cast delay_ms integer
 
   -- no delay, show immediately
   -- only start a new timer if the cursor has moved or the id has changed.

--- a/lua/blink/cmp/completion/windows/render/column.lua
+++ b/lua/blink/cmp/completion/windows/render/column.lua
@@ -1,16 +1,16 @@
 --- @class blink.cmp.DrawColumn
 --- @field component_names string[]
 --- @field components blink.cmp.DrawComponent[]
---- @field gap number
+--- @field gap integer
 --- @field overlap_components boolean
 --- @field lines string[][]
---- @field width number
+--- @field width integer
 --- @field ctxs blink.cmp.DrawItemContext[]
 ---
---- @field new fun(component_names: string[], components: blink.cmp.DrawComponent[], gap: number, overlap_components: boolean): blink.cmp.DrawColumn
+--- @field new fun(component_names: string[], components: blink.cmp.DrawComponent[], gap: integer, overlap_components: boolean): blink.cmp.DrawColumn
 --- @field render fun(self: blink.cmp.DrawColumn,context: blink.cmp.Context, ctxs: blink.cmp.DrawItemContext[])
---- @field get_line_text fun(self: blink.cmp.DrawColumn, line_idx: number): string
---- @field get_line_highlights fun(self: blink.cmp.DrawColumn, line_idx: number): blink.cmp.DrawHighlight[]
+--- @field get_line_text fun(self: blink.cmp.DrawColumn, line_idx: integer): string
+--- @field get_line_highlights fun(self: blink.cmp.DrawColumn, line_idx: integer): blink.cmp.DrawHighlight[]
 
 local text_lib = require('blink.cmp.completion.windows.render.text')
 
@@ -34,13 +34,14 @@ function column:render(context, ctxs)
   --- render text and get the max widths of each component
   --- @type string[][]
   local lines = {}
+  --- @type integer[]
   local max_component_widths = {}
   local column_width = 0
   for _, ctx in ipairs(ctxs) do
     --- @type string[]
     local line = {}
     for component_idx, component in ipairs(self.components) do
-      local text = text_lib.apply_component_width(context, component.text(ctx) or '', component)
+      local text = text_lib.apply_component_width(context, component.text and component.text(ctx) or '', component)
       table.insert(line, text)
       max_component_widths[component_idx] =
         math.max(max_component_widths[component_idx] or 0, vim.api.nvim_strwidth(text))
@@ -86,8 +87,8 @@ function column:render(context, ctxs)
 end
 
 function column:get_line_text(line_idx)
+  local line = assert(self.lines[line_idx])
   local text = ''
-  local line = self.lines[line_idx]
   for _, component in ipairs(line) do
     if #component > 0 then text = text .. component .. string.rep(' ', self.gap) end
   end
@@ -95,12 +96,14 @@ function column:get_line_text(line_idx)
 end
 
 function column:get_line_highlights(line_idx)
-  local ctx = self.ctxs[line_idx]
+  local ctx = assert(self.ctxs[line_idx])
   local offset = 0
+  ---@type blink.cmp.DrawHighlight[]
   local highlights = {}
 
   for component_idx, component in ipairs(self.components) do
-    local text = self.lines[line_idx][component_idx]
+    local line = assert(self.lines[line_idx])
+    local text = line[component_idx] or ''
     if #text > 0 then
       local column_highlights = type(component.highlight) == 'function' and component.highlight(ctx, text)
         or component.highlight
@@ -116,9 +119,8 @@ function column:get_line_highlights(line_idx)
             math.min(math.max(start_col, offset), offset + #text),
             math.min(math.max(end_col, offset), offset + #text),
             group = highlight.group,
-            params = highlight.params,
             priority = highlight.priority,
-          })
+          } --[[@as blink.cmp.DrawHighlight]])
         end
       end
 

--- a/lua/blink/cmp/completion/windows/render/context.lua
+++ b/lua/blink/cmp/completion/windows/render/context.lua
@@ -1,11 +1,11 @@
 --- @class blink.cmp.DrawItemContext
 --- @field self blink.cmp.Draw
 --- @field item blink.cmp.CompletionItem
---- @field idx number
+--- @field idx integer
 --- @field label string
 --- @field label_detail string
 --- @field label_description string
---- @field label_matched_indices number[]
+--- @field label_matched_indices integer[]
 --- @field kind string
 --- @field kind_icon string
 --- @field kind_hl string
@@ -32,7 +32,9 @@ function draw_context.get_from_items(context, draw, items)
 
   local ctxs = {}
   for idx, item in ipairs(items) do
-    ctxs[idx] = draw_context.new(draw, idx, item, matched_indices[idx])
+    local matched_idx = matched_indices[idx]
+    assert(matched_idx, 'No index ' .. idx .. ' found in fuzzy_matched_indices')
+    ctxs[idx] = draw_context.new(draw, idx, item, matched_idx)
   end
   return ctxs
 end
@@ -41,9 +43,9 @@ local config = require('blink.cmp.config').appearance
 local kinds = require('blink.cmp.types').CompletionItemKind
 
 --- @param draw blink.cmp.Draw
---- @param item_idx number
+--- @param item_idx integer
 --- @param item blink.cmp.CompletionItem
---- @param matched_indices number[]
+--- @param matched_indices integer[]
 --- @return blink.cmp.DrawItemContext
 function draw_context.new(draw, item_idx, item, matched_indices)
   local kind = item.kind_name or kinds[item.kind] or 'Unknown'
@@ -83,11 +85,11 @@ function draw_context.new(draw, item_idx, item, matched_indices)
     kind_hl = kind_hl,
     icon_gap = config.nerd_font_variant == 'mono' and '' or ' ',
     deprecated = (lib.is_not_nil(item.deprecated) and item.deprecated)
-      or (lib.is_not_nil(item.tags) and vim.tbl_contains(item.tags, 1))
+      or (lib.is_not_nil(item.tags) and vim.tbl_contains(item.tags or {}, 1))
       or false,
     source_id = source_id,
     source_name = source_name,
-  }
+  } --[[@as blink.cmp.DrawItemContext]]
 end
 
 return draw_context

--- a/lua/blink/cmp/completion/windows/render/init.lua
+++ b/lua/blink/cmp/completion/windows/render/init.lua
@@ -2,17 +2,17 @@ local nvim = require('blink.lib.nvim')
 
 --- @class blink.cmp.Renderer
 --- @field def blink.cmp.Draw
---- @field padding number[]
---- @field gap number
+--- @field padding {[1]: integer, [2]:integer}
+--- @field gap integer
 --- @field columns blink.cmp.DrawColumn[]
---- @field bufnr number?
+--- @field bufnr? integer
 ---
 --- @field new fun(draw: blink.cmp.Draw): blink.cmp.Renderer
---- @field draw fun(self: blink.cmp.Renderer, context: blink.cmp.Context, bufnr: number, items: blink.cmp.CompletionItem[], draw: blink.cmp.Draw): blink.cmp.DrawColumn[]
+--- @field draw fun(self: blink.cmp.Renderer, context: blink.cmp.Context, bufnr: integer, items: blink.cmp.CompletionItem[], draw: blink.cmp.Draw)
 --- @field get_columns fun(self: blink.cmp.Renderer, context: blink.cmp.Context, draw: blink.cmp.Draw): blink.cmp.DrawColumn[]
---- @field get_component_column_location fun(self: blink.cmp.Renderer, columns: blink.cmp.DrawColumn[], component_name: string): { column_idx: number, component_idx: number }
---- @field get_component_start_col fun(self: blink.cmp.Renderer, columns: blink.cmp.DrawColumn[], component_name: string): number
---- @field get_alignment_start_col fun(self: blink.cmp.Renderer): number
+--- @field get_component_column_location fun(self: blink.cmp.Renderer, columns: blink.cmp.DrawColumn[], component_name: string): { [1]: integer, [2]: integer }
+--- @field get_component_start_col fun(self: blink.cmp.Renderer, columns: blink.cmp.DrawColumn[], component_name: string): integer
+--- @field get_alignment_start_col fun(self: blink.cmp.Renderer): integer
 
 local ns = nvim.create_namespace('blink_cmp_renderer')
 
@@ -22,7 +22,6 @@ local renderer = {}
 
 function renderer.new(draw)
   local padding = type(draw.padding) == 'number' and { draw.padding, draw.padding } or draw.padding
-  --- @cast padding number[]
 
   local self = setmetatable({}, { __index = renderer })
   self.padding = padding
@@ -35,7 +34,7 @@ function renderer.new(draw)
   nvim.set_decoration_provider(ns, {
     on_win = function(_, _, win_bufnr) return self.bufnr == win_bufnr end,
     on_line = function(_, _, _, line)
-      local offset = self.padding[1]
+      local offset = self.padding[1] or 0
       for _, column in ipairs(self.columns) do
         local text = column:get_line_text(line + 1)
         if #text > 0 then
@@ -70,9 +69,9 @@ function renderer:get_columns(context, draw)
   local columns_definitions = vim.tbl_map(function(column)
     local components = {}
     for _, component_name in ipairs(column) do
-      local component = draw.components[component_name]
+      local component = draw.components and draw.components[component_name]
       assert(component ~= nil, 'No component definition found for component: "' .. component_name .. '"')
-      table.insert(components, draw.components[component_name])
+      table.insert(components, component)
     end
     return {
       component_names = column,
@@ -145,11 +144,13 @@ function renderer:get_component_start_col(columns, component_name)
   -- add previous columns
   local start_col = self.padding[1]
   for i = 1, column_idx - 1 do
-    start_col = start_col + columns[i].width + self.gap
+    local column = assert(columns[i])
+    start_col = start_col + column.width + self.gap
   end
 
   -- add previous components
-  local line = columns[column_idx].lines[1]
+  local column = assert(columns[column_idx])
+  local line = column.lines[1]
   if not line then return start_col end
   for i = 1, component_idx - 1 do
     start_col = start_col + #line[i]

--- a/lua/blink/cmp/completion/windows/render/text.lua
+++ b/lua/blink/cmp/completion/windows/render/text.lua
@@ -20,7 +20,7 @@ end
 
 --- Sets the text width to the given width
 --- @param text string
---- @param width number
+--- @param width integer
 --- @param component blink.cmp.DrawComponent
 --- @return string text
 function text_lib.set_width(text, width, component)
@@ -36,7 +36,7 @@ end
 
 --- Truncates the text to the given width
 --- @param text string
---- @param target_width number
+--- @param target_width integer
 --- @param ellipsis? boolean
 --- @return string truncated_text
 function text_lib.truncate(text, target_width, ellipsis)
@@ -52,8 +52,9 @@ function text_lib.truncate(text, target_width, ellipsis)
 end
 
 --- Distributes a total amount of  spaces over a given number of fields
---- @param total number
---- @param count number
+--- @param total integer
+--- @param count integer
+--- @return {[integer]: integer}
 function text_lib.distr_spaces(total, count)
   if count == 0 then return {} end
   local base = math.floor(total / count)
@@ -67,7 +68,7 @@ end
 
 --- Pads the text to the given width
 --- @param text string
---- @param target_width number
+--- @param target_width integer
 --- @return string padded_text The amount of padding added to the left and the padded text
 function text_lib.pad(text, target_width)
   local text_width = nvim.strwidth(text)

--- a/lua/blink/cmp/completion/windows/render/treesitter.lua
+++ b/lua/blink/cmp/completion/windows/render/treesitter.lua
@@ -6,7 +6,7 @@ local cache_size = 0
 local MAX_CACHE_SIZE = 1000
 
 --- @param ctx blink.cmp.DrawItemContext
---- @param opts? {offset?: number}
+--- @param opts? {offset?: integer}
 function treesitter.highlight(ctx, opts)
   local ret = cache[ctx.label]
   if not ret then

--- a/lua/blink/cmp/completion/windows/render/treesitter.lua
+++ b/lua/blink/cmp/completion/windows/render/treesitter.lua
@@ -53,14 +53,13 @@ function treesitter._highlight(ctx)
     for capture, node in query:iter_captures(tstree:root(), source) do
       local _, start_col, _, end_col = node:range()
 
-      ---@type string
       local name = query.captures[capture]
       if name ~= 'spell' then
         ret[#ret + 1] = {
           start_col,
           end_col,
           group = '@' .. name .. '.' .. lang,
-        }
+        } --[[@as blink.cmp.DrawHighlight]]
       end
     end
   end)

--- a/lua/blink/cmp/completion/windows/render/types.lua
+++ b/lua/blink/cmp/completion/windows/render/types.lua
@@ -1,23 +1,23 @@
 --- @class blink.cmp.Draw
 --- @field align_to? string | 'none' | 'cursor' Align the window to the component with the given name, or to the cursor
---- @field padding? number | number[] Padding on the left and right of the grid
---- @field gap? number Gap between columns
---- @field cursorline_priority? number Priority of the background highlight for the cursorline, defaults to 10000. Setting this to 0 will render it below other highlights
+--- @field padding? integer | integer[] Padding on the left and right of the grid
+--- @field gap? integer Gap between columns
+--- @field cursorline_priority? integer Priority of the background highlight for the cursorline, defaults to 10000. Setting this to 0 will render it below other highlights
 --- @field snippet_indicator? string Appends an indicator to snippets label, `'~'` by default
 --- @field treesitter? string[] Use treesitter to highlight the label text of completions from these sources
 --- @field columns? blink.cmp.DrawColumnDefinition[] | fun(context: blink.cmp.Context): blink.cmp.DrawColumnDefinition[] Components to render, grouped by column
 --- @field components? table<string, blink.cmp.DrawComponent> Component definitions
 ---
 --- @class blink.cmp.DrawHighlight
---- @field [number] number Start and end index of the highlight
+--- @field [integer] integer Start and end index of the highlight
 --- @field group? string Highlight group
---- @field priority? number Priority of the highlight
+--- @field priority? integer Priority of the highlight
 ---
 --- @class blink.cmp.DrawWidth
---- @field fixed? number Fixed width
+--- @field fixed? integer Fixed width
 --- @field fill? boolean Fill the remaining space
---- @field min? number Minimum width
---- @field max? number Maximum width
+--- @field min? integer Minimum width
+--- @field max? integer Maximum width
 ---
 --- @class blink.cmp.DrawComponent
 --- @field width? blink.cmp.DrawWidth
@@ -25,4 +25,4 @@
 --- @field text? fun(ctx: blink.cmp.DrawItemContext): string? Renders the text of the component
 --- @field highlight? string | fun(ctx: blink.cmp.DrawItemContext, text: string): string | blink.cmp.DrawHighlight[] Renders the highlights of the component
 ---
---- @alias blink.cmp.DrawColumnDefinition { [number]: string, gap?: number }
+--- @alias blink.cmp.DrawColumnDefinition { [integer]: string, gap?: integer, overlap_components?: boolean }

--- a/lua/blink/cmp/config/appearance.lua
+++ b/lua/blink/cmp/config/appearance.lua
@@ -1,5 +1,5 @@
 --- @class (exact) blink.cmp.AppearanceConfig
---- @field highlight_ns number
+--- @field highlight_ns integer
 --- @field use_nvim_cmp_as_default boolean Sets the fallback highlight groups to nvim-cmp's highlight groups. Useful for when your theme doesn't support blink.cmp, will be removed in a future release.
 --- @field nerd_font_variant 'mono' | 'normal' Set to 'mono' for 'Nerd Font Mono' or 'normal' for 'Nerd Font'. Adjusts spacing to ensure icons are aligned
 --- @field kind_icons table<string, string>

--- a/lua/blink/cmp/config/completion/accept.lua
+++ b/lua/blink/cmp/config/completion/accept.lua
@@ -1,7 +1,7 @@
 --- @class (exact) blink.cmp.CompletionAcceptConfig
 --- @field dot_repeat boolean Write completions to the `.` register
 --- @field create_undo_point boolean Create an undo point when accepting a completion item
---- @field resolve_timeout_ms number How long to wait for the LSP to resolve the item with additional information before continuing as-is
+--- @field resolve_timeout_ms integer How long to wait for the LSP to resolve the item with additional information before continuing as-is
 --- @field auto_brackets blink.cmp.AutoBracketsConfig
 
 --- @class (exact) blink.cmp.AutoBracketsConfig
@@ -20,7 +20,7 @@
 --- @class (exact) blink.cmp.AutoBracketSemanticTokenResolutionConfig
 --- @field enabled boolean
 --- @field blocked_filetypes string[]
---- @field timeout_ms number How long to wait for semantic tokens to return before assuming no brackets should be added
+--- @field timeout_ms integer How long to wait for semantic tokens to return before assuming no brackets should be added
 
 local config = require('blink.lib.config')
 return {

--- a/lua/blink/cmp/config/completion/documentation.lua
+++ b/lua/blink/cmp/config/completion/documentation.lua
@@ -44,7 +44,11 @@ return {
     ),
   },
   treesitter_highlighting = { true, 'boolean' },
-  draw = { function(opts) opts.default_implementation() end, 'function' },
+  draw = {
+    ---@param opts blink.cmp.CompletionDocumentationDrawOpts
+    function(opts) opts.default_implementation() end,
+    'function',
+  },
   window = {
     min_width = { 10, 'number' },
     max_width = { 80, 'number' },

--- a/lua/blink/cmp/config/completion/documentation.lua
+++ b/lua/blink/cmp/config/completion/documentation.lua
@@ -1,19 +1,19 @@
 --- @class (exact) blink.cmp.CompletionDocumentationConfig
 --- @field auto_show boolean Controls whether the documentation window will automatically show when selecting a completion item
---- @field auto_show_delay_ms number Delay before showing the documentation window
---- @field update_delay_ms number Delay before updating the documentation window when selecting a new item, while an existing item is still visible
+--- @field auto_show_delay_ms integer Delay before showing the documentation window
+--- @field update_delay_ms integer Delay before updating the documentation window when selecting a new item, while an existing item is still visible
 --- @field treesitter_highlighting boolean Whether to use treesitter highlighting, disable if you run into performance issues
 --- @field draw fun(opts: blink.cmp.CompletionDocumentationDrawOpts): nil Renders the item in the documentation window, by default using an internal treesitter based implementation
 --- @field window blink.cmp.CompletionDocumentationWindowConfig
 
 --- @class (exact) blink.cmp.CompletionDocumentationWindowConfig
---- @field min_width number
---- @field max_width number
---- @field max_height number
---- @field desired_min_width number
---- @field desired_min_height number
+--- @field min_width integer
+--- @field max_width integer
+--- @field max_height integer
+--- @field desired_min_width integer
+--- @field desired_min_height integer
 --- @field border blink.cmp.WindowBorder
---- @field winblend number
+--- @field winblend integer
 --- @field winhighlight string
 --- @field scrollbar boolean Note that the gutter will be disabled when border ~= 'none'
 --- @field direction_priority blink.cmp.CompletionDocumentationDirectionPriorityConfig Which directions to show the window, for each of the possible menu window directions, falling back to the next direction when there's not enough space

--- a/lua/blink/cmp/config/completion/documentation.lua
+++ b/lua/blink/cmp/config/completion/documentation.lua
@@ -28,6 +28,9 @@
 --- @field config blink.cmp.CompletionDocumentationConfig
 --- @field default_implementation fun(opts?: blink.cmp.RenderDetailAndDocumentationOptsPartial)
 
+--- @class blink.cmp.CompletionDocumentationMarkupContent : lsp.MarkupContent
+--- @field draw? fun(opts?: blink.cmp.CompletionDocumentationDrawOpts)
+
 local config = require('blink.lib.config')
 return {
   enabled = { true, 'boolean' },

--- a/lua/blink/cmp/config/completion/list.lua
+++ b/lua/blink/cmp/config/completion/list.lua
@@ -1,5 +1,5 @@
 --- @class (exact) blink.cmp.CompletionListConfig
---- @field max_items number Maximum number of items to display
+--- @field max_items integer Maximum number of items to display
 --- @field selection blink.cmp.CompletionListSelectionConfig
 --- @field cycle blink.cmp.CompletionListCycleConfig
 

--- a/lua/blink/cmp/config/completion/menu.lua
+++ b/lua/blink/cmp/config/completion/menu.lua
@@ -1,17 +1,17 @@
 --- @class (exact) blink.cmp.CompletionMenuConfig
 --- @field enabled boolean
---- @field min_width number
---- @field max_height number
+--- @field min_width integer
+--- @field max_height integer
 --- @field border blink.cmp.WindowBorder
---- @field winblend number
+--- @field winblend integer
 --- @field winhighlight string
---- @field scrolloff number Keep the cursor X lines away from the top/bottom of the window
+--- @field scrolloff integer Keep the cursor X lines away from the top/bottom of the window
 --- @field scrollbar boolean Note that the gutter will be disabled when border ~= 'none'
 --- @field direction_priority ("n" | "s")[]| fun(): ("n" | "s")[] Which directions to show the window, or a function returning such a table, falling back to the next direction when there's not enough space
 --- @field order blink.cmp.CompletionMenuOrderConfig TODO: implement
 --- @field auto_show boolean | fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): boolean Whether to automatically show the window when new completion items are available
---- @field auto_show_delay_ms number | fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): number Delay before showing the completion menu
---- @field cmdline_position fun(): number[] Screen coordinates (0-indexed) of the command line
+--- @field auto_show_delay_ms integer | fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): integer Delay before showing the completion menu
+--- @field cmdline_position fun(): { [1]: integer, [2]: integer } Screen coordinates (0-indexed) of the command line
 --- @field draw blink.cmp.Draw Controls how the completion items are rendered on the popup window
 
 local config = require('blink.lib.config')

--- a/lua/blink/cmp/config/fuzzy.lua
+++ b/lua/blink/cmp/config/fuzzy.lua
@@ -1,9 +1,13 @@
 --- @class (exact) blink.cmp.FuzzyConfig
 --- @field implementation blink.cmp.FuzzyImplementationType Controls which implementation to use for the fuzzy matcher. See the documentation for the available values for more information.
---- @field max_typos number | fun(keyword: string): number Allows for a number of typos relative to the length of the query. Set this to 0 to match the behavior of fzf. Note, this does not apply when using the Lua implementation.
+--- @field max_typos integer | fun(keyword: string): integer Allows for a number of typos relative to the length of the query. Set this to 0 to match the behavior of fzf. Note, this does not apply when using the Lua implementation.
 --- @field sorts blink.cmp.Sort[] Controls which sorts to use and in which order.
---- @field frecency boolean Tracks the most recently/frequently used items and boosts the score of the item. Note, this does not apply when using the Lua implementation.
---- @field proximity boolean Boosts the score of items matching nearby words. Note, this does not apply when using the Lua implementation.
+--- @field frecency blink.cmp.FuzzyConfigFrecency Tracks the most recently/frequently used items and boosts the score of the item. Note, this does not apply when using the Lua implementation.
+--- @field use_proximity boolean Boosts the score of items matching nearby words. Note, this does not apply when using the Lua implementation.
+
+--- @class (exact) blink.cmp.FuzzyConfigFrecency
+--- @field enabled boolean
+--- @field path string
 
 --- @alias blink.cmp.FuzzyImplementationType
 --- | 'prefer_rust_with_warning' (Recommended) If available, use the Rust implementation. Fallback to the Lua implementation when not available, emitting a warning message.

--- a/lua/blink/cmp/config/fuzzy.lua
+++ b/lua/blink/cmp/config/fuzzy.lua
@@ -15,7 +15,7 @@
 --- | 'rust' Always use the Rust implementation. Error if not available.
 --- | 'lua' Always use the Lua implementation
 
---- @alias blink.cmp.SortFunction fun(a: blink.cmp.CompletionItem, b: blink.cmp.CompletionItem): boolean | nil
+--- @alias blink.cmp.SortFunction fun(a: blink.cmp.CompletionItem, b: blink.cmp.CompletionItem): boolean?
 --- @alias blink.cmp.Sort ("label" | "sort_text" | "kind" | "score" | "exact" | blink.cmp.SortFunction)
 
 local config = require('blink.lib.config')

--- a/lua/blink/cmp/config/shared.lua
+++ b/lua/blink/cmp/config/shared.lua
@@ -1,2 +1,0 @@
---- @alias blink.cmp.WindowBorderChar string | table
---- @alias blink.cmp.WindowBorder nil | 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'bold' | 'padded' | 'none' | blink.cmp.WindowBorderChar[] When set to `nil`, uses the `vim.o.winborder` value on nvim 0.11+

--- a/lua/blink/cmp/config/signature.lua
+++ b/lua/blink/cmp/config/signature.lua
@@ -15,14 +15,14 @@
 --- @field show_on_accept_on_trigger_character boolean Show the signature help window when the cursor comes after a trigger character after accepting a completion item, e.g. func(|) where "(" is a trigger character
 
 --- @class (exact) blink.cmp.SignatureWindowConfig
---- @field min_width number
---- @field max_width number
---- @field max_height number
+--- @field min_width integer
+--- @field max_width integer
+--- @field max_height integer
 --- @field border blink.cmp.WindowBorder
---- @field winblend number
+--- @field winblend integer
 --- @field winhighlight string
 --- @field scrollbar boolean Note that the gutter will be disabled when border ~= 'none'
---- @field direction_priority ("n" | "s")[] | fun(): table Which directions to show the window ,or a function returning such a table, falling back to the next direction when there's not enough space, or another window is in the way.
+--- @field direction_priority blink.cmp.WindowDirectionPriority table Which directions to show the window ,or a function returning such a table, falling back to the next direction when there's not enough space, or another window is in the way.
 --- @field treesitter_highlighting boolean Disable if you run into performance issues, (v2.0, drop this)
 --- @field show_documentation boolean (v2.0, set this to false by default)
 

--- a/lua/blink/cmp/config/snippets.lua
+++ b/lua/blink/cmp/config/snippets.lua
@@ -1,9 +1,9 @@
 --- @class (exact) blink.cmp.SnippetsConfig
 --- @field preset 'default' | 'luasnip' | 'mini_snippets' | 'vsnip'
 --- @field expand fun(snippet: string) Function to use when expanding LSP provided snippets
---- @field active fun(filter?: { direction?: number }): boolean Function to use when checking if a snippet is active
---- @field jump fun(direction: number): boolean Function to use when jumping between tab stops in a snippet, where direction can be negative or positive
---- @field score_offset number Offset to the score of all snippet items
+--- @field active fun(filter?: { direction?: integer }): boolean Function to use when checking if a snippet is active
+--- @field jump fun(direction: integer): boolean Function to use when jumping between tab stops in a snippet, where direction can be negative or positive
+--- @field score_offset integer Offset to the score of all snippet items
 
 --- @param handlers table<'default' | 'luasnip' | 'mini_snippets' | 'vsnip', fun(...): any>
 local function by_preset(handlers)

--- a/lua/blink/cmp/config/sources.lua
+++ b/lua/blink/cmp/config/sources.lua
@@ -18,12 +18,12 @@
 --- @field per_filetype table<string, blink.cmp.SourceListPerFiletype>
 ---
 --- @field transform_items fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): blink.cmp.CompletionItem[] Function to transform the items before they're returned
---- @field min_keyword_length number | fun(ctx: blink.cmp.Context): number Minimum number of characters in the keyword to trigger
+--- @field min_keyword_length integer | fun(ctx: blink.cmp.Context): integer Minimum number of characters in the keyword to trigger
 ---
 --- @field providers table<string, blink.cmp.SourceProviderConfig>
 
 --- @alias blink.cmp.SourceList string[] | fun(): string[]
---- @alias blink.cmp.SourceListPerFiletype { inherit_defaults?: boolean, [number]: string } | fun(): ({ inherit_defaults?: boolean, [number]: string })
+--- @alias blink.cmp.SourceListPerFiletype { inherit_defaults?: boolean, [integer]: string } | fun(): ({ inherit_defaults?: boolean, [integer]: string })
 
 --- @class blink.cmp.SourceProviderConfig
 --- @field module string
@@ -31,19 +31,19 @@
 --- @field enabled? boolean | fun(): boolean Whether or not to enable the provider
 --- @field opts? table
 --- @field async? boolean | fun(ctx: blink.cmp.Context): boolean Whether we should show the completions before this provider returns, without waiting for it
---- @field timeout_ms? number | fun(ctx: blink.cmp.Context): number How long to wait for the provider to return before showing completions and treating it as asynchronous
+--- @field timeout_ms? integer | fun(ctx: blink.cmp.Context): integer How long to wait for the provider to return before showing completions and treating it as asynchronous
 --- @field transform_items? fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): blink.cmp.CompletionItem[] Function to transform the items before they're returned
 --- @field should_show_items? boolean | fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): boolean Whether or not to show the items
---- @field max_items? number | fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): number Maximum number of items to display in the menu
---- @field min_keyword_length? number | fun(ctx: blink.cmp.Context): number Minimum number of characters in the keyword to trigger the provider
+--- @field max_items? integer | fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): integer Maximum number of items to display in the menu
+--- @field min_keyword_length? integer | fun(ctx: blink.cmp.Context): integer Minimum number of characters in the keyword to trigger the provider
 --- @field fallbacks? string[] | fun(ctx: blink.cmp.Context, enabled_sources: string[]): string[] If this provider returns 0 items, it will fallback to these providers
---- @field score_offset? number | fun(ctx: blink.cmp.Context, enabled_sources: string[]): number Boost/penalize the score of the items
+--- @field score_offset? integer | fun(ctx: blink.cmp.Context, enabled_sources: string[]): integer Boost/penalize the score of the items
 --- @field override? blink.cmp.SourceOverride Override the source's functions
 
 local config = require('blink.lib.config')
 
 local source_list_per_filetype = config.types.validator(
-  '{ inherit_defaults?: boolean, [number]: string }',
+  '{ inherit_defaults?: boolean, [integer]: string }',
   function(val)
     if type(val) ~= 'table' then return false end
     for k, v in pairs(val) do

--- a/lua/blink/cmp/fuzzy/build/init.lua
+++ b/lua/blink/cmp/fuzzy/build/init.lua
@@ -25,11 +25,11 @@ local async_system = function(cmd, opts)
     )
 
     return function() return proc:kill('TERM') end
-  end)
+  end) --[[@as blink.lib.Task<vim.SystemCompleted>]]
 end
 
 --- Builds the rust binary from source
---- @return blink.lib.Task
+--- @return blink.lib.Task<vim.SystemCompleted>
 function build.build()
   logger:notify(vim.log.levels.INFO, 'Building fuzzy matching library from source...')
 

--- a/lua/blink/cmp/fuzzy/init.lua
+++ b/lua/blink/cmp/fuzzy/init.lua
@@ -168,7 +168,7 @@ function fuzzy.fuzzy(line, cursor_col, haystacks_by_provider, range)
 end
 
 --- @param line string
---- @param col number
+--- @param col integer
 --- @param range? blink.cmp.CompletionKeywordRange
 --- @return integer, integer
 function fuzzy.get_keyword_range(line, col, range)

--- a/lua/blink/cmp/fuzzy/init.lua
+++ b/lua/blink/cmp/fuzzy/init.lua
@@ -33,45 +33,59 @@ function fuzzy.init_db()
   fuzzy.has_init_db = true
 end
 
+---Returns the library name and path
+---@return string, string
+function fuzzy.get_lib()
+  local cmp = require('blink.cmp')
+  local native = require('blink.lib.native')
+  local commit = native.try_git_commit(cmp.get_repo_root())
+  local name = cmp.get_library_name()
+
+  return name, native.resolve(name, commit)
+end
+
 ---@param item blink.cmp.CompletionItem
 function fuzzy.access(item)
   if fuzzy.implementation_type ~= 'rust' or not config.fuzzy.frecency.enabled then return end
 
   fuzzy.init_db()
 
-  -- TODO: fails to load in uv thread
   -- send only the properties we need for LspItem
-  -- local trimmed_item = {
-  --   label = lib.is_not_nil(item.label) and item.label or nil,
-  --   filterText = lib.is_not_nil(item.filterText) and item.filterText or nil,
-  --   sortText = lib.is_not_nil(item.sortText) and item.sortText or nil,
-  --   insertText = lib.is_not_nil(item.insertText) and item.insertText or nil,
-  --   kind = lib.is_not_nil(item.kind) and item.kind or nil,
-  --   score_offset = lib.is_not_nil(item.score_offset) and item.score_offset or nil,
-  --   source_id = lib.is_not_nil(item.source_id) and item.source_id or nil,
-  -- }
-  --
-  -- -- writing to the db takes ~10ms, so schedule writes in another thread
-  -- local encode
-  -- if jit and package.preload['string.buffer'] then
-  --   encode = require('string.buffer').encode
-  -- else
-  --   encode = vim.mpack.encode
-  -- end
+  local trimmed_item = {
+    label = lib.is_not_nil(item.label) and item.label or nil,
+    filterText = lib.is_not_nil(item.filterText) and item.filterText or nil,
+    sortText = lib.is_not_nil(item.sortText) and item.sortText or nil,
+    insertText = lib.is_not_nil(item.insertText) and item.insertText or nil,
+    kind = lib.is_not_nil(item.kind) and item.kind or nil,
+    score_offset = lib.is_not_nil(item.score_offset) and item.score_offset or nil,
+    source_id = lib.is_not_nil(item.source_id) and item.source_id or nil,
+  }
 
-  -- vim.uv
-  --   .new_work(function(itm, cpath)
-  --     local decode
-  --     if jit and package.preload['string.buffer'] then
-  --       decode = require('string.buffer').decode
-  --     else
-  --       decode = vim.mpack.decode
-  --     end
-  --
-  --     package.cpath = cpath
-  --     require('blink.cmp.fuzzy.rust').access(decode(itm))
-  --   end, function() end)
-  --   :queue(encode(trimmed_item), package.cpath)
+  -- writing to the db takes ~10ms, so schedule writes in another thread
+  local encode
+  if jit and package.preload['string.buffer'] then
+    encode = require('string.buffer').encode
+  else
+    encode = vim.mpack.encode
+  end
+
+  local lib_name, lib_path = require('blink.cmp.fuzzy').get_lib()
+  vim.uv
+    .new_work(function(itm, libname, libpath)
+      local decode
+      if jit and package.preload['string.buffer'] then
+        decode = require('string.buffer').decode
+      else
+        decode = vim.mpack.decode
+      end
+
+      local loader, err = package.loadlib(libpath, 'luaopen_' .. libname)
+      assert(loader, err)
+
+      local rust = loader()
+      rust.access(decode(itm))
+    end, function() end)
+    :queue(encode(trimmed_item), lib_name, lib_path)
 end
 
 ---@param lines string

--- a/lua/blink/cmp/fuzzy/init.lua
+++ b/lua/blink/cmp/fuzzy/init.lua
@@ -15,11 +15,13 @@ local fuzzy = {
 --- @param implementation 'lua' | 'rust'
 function fuzzy.set_implementation(implementation)
   assert(implementation == 'lua' or implementation == 'rust', 'Invalid fuzzy implementation: ' .. implementation)
+
   fuzzy.implementation_type = implementation
   fuzzy.implementation = require('blink.cmp.fuzzy.' .. implementation)
 end
 
 function fuzzy.init_db()
+  ---@diagnostic disable-next-line: unnecessary-if
   if fuzzy.has_init_db then return end
 
   fuzzy.implementation.init_db(config.fuzzy.frecency.path)
@@ -37,26 +39,26 @@ function fuzzy.access(item)
 
   fuzzy.init_db()
 
-  -- send only the properties we need for LspItem
-  local trimmed_item = {
-    label = lib.is_not_nil(item.label) and item.label or nil,
-    filterText = lib.is_not_nil(item.filterText) and item.filterText or nil,
-    sortText = lib.is_not_nil(item.sortText) and item.sortText or nil,
-    insertText = lib.is_not_nil(item.insertText) and item.insertText or nil,
-    kind = lib.is_not_nil(item.kind) and item.kind or nil,
-    score_offset = lib.is_not_nil(item.score_offset) and item.score_offset or nil,
-    source_id = lib.is_not_nil(item.source_id) and item.source_id or nil,
-  }
-
-  -- writing to the db takes ~10ms, so schedule writes in another thread
-  local encode
-  if jit and package.preload['string.buffer'] then
-    encode = require('string.buffer').encode
-  else
-    encode = vim.mpack.encode
-  end
-
   -- TODO: fails to load in uv thread
+  -- send only the properties we need for LspItem
+  -- local trimmed_item = {
+  --   label = lib.is_not_nil(item.label) and item.label or nil,
+  --   filterText = lib.is_not_nil(item.filterText) and item.filterText or nil,
+  --   sortText = lib.is_not_nil(item.sortText) and item.sortText or nil,
+  --   insertText = lib.is_not_nil(item.insertText) and item.insertText or nil,
+  --   kind = lib.is_not_nil(item.kind) and item.kind or nil,
+  --   score_offset = lib.is_not_nil(item.score_offset) and item.score_offset or nil,
+  --   source_id = lib.is_not_nil(item.source_id) and item.source_id or nil,
+  -- }
+  --
+  -- -- writing to the db takes ~10ms, so schedule writes in another thread
+  -- local encode
+  -- if jit and package.preload['string.buffer'] then
+  --   encode = require('string.buffer').encode
+  -- else
+  --   encode = vim.mpack.encode
+  -- end
+
   -- vim.uv
   --   .new_work(function(itm, cpath)
   --     local decode
@@ -76,7 +78,7 @@ end
 function fuzzy.get_words(lines) return fuzzy.implementation.get_words(lines) end
 
 --- @param line string
---- @param cursor_col number
+--- @param cursor_col integer
 --- @param haystack string[]
 --- @param range blink.cmp.CompletionKeywordRange
 function fuzzy.fuzzy_matched_indices(line, cursor_col, haystack, range)
@@ -84,7 +86,7 @@ function fuzzy.fuzzy_matched_indices(line, cursor_col, haystack, range)
 end
 
 --- @param line string
---- @param cursor_col number
+--- @param cursor_col integer
 --- @param haystacks_by_provider table<string, blink.cmp.CompletionItem[]>
 --- @param range blink.cmp.CompletionKeywordRange
 --- @return blink.cmp.CompletionItem[]
@@ -120,7 +122,7 @@ function fuzzy.fuzzy(line, cursor_col, haystacks_by_provider, range)
 
   local max_typos = type(config.fuzzy.max_typos) == 'function' and config.fuzzy.max_typos(keyword)
     or config.fuzzy.max_typos
-  --- @cast max_typos number
+  --- @cast max_typos integer
 
   -- perform fuzzy search
   local provider_ids = vim.tbl_keys(haystacks_by_provider)
@@ -154,7 +156,7 @@ end
 --- @param line string
 --- @param col number
 --- @param range? blink.cmp.CompletionKeywordRange
---- @return number, number
+--- @return integer, integer
 function fuzzy.get_keyword_range(line, col, range)
   return fuzzy.implementation.get_keyword_range(line, col, range == 'full')
 end
@@ -169,9 +171,9 @@ end
 
 --- @param item blink.cmp.CompletionItem
 --- @param line string
---- @param col number
+--- @param col integer
 --- @param range blink.cmp.CompletionKeywordRange
---- @return number, number
+--- @return integer, integer
 function fuzzy.guess_edit_range(item, line, col, range)
   return fuzzy.implementation.guess_edit_range(item, line, col, range == 'full')
 end

--- a/lua/blink/cmp/fuzzy/lua/init.lua
+++ b/lua/blink/cmp/fuzzy/lua/init.lua
@@ -24,7 +24,7 @@ function fuzzy.get_words(text)
 
   while #text > 0 do
     local match_start, match_end = words_regex:match_str(text)
-    if match_start == nil then break end
+    if not match_start or not match_end then break end
 
     if match_end - match_start > 2 then
       local word = text:sub(match_start + 1, match_end)

--- a/lua/blink/cmp/fuzzy/lua/keyword.lua
+++ b/lua/blink/cmp/fuzzy/lua/keyword.lua
@@ -23,9 +23,9 @@ function keyword.with_constant_is_keyword(cb)
 end
 
 --- @param line string
---- @param col number
+--- @param col integer
 --- @param match_suffix boolean
---- @return number, number
+--- @return integer, integer
 function keyword.get_keyword_range(line, col, match_suffix)
   return keyword.with_constant_is_keyword(function()
     local before_match_start = BACKWARD_REGEX:match_str(line:sub(1, col))
@@ -43,11 +43,11 @@ function keyword.get_keyword_range(line, col, match_suffix)
   end)
 end
 
---- @param keyword_start number
---- @param keyword_end number
+--- @param keyword_start integer
+--- @param keyword_end integer
 --- @param word string
 --- @param line string
---- @return number, number
+--- @return integer, integer
 function keyword.guess_keyword_range(keyword_start, keyword_end, word, line)
   keyword_start = keyword_start + 1
   local og_keyword_start = keyword_start
@@ -83,8 +83,8 @@ function keyword.guess_keyword_range(keyword_start, keyword_end, word, line)
   return keyword_start - 1, keyword_end
 end
 
---- @param keyword_start number
---- @param keyword_end number
+--- @param keyword_start integer
+--- @param keyword_end integer
 --- @param word string
 --- @param line string
 --- @return string

--- a/lua/blink/cmp/fuzzy/rust/init.lua
+++ b/lua/blink/cmp/fuzzy/rust/init.lua
@@ -1,4 +1,6 @@
+local cmp = require('blink.cmp')
 local native = require('blink.lib.native')
-local project_root = require('blink.cmp').get_repo_root()
+local commit = native.try_git_commit(cmp.get_repo_root())
+local name = cmp.get_library_name()
 
-return native.load('blink_cmp_fuzzy', native.try_git_commit(project_root))
+return native.load(name, commit)

--- a/lua/blink/cmp/fuzzy/types.lua
+++ b/lua/blink/cmp/fuzzy/types.lua
@@ -1,19 +1,19 @@
 --- @class blink.cmp.FuzzyImplementation
---- @field init_db fun(path: string, use_unsafe_no_lock: boolean)
+--- @field init_db fun(path: string)
 --- @field destroy_db fun()
 --- @field access fun(item: blink.cmp.CompletionItem)
 --- @field get_words fun(text: string): string[]
 --- @field set_provider_items fun(provider_id: string, items: blink.cmp.CompletionItem[])
---- @field fuzzy fun(line: string, cursor_col: number, provider_ids: string[], opts: blink.cmp.FuzzyOptions): number[], number[], number[], boolean[]
---- @field fuzzy_matched_indices fun(line: string, cursor_col: number, haystack: string[], match_suffix: boolean): number[][]
---- @field get_keyword_range fun(line: string, col: number, match_suffix: boolean): number, number
---- @field guess_edit_range fun(item: blink.cmp.CompletionItem, line: string, cursor_col: number, match_suffix: boolean): number, number
+--- @field fuzzy fun(line: string, cursor_col: integer, provider_ids: string[], opts: blink.cmp.FuzzyOptions): integer[], integer[], integer[], boolean[]
+--- @field fuzzy_matched_indices fun(line: string, cursor_col: integer, haystack: string[], match_suffix: boolean): integer[][]
+--- @field get_keyword_range fun(line: string, col: integer, match_suffix: boolean): integer, integer
+--- @field guess_edit_range fun(item: blink.cmp.CompletionItem, line: string, cursor_col: integer, match_suffix: boolean): integer, integer
 
 --- @class blink.cmp.FuzzyOptions
 --- @field match_suffix boolean
---- @field max_typos number
+--- @field max_typos integer
 --- @field use_frecency boolean
 --- @field use_proximity boolean
 --- @field nearby_words string[]
---- @field snippet_score_offset number
+--- @field snippet_score_offset integer
 --- @field sorts? blink.cmp.Sort[]

--- a/lua/blink/cmp/health.lua
+++ b/lua/blink/cmp/health.lua
@@ -67,7 +67,10 @@ function health.report_sources_list(header, provider_ids)
   vim.health.start(header)
   local all_providers = require('blink.cmp.sources.lib').get_all_providers()
   for _, provider_id in ipairs(provider_ids) do
-    vim.health.info(('%s (%s)'):format(provider_id, all_providers[provider_id].config.module))
+    ---@type blink.cmp.SourceProvider
+    ---@diagnostic disable-next-line: undefined-field
+    local source_provider = all_providers[provider_id]
+    vim.health.info(('%s (%s)'):format(provider_id, source_provider.config.module))
   end
 end
 

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -96,7 +96,7 @@ end
 -------- Native Library --------
 
 function cmp.get_repo_root() return native.repo_root end
-
+function cmp.get_library_name() return native.library_name end
 function cmp.library_available() return native:library_available() end
 
 --- Builds the native library if it's not already available

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -1,7 +1,9 @@
 if vim.fn.has('nvim-0.12') == 0 then error('blink.cmp v2 requires nvim 0.12+, consider pinning to v1') end
 
-local success, lib = pcall(require, 'blink.lib')
-if not success then error('blink.cmp v2 requires "saghen/blink.lib" installed via your package manager: ' .. lib) end
+local success, mod = pcall(require, 'blink.lib')
+if not success then error('blink.cmp v2 requires "saghen/blink.lib" installed via your package manager: ' .. mod) end
+---@module "blink.lib"
+local lib = mod
 
 local logger = require('blink.cmp.logger')
 local config = require('blink.cmp.config')
@@ -50,6 +52,7 @@ function cmp.setup(opts)
 
   -- configuration
   opts = opts or {}
+  ---@type blink.cmp.Config
   opts = lib.tbl.copy(opts)
   if opts.cmdline then
     config(lib.tbl.omit(opts.cmdline, { 'enabled', 'keymap' }), { mode = 'cmdline' })
@@ -151,7 +154,7 @@ function cmp.is_documentation_visible() return require('blink.cmp.completion.win
 
 --- @class blink.cmp.ShowOpts
 --- @field providers? string[] List of providers to show
---- @field initial_selected_item_idx? number The index of the item to select initially
+--- @field initial_selected_item_idx? integer The index of the item to select initially
 --- @field callback? fun() Called after the menu is shown
 
 --- Show the completion window
@@ -344,7 +347,7 @@ function cmp.get_context() return require('blink.cmp.completion.list').context e
 function cmp.get_selected_item() return require('blink.cmp.completion.list').get_selected_item() end
 
 --- Gets the currently selected completion item index
---- @return number?
+--- @return integer?
 function cmp.get_selected_item_idx() return require('blink.cmp.completion.list').selected_item_idx end
 
 --- Gets the sorted list of completion items
@@ -377,7 +380,7 @@ function cmp.hide_documentation()
 end
 
 --- Scroll the documentation window up
---- @param count? number
+--- @param count? integer
 --- @return boolean
 function cmp.scroll_documentation_up(count)
   local documentation = require('blink.cmp.completion.windows.documentation')
@@ -387,7 +390,7 @@ function cmp.scroll_documentation_up(count)
 end
 
 --- Scroll the documentation window down
---- @param count? number
+--- @param count? integer
 --- @return boolean
 function cmp.scroll_documentation_down(count)
   local documentation = require('blink.cmp.completion.windows.documentation')
@@ -419,7 +422,7 @@ function cmp.hide_signature()
 end
 
 --- Scroll the signature window up
---- @param count? number
+--- @param count? integer
 --- @return boolean
 function cmp.scroll_signature_up(count)
   local signature = require('blink.cmp.signature.window')
@@ -429,7 +432,7 @@ function cmp.scroll_signature_up(count)
 end
 
 --- Scroll the signature window down
---- @param count? number
+--- @param count? integer
 --- @return boolean
 function cmp.scroll_signature_down(count)
   local signature = require('blink.cmp.signature.window')
@@ -439,7 +442,7 @@ function cmp.scroll_signature_down(count)
 end
 
 --- Check if a snippet is active, optionally filtering by direction
---- @param filter? { direction?: number }
+--- @param filter? { direction?: integer }
 --- @return boolean
 function cmp.snippet_active(filter) return config.snippets.active(filter) end
 

--- a/lua/blink/cmp/keymap/apply.lua
+++ b/lua/blink/cmp/keymap/apply.lua
@@ -71,7 +71,7 @@ local function apply_callback(mode, key, commands, callback)
 end
 
 --- @param mode 'i'|'s'|'c'|'t'
---- @param keys_to_commands table<string, blink.cmp.KeymapCommand[]>
+--- @param keys_to_commands blink.cmp.KeymapList
 local function set_keymaps_for_mode(mode, keys_to_commands, command_filter, filter_fn)
   for key, commands in pairs(keys_to_commands) do
     if not command_filter or command_filter(commands) then
@@ -121,7 +121,7 @@ end
 
 --- Applies the keymaps based on the mode
 --- @param mode blink.cmp.Mode
---- @param keys_to_commands table<string, blink.cmp.KeymapCommand[]>
+--- @param keys_to_commands blink.cmp.KeymapList
 function apply.keymaps(mode, keys_to_commands) keymaps_per_mode[mode](keys_to_commands) end
 
 return apply

--- a/lua/blink/cmp/keymap/fallback.lua
+++ b/lua/blink/cmp/keymap/fallback.lua
@@ -5,6 +5,7 @@ local utils = require('blink.cmp.keymap.utils')
 --- Prepare a single key to feed
 --- @param key string
 --- @param mode? string
+--- @return { key: string, mode: string }[]
 local function single_key(key, mode) return { { key = key, mode = mode or 'n' } } end
 
 --- Build a lhs/mapping index (case-insensitive, normalized)
@@ -14,7 +15,7 @@ local function get_non_blink_keymaps(mappings)
   local index = {}
   for _, mapping in ipairs(mappings) do
     if not utils.is_blink_keymap(mapping) then
-      local lhs = utils.normalize_lhs(mapping.lhs)
+      local lhs = utils.normalize_lhs(assert(mapping.lhs))
       index[lhs] = mapping
     end
   end
@@ -46,7 +47,7 @@ function fallback.wrap(mode, key)
     end
 
     local mapping = buffer_index[normalized_key] or global_index[normalized_key]
-    if mapping then return fallback.run_non_blink_keymap(mapping, key) end
+    if mapping ~= nil then return fallback.run_non_blink_keymap(mapping, key) end
     if not mappings_only then return single_key(key) end
 
     return {}
@@ -91,7 +92,7 @@ function fallback.run_non_blink_keymap(mapping, default_key)
   -- Script mappings (<script>): <Plug>, <SID>, <SNR>, etc.
   if mapping.script == 1 then
     local keys = utils.split_script_rhs(mapping.rhs)
-    return #keys > 0 and keys or single_key(default_key)
+    return keys or single_key(default_key)
   end
 
   -- Remap logic (recursive)

--- a/lua/blink/cmp/keymap/init.lua
+++ b/lua/blink/cmp/keymap/init.lua
@@ -4,15 +4,17 @@ local apply = require('blink.cmp.keymap.apply')
 local presets = require('blink.cmp.keymap.presets')
 local utils = require('blink.cmp.keymap.utils')
 
+--- @alias blink.cmp.KeymapList table<string, blink.cmp.KeymapCommand[] | false>
+---
 --- @class blink.cmp.KeymapContext
 --- @field vim_mode string Vim's current mode (e.g. 'i', 'c', 't')
 --- @field blink_mode blink.cmp.Mode The corresponding blink mode
---- @field bufnr number Buffer number (0 for global cmdline)
+--- @field bufnr integer Buffer number (0 for global cmdline)
 --- @field bufkey string Unique identifier for buffer keymaps
 
 local keymap = {
   bufkey_prefix = 'blink_cmp_keymap_',
-  ---@type table<blink.cmp.Mode, table<string, blink.cmp.KeymapCommand[]>>
+  ---@type table<blink.cmp.Mode, blink.cmp.KeymapList>
   mappings = { default = {}, cmdline = {}, term = {} },
   ---@type table<string, blink.cmp.Mode>
   mode_map = { i = 'default', s = 'default', c = 'cmdline', t = 'term' },
@@ -35,7 +37,7 @@ end
 
 --- Collect buffer keymaps and reapply any missing blink.cmp keymaps
 --- @param ctx blink.cmp.KeymapContext
---- @param expected_mappings table<string, blink.cmp.KeymapCommand[]>
+--- @param expected_mappings blink.cmp.KeymapList
 local function repair_mappings(ctx, expected_mappings)
   local expected_hash = vim.b[ctx.bufnr][ctx.bufkey .. '_hash']
   local current_hash = utils.hash_keymaps(ctx.bufnr, ctx.vim_mode)
@@ -43,7 +45,7 @@ local function repair_mappings(ctx, expected_mappings)
 
   local existing_mappings = {}
   for _, map in ipairs(nvim.buf_get_keymap(ctx.bufnr, ctx.vim_mode)) do
-    if utils.is_blink_keymap(map) then existing_mappings[utils.normalize_lhs(map.lhs)] = true end
+    if utils.is_blink_keymap(map) then existing_mappings[utils.normalize_lhs(assert(map.lhs))] = true end
   end
 
   local missing_mappings = {}
@@ -59,13 +61,13 @@ function keymap.ensure_mappings()
   local ctx = get_keymap_context()
   if not ctx then return end
 
-  ---@type table<string, blink.cmp.KeymapCommand[]>
+  ---@type blink.cmp.KeymapList
   local expected_mappings = vim.b[ctx.bufnr][ctx.bufkey]
   -- If already defined, check and reapply any missing keymaps.
-  if expected_mappings then return repair_mappings(ctx, expected_mappings) end
+  if expected_mappings ~= nil then return repair_mappings(ctx, expected_mappings) end
 
   local mappings = keymap.mappings[ctx.blink_mode]
-  if mappings then
+  if mappings ~= nil then
     apply.keymaps(ctx.blink_mode, mappings)
     vim.b[ctx.bufnr][ctx.bufkey] = mappings
     vim.b[ctx.bufnr][ctx.bufkey .. '_hash'] = utils.hash_keymaps(ctx.bufnr, ctx.vim_mode)
@@ -74,13 +76,16 @@ end
 
 --- @param keymap_config blink.cmp.KeymapConfig
 --- @param mode blink.cmp.Mode
---- @return table<string, blink.cmp.KeymapCommand[]>
+--- @return blink.cmp.KeymapList
 function keymap.get_mappings(keymap_config, mode)
   local mappings = vim.deepcopy(keymap_config)
 
   -- Inherit preset from default, if needed
   if mappings.preset == 'inherit' and mode ~= 'default' then
+    ---@diagnostic disable-next-line: undefined-field
+    ---@type blink.cmp.ConfigStrict
     local snapshot = config.snapshot()
+
     mappings = vim.tbl_deep_extend('force', snapshot.keymap, mappings)
     mappings.preset = snapshot.keymap.preset
   end
@@ -94,29 +99,35 @@ function keymap.get_mappings(keymap_config, mode)
     end
   end
 
+  local keymaps = mappings
+  ---@cast keymaps blink.cmp.KeymapList
+
   -- Handle preset
   if mappings.preset then
     local preset_keymap = presets.get(mappings.preset)
     -- Remove 'preset' key from opts to prevent it from being treated as a keymap
-    mappings.preset = nil
-    mappings = utils.merge_mappings(preset_keymap, mappings)
+    keymaps.preset = nil
+    keymaps = utils.merge_mappings(preset_keymap, keymaps)
   end
 
   -- Remove keys explicitly disabled by user (set to false or no commands)
-  for key, commands in pairs(mappings) do
-    if commands == false or #commands == 0 then mappings[key] = nil end
+  for key, commands in pairs(keymaps) do
+    if commands == false or #commands == 0 then keymaps[key] = nil end
   end
 
-  return mappings --[[@as table<string, blink.cmp.KeymapCommand[]>]]
+  return keymaps
 end
 
 function keymap.setup()
-  local config = config.snapshot()
+  ---@diagnostic disable-next-line: undefined-field
+  ---@type blink.cmp.ConfigStrict
+  local cfg = config.snapshot()
+
   -- Load keymaps per mode
   keymap.mappings = {
-    default = keymap.get_mappings(config.keymap, 'default'),
-    cmdline = keymap.get_mappings(config.cmdline.keymap, 'cmdline'),
-    term = keymap.get_mappings(config.term.keymap, 'term'),
+    default = keymap.get_mappings(cfg.keymap, 'default'),
+    cmdline = keymap.get_mappings(cfg.cmdline.keymap, 'cmdline'),
+    term = keymap.get_mappings(cfg.term.keymap, 'term'),
   }
 
   -- Ensure blink.cmp keymaps are (still) applied

--- a/lua/blink/cmp/keymap/utils.lua
+++ b/lua/blink/cmp/keymap/utils.lua
@@ -1,10 +1,12 @@
 local nvim = require('blink.lib.nvim')
+-- TODO: Move this constant elsewhere
+local PROJECT_NAME = 'blink.cmp'
 
 local utils = {}
 
 --- @param mapping vim.api.keyset.get_keymap
 --- @return boolean?
-function utils.is_blink_keymap(mapping) return mapping.desc and mapping.desc:match('^blink%.cmp') ~= nil end
+function utils.is_blink_keymap(mapping) return mapping.desc and mapping.desc:match('^' .. vim.pesc(PROJECT_NAME)) ~= nil end
 
 --- @param keys string
 --- @param mode string
@@ -17,13 +19,13 @@ end
 --- @param mapping vim.api.keyset.get_keymap
 --- @return boolean, string?
 function utils.eval_vlua_expr(mapping)
-  local expr = mapping.rhs:gsub('^v:lua%.', '')
+  local expr = assert(mapping.rhs):gsub('^v:lua%.', '')
   local fn_path = expr:match('^(.-)%(')
   if fn_path and not fn_path:find('[^%w_%.]') then
     local fn = vim.tbl_get(_G, unpack(vim.split(fn_path, '.', { plain = true })))
-    if type(fn) == 'function' then return pcall(fn, mapping.lhsraw) end
+    if type(fn) == 'function' then return (pcall(fn, mapping.lhsraw)) end
   end
-  return pcall(vim.fn.luaeval, expr)
+  return (pcall(vim.fn.luaeval, expr))
 end
 
 --- nvim_buf_get_keymap translates LHS for leaders and space by their literal
@@ -31,8 +33,6 @@ end
 --- Mimic that behavior to ease the comparison with our mappings.
 --- @param lhs string
 function utils.normalize_lhs(lhs)
-  if not lhs then return lhs end
-
   -- Normalize Alt to Meta
   lhs = lhs:gsub('<[aAM]%-', '<m-')
   -- Convert <m-s-x> to <m-X>
@@ -41,7 +41,7 @@ function utils.normalize_lhs(lhs)
   -- when it would change the keycode (e.g. <m-H> = <m-S-h> != <m-h>)
   lhs = lhs:gsub('<([^>]+)>', function(inner)
     local prefix, key = inner:match('^(.*-)([^-]+)$')
-    if prefix then
+    if prefix and key then
       local original = '<' .. inner .. '>'
       local lowered = '<' .. prefix:lower() .. key:lower() .. '>'
       -- If lowercasing changes the keycode, preserve the key case
@@ -78,8 +78,10 @@ function utils.normalize_leader(lhs)
 end
 
 --- @param rhs string
+--- @return { key: string, mode: string }[]?
 function utils.split_script_rhs(rhs)
-  local out = {}
+  ---@type { key: string, mode: string }[]
+  local keys = {}
   local i = 1
 
   while i <= #rhs do
@@ -95,11 +97,11 @@ function utils.split_script_rhs(rhs)
     local mode = (chunk:match('^<SNR>') or chunk:match('^<SID>') or chunk:match('^<Plug>')) and 'm' -- internal/script
       or 'n' -- normal/literal
 
-    table.insert(out, { key = chunk, mode = mode })
+    table.insert(keys, { key = chunk, mode = mode })
     i = i + #chunk
   end
 
-  return out
+  return #keys > 0 and keys or nil
 end
 
 --- Generates the keymap description based on commands
@@ -115,20 +117,20 @@ function utils.get_description(commands)
     end
   end
 
-  return 'blink.cmp: ' .. (#parts == 0 and 'Default Behavior' or table.concat(parts, ', '))
+  return PROJECT_NAME .. ': ' .. (#parts == 0 and 'Default Behavior' or table.concat(parts, ', '))
 end
 
 --- Merge the existing keymap with the new keymaps, newer overwriting the existing.
---- @param existing_mappings table<string, blink.cmp.KeymapCommand[] | false>
---- @param new_mappings table<string, blink.cmp.KeymapCommand[] | false>
---- @return table<string, blink.cmp.KeymapCommand[] | false>
+--- @param existing_mappings blink.cmp.KeymapList
+--- @param new_mappings blink.cmp.KeymapList
+--- @return blink.cmp.KeymapList
 function utils.merge_mappings(existing_mappings, new_mappings)
-  local merged = {}
+  local merged, existing = {}, {}
+
   for key, commands in pairs(existing_mappings or {}) do
     merged[utils.normalize_leader(key)] = commands
   end
 
-  local existing = {}
   for key in pairs(existing_mappings or {}) do
     local k = utils.normalize_leader(key)
     existing[k] = k
@@ -138,7 +140,7 @@ function utils.merge_mappings(existing_mappings, new_mappings)
     merged[existing[key] or utils.normalize_leader(key)] = commands
   end
 
-  return merged
+  return merged --[[@as blink.cmp.KeymapList]]
 end
 
 --- Compute a fingerprint of the currently registered blink.cmp keymaps based on
@@ -149,7 +151,7 @@ end
 function utils.hash_keymaps(bufnr, vim_mode)
   local lhs = {}
   for _, map in ipairs(nvim.buf_get_keymap(bufnr, vim_mode)) do
-    if utils.is_blink_keymap(map) then lhs[#lhs + 1] = utils.normalize_lhs(map.lhs) end
+    if utils.is_blink_keymap(map) then lhs[#lhs + 1] = utils.normalize_lhs(assert(map.lhs)) end
   end
   table.sort(lhs)
 

--- a/lua/blink/cmp/lib/buffer_events.lua
+++ b/lua/blink/cmp/lib/buffer_events.lua
@@ -23,10 +23,10 @@ local nvim = require('blink.lib.nvim')
 --- @field show_in_snippet boolean
 
 --- @class blink.cmp.BufferEventsListener
---- @field on_char_added fun(char: string, is_ignored: boolean)
---- @field on_cursor_moved fun(event: 'CursorMoved' | 'InsertEnter', is_ignored: boolean, is_backspace: boolean, last_event: 'accept'|'enter'|nil)
---- @field on_insert_leave fun()
---- @field on_complete_changed fun()
+--- @field on_char_added? fun(char: string, is_ignored: boolean)
+--- @field on_cursor_moved? fun(event: 'CursorMoved' | 'InsertEnter', is_ignored: boolean, is_backspace: boolean, last_event: 'accept'|'enter'|nil)
+--- @field on_insert_leave? fun()
+--- @field on_complete_changed? fun()
 
 --- @type blink.cmp.BufferEvents
 local buffer_events = {}

--- a/lua/blink/cmp/lib/buffer_events.lua
+++ b/lua/blink/cmp/lib/buffer_events.lua
@@ -3,6 +3,7 @@
 --- Unlike in regular neovim, ctrl + c and buffer switching will trigger "insert leave"
 
 local nvim = require('blink.lib.nvim')
+local snippet = require('blink.cmp.config').snippets
 
 --- @class blink.cmp.BufferEvents
 --- @field has_context fun(): boolean
@@ -10,12 +11,13 @@ local nvim = require('blink.lib.nvim')
 --- @field ignore_next_text_changed boolean
 --- @field ignore_next_cursor_moved boolean
 --- @field last_char string
---- @field textchangedi_id number
+--- @field textchangedi_id integer
 --- @field backspace_keycodes table<string, boolean>
+--- @field hide_in_snippet fun(): boolean
 ---
 --- @field new fun(opts: blink.cmp.BufferEventsOptions): blink.cmp.BufferEvents
 --- @field listen fun(self: blink.cmp.BufferEvents, opts: blink.cmp.BufferEventsListener)
---- @field resubscribe fun(self: blink.cmp.BufferEvents, opts: blink.cmp.BufferEventsListener) Effectively ensures that our autocmd listeners run last, after other registered listeners
+--- @field resubscribe fun(self: blink.cmp.BufferEvents, opts: blink.cmp.BufferEventsListener) Ensures that our autocmd listeners run last, after other registered listeners
 --- @field suppress_events_for_callback fun(self: blink.cmp.BufferEvents, cb: fun())
 
 --- @class blink.cmp.BufferEventsOptions
@@ -24,11 +26,12 @@ local nvim = require('blink.lib.nvim')
 
 --- @class blink.cmp.BufferEventsListener
 --- @field on_char_added? fun(char: string, is_ignored: boolean)
---- @field on_cursor_moved? fun(event: 'CursorMoved' | 'InsertEnter', is_ignored: boolean, is_backspace: boolean, last_event: 'accept'|'enter'|nil)
+--- @field on_cursor_moved? fun(event: 'CursorMoved' | 'CursorMovedI' | 'InsertEnter', is_ignored: boolean, is_backspace: boolean, last_event: 'accept' | 'enter' | nil)
 --- @field on_insert_leave? fun()
 --- @field on_complete_changed? fun()
 
 --- @type blink.cmp.BufferEvents
+--- @diagnostic disable-next-line: missing-fields
 local buffer_events = {}
 
 function buffer_events.new(opts)
@@ -48,10 +51,11 @@ function buffer_events.new(opts)
   }, { __index = buffer_events }) --[[@as blink.cmp.BufferEvents]]
 end
 
-local function make_char_added(self, snippet, on_char_added)
+--- @param self blink.cmp.BufferEvents
+--- @param on_char_added fun(char: string, is_ignored: boolean)
+local function make_char_added(self, on_char_added)
   return function()
-    if not require('blink.cmp').is_enabled() then return end
-    if snippet.active() and not self.show_in_snippet and not self.has_context() then return end
+    if not require('blink.cmp').is_enabled() or self:hide_in_snippet() then return end
 
     local is_ignored = self.ignore_next_text_changed
     self.ignore_next_text_changed = false
@@ -65,7 +69,9 @@ local function make_char_added(self, snippet, on_char_added)
   end
 end
 
-local function make_cursor_moved(self, snippet, on_cursor_moved)
+--- @param self blink.cmp.BufferEvents
+--- @param on_cursor_moved fun(event: 'CursorMoved' | 'CursorMovedI' | 'InsertEnter', is_ignored: boolean, is_backspace: boolean, last_event: 'accept' | 'enter' | nil)
+local function make_cursor_moved(self, on_cursor_moved)
   --- @type 'accept' | 'enter' | nil
   local last_event = nil
 
@@ -87,14 +93,14 @@ local function make_cursor_moved(self, snippet, on_cursor_moved)
   })
 
   return function(ev)
+    --- @cast ev vim.api.keyset.create_autocmd.callback_args
+    --- @cast ev.event 'CursorMoved' | 'CursorMovedI' | 'InsertEnter'
+
+    local in_snippet_context = self.has_context() and snippet.active()
+
     -- only fire a CursorMoved event (notable not CursorMovedI)
     -- when jumping between tab stops in a snippet while showing the menu
-    if
-      ev.event == 'CursorMoved'
-      and (nvim.get_mode().mode ~= 'v' or not self.has_context() or not snippet.active())
-    then
-      return
-    end
+    if ev.event == 'CursorMoved' and (nvim.get_mode().mode ~= 'v' or not in_snippet_context) then return end
 
     local is_cursor_moved = ev.event == 'CursorMoved' or ev.event == 'CursorMovedI'
     local is_ignored = is_cursor_moved and self.ignore_next_cursor_moved
@@ -118,14 +124,14 @@ local function make_cursor_moved(self, snippet, on_cursor_moved)
 
     -- characters added so let textchanged handle it
     if self.last_char ~= '' then return end
-
-    if not require('blink.cmp').is_enabled() then return end
-    if not self.show_in_snippet and not self.has_context() and snippet.active() then return end
+    if not require('blink.cmp').is_enabled() or self:hide_in_snippet() then return end
 
     on_cursor_moved(is_cursor_moved and 'CursorMoved' or ev.event, is_ignored, is_backspace, tmp_last_event)
   end
 end
 
+--- @param self blink.cmp.BufferEvents
+--- @param on_insert_leave fun()
 local function make_insert_leave(self, on_insert_leave)
   return function()
     -- HACK: when using vim.snippet.expand, the mode switches from insert -> normal -> visual -> select
@@ -141,45 +147,50 @@ local function make_insert_leave(self, on_insert_leave)
   end
 end
 
---- Normalizes the autocmds + ctrl+c into a common api and handles ignored events
+--- Normalizes the autocmds into a common api and handles ignored events
 function buffer_events:listen(opts)
-  local snippet = require('blink.cmp.config').snippets
-
   nvim.create_autocmd('InsertCharPre', {
     callback = function()
-      if snippet.active() and not self.show_in_snippet and not self.has_context() then return end
+      if self:hide_in_snippet() then return end
+
       -- FIXME: vim.v.char can be an escape code such as <95> in the case of <F2>. This breaks downstream
       -- since this isn't a valid utf-8 string. How can we identify and ignore these?
       self.last_char = vim.v.char
     end,
   })
 
-  self.textchangedi_id = nvim.create_autocmd('TextChangedI', {
-    callback = make_char_added(self, snippet, opts.on_char_added),
-  })
-
-  nvim.create_autocmd({ 'CursorMoved', 'CursorMovedI', 'InsertEnter' }, {
-    callback = make_cursor_moved(self, snippet, opts.on_cursor_moved),
-  })
-
   -- definitely leaving the context
-  nvim.create_autocmd({ 'ModeChanged', 'BufLeave' }, {
-    callback = make_insert_leave(self, opts.on_insert_leave),
-  })
+  if opts.on_char_added then
+    self.textchangedi_id = nvim.create_autocmd('TextChangedI', {
+      callback = make_char_added(self, opts.on_char_added),
+    })
+  end
 
-  -- ctrl+c doesn't trigger InsertLeave so handle it separately
-  local ctrl_c = vim.keycode('<C-c>')
-  vim.on_key(function(key)
-    if key == ctrl_c then
-      vim.schedule(function()
-        local mode = nvim.get_mode().mode
-        if mode ~= 'i' then
-          self.last_char = ''
-          opts.on_insert_leave()
-        end
-      end)
-    end
-  end)
+  if opts.on_cursor_moved then
+    nvim.create_autocmd({ 'CursorMoved', 'CursorMovedI', 'InsertEnter' }, {
+      callback = make_cursor_moved(self, opts.on_cursor_moved),
+    })
+  end
+
+  if opts.on_insert_leave then
+    nvim.create_autocmd({ 'ModeChanged', 'BufLeave' }, {
+      callback = make_insert_leave(self, opts.on_insert_leave),
+    })
+
+    -- ctrl+c doesn't trigger InsertLeave so handle it separately
+    local ctrl_c = vim.keycode('<C-c>')
+    vim.on_key(function(key)
+      if key == ctrl_c then
+        vim.schedule(function()
+          local mode = nvim.get_mode().mode
+          if mode ~= 'i' then
+            self.last_char = ''
+            opts.on_insert_leave()
+          end
+        end)
+      end
+    end)
+  end
 
   if opts.on_complete_changed then
     nvim.create_autocmd('CompleteChanged', {
@@ -191,12 +202,11 @@ end
 --- Effectively ensures that our autocmd listeners run last, after other registered listeners
 --- HACK: Ideally, we would have some way to ensure that we always run after other listeners
 function buffer_events:resubscribe(opts)
-  if self.textchangedi_id == -1 then return end
+  if not opts.on_char_added or self.textchangedi_id == -1 then return end
 
-  local snippet = require('blink.cmp.config').snippets
   nvim.del_autocmd(self.textchangedi_id)
   self.textchangedi_id = nvim.create_autocmd('TextChangedI', {
-    callback = make_char_added(self, snippet, opts.on_char_added),
+    callback = make_char_added(self, opts.on_char_added),
   })
 end
 
@@ -227,5 +237,7 @@ function buffer_events:suppress_events_for_callback(cb)
   self.ignore_next_cursor_moved = is_insert_mode
   if not cursor_moved then vim.defer_fn(function() self.ignore_next_cursor_moved = false end, 10) end
 end
+
+function buffer_events:hide_in_snippet() return not self.show_in_snippet and not self.has_context() and snippet.active() end
 
 return buffer_events

--- a/lua/blink/cmp/lib/cmdline_events.lua
+++ b/lua/blink/cmp/lib/cmdline_events.lua
@@ -29,7 +29,8 @@ function cmdline_events:listen(opts)
   -- TextChanged
   local on_changed = function(key) opts.on_char_added(key, false) end
 
-  local last_move_time, pending_key
+  local last_move_time ---@type number?
+  local pending_key ---@type string?
   local is_change_queued = false
   vim.on_key(function(raw_key, escaped_key)
     if nvim.get_mode().mode ~= 'c' then return end
@@ -61,9 +62,9 @@ function cmdline_events:listen(opts)
   local burst_threshold_ms = 2
   local function is_burst_move()
     local current_time = vim.uv.hrtime() / 1e6
-    local is_burst = last_move_time and (current_time - last_move_time) < burst_threshold_ms
+    local is_burst = last_move_time and (current_time - last_move_time) < burst_threshold_ms or false
     last_move_time = current_time
-    return is_burst or false
+    return is_burst
   end
 
   -- CursorMoved

--- a/lua/blink/cmp/lib/event_emitter.lua
+++ b/lua/blink/cmp/lib/event_emitter.lua
@@ -1,4 +1,4 @@
---- @class blink.cmp.EventEmitter<T> : { event: string, autocmd?: string, listeners: table<fun(data: T)>, new: ( fun(event: string, autocmd: string): blink.cmp.EventEmitter ), on: ( fun(self: blink.cmp.EventEmitter, callback: fun(data: T)) ), off: ( fun(self: blink.cmp.EventEmitter, callback: fun(data: T)) ), emit: ( fun(self: blink.cmp.EventEmitter, data?: table) ) };
+--- @class blink.cmp.EventEmitter<T> : { event: string, autocmd?: string, listeners: table<fun(data: T)>, new: ( fun(event: string, autocmd: string): blink.cmp.EventEmitter<T>), on: ( fun(self: blink.cmp.EventEmitter<T>, callback: fun(data: T)) ), off: ( fun(self: blink.cmp.EventEmitter<T>, callback: fun(data: T)) ), emit: ( fun(self: blink.cmp.EventEmitter<T>, data?: table) ) };
 --- TODO: is there a better syntax for this?
 
 local event_emitter = {}

--- a/lua/blink/cmp/lib/term_events.lua
+++ b/lua/blink/cmp/lib/term_events.lua
@@ -89,6 +89,7 @@ function term_events:listen(opts)
   nvim.create_autocmd('TermRequest', {
     callback = function(args)
       if string.match(args.data.sequence, '^\027]133;B') then
+        --- @type integer, integer
         local row, col = unpack(args.data.cursor)
         pcall(nvim.buf_set_extmark, args.buf, term_command_start_ns, row - 1, col, {})
       end

--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -109,7 +109,7 @@ end
 --- Grabbed from vim.lsp.utils. Converts an offset_encoding to byte offset
 --- @param position lsp.Position
 --- @param offset_encoding? 'utf-8'|'utf-16'|'utf-32'
---- @return number
+--- @return integer
 local function get_line_byte_from_position(position, offset_encoding)
   local bufnr = nvim.get_current_buf()
   local col = position.character
@@ -162,8 +162,8 @@ end
 --- from when the items were fetched versus the current.
 --- HACK: is there a better way?
 --- @param text_edit lsp.TextEdit
---- @param old_cursor_col number Position of the cursor when the text edit was created
---- @param new_cursor_col number New position of the cursor
+--- @param old_cursor_col integer Position of the cursor when the text edit was created
+--- @param new_cursor_col integer New position of the cursor
 --- @return lsp.TextEdit
 function text_edits.compensate_for_cursor_movement(text_edit, old_cursor_col, new_cursor_col)
   text_edit = vim.deepcopy(text_edit)
@@ -179,8 +179,12 @@ function text_edits.offset_encoding_from_item(item)
   return client ~= nil and client.offset_encoding or 'utf-8'
 end
 
+--- @param text_edit lsp.TextEdit
+--- @param offset_encoding "utf-8"|"utf-16"|"utf-32"
+--- @return lsp.TextEdit
 function text_edits.to_utf_8(text_edit, offset_encoding)
   if offset_encoding == 'utf-8' then return text_edit end
+
   text_edit = vim.deepcopy(text_edit)
   text_edit.range.start.character = get_line_byte_from_position(text_edit.range.start, offset_encoding)
   text_edit.range['end'].character = get_line_byte_from_position(text_edit.range['end'], offset_encoding)
@@ -188,12 +192,13 @@ function text_edits.to_utf_8(text_edit, offset_encoding)
 end
 
 --- Uses the keyword_regex to guess the text edit ranges
+--- TODO: Doesn't work when the item contains characters not included in the context regex
 --- @param item blink.cmp.CompletionItem
---- TODO: doesnt work when the item contains characters not included in the context regex
+--- @return lsp.TextEdit
 function text_edits.guess(item)
   local word = (lib.is_not_nil(item.insertText) and item.insertText)
     or (lib.is_not_nil(item.label) and item.label)
-    or nil
+    or ''
 
   local start_col, end_col = require('blink.cmp.fuzzy').guess_edit_range(
     item,
@@ -239,12 +244,13 @@ end
 --- This means that the end position will be the range _before_ applying the edit.
 --- This function gets the end position of the range _after_ applying the edit.
 --- This may be used for placing the cursor after applying the edit.
+--- Returns (1, 0) indexed line and column
 ---
 --- TODO: write tests cases, there are many uncommon cases it doesn't handle
 ---
 --- @param text_edit lsp.TextEdit
 --- @param additional_text_edits lsp.TextEdit[]
---- @return number[] (1, 0) indexed line and column
+--- @return blink.cmp.CursorPos
 function text_edits.get_apply_end_position(text_edit, additional_text_edits)
   -- Calculate the end position of the range, ignoring the additional text edits
   local lines = vim.split(text_edit.newText, '\n')
@@ -326,6 +332,7 @@ nvim.set_keymap('v', dot_repeat_hack_name, '', opts)
 nvim.set_keymap('c', dot_repeat_hack_name, '', opts)
 nvim.set_keymap('t', dot_repeat_hack_name, '', opts)
 
+---@type integer?
 local dot_repeat_buffer = nil
 local function get_dot_repeat_buffer()
   if dot_repeat_buffer == nil or not nvim.buf_is_valid(dot_repeat_buffer) then
@@ -379,7 +386,7 @@ function text_edits.write_to_dot_repeat(text_edit)
       local saved_completeopt = vim.opt.completeopt
       local saved_shortmess = vim.o.shortmess
       vim.opt.completeopt = ''
-      if not vim.o.shortmess:match('c') then vim.o.shortmess = vim.o.shortmess .. 'c' end
+      if not saved_shortmess:match('c') then vim.o.shortmess = vim.o.shortmess .. 'c' end
       vim.fn.complete(1, { '_' .. chars_to_insert })
       vim.opt.completeopt = saved_completeopt
       vim.o.shortmess = saved_shortmess
@@ -395,7 +402,7 @@ function text_edits.write_to_dot_repeat(text_edit)
 end
 
 --- Moves the cursor while preserving dot repeat
---- @param amount number Number of characters to move the cursor by, can be negative to move left
+--- @param amount integer Number of characters to move the cursor by, can be negative to move left
 function text_edits.move_cursor_in_dot_repeat(amount)
   if amount == 0 then return end
 

--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -127,29 +127,35 @@ end
 --- @param item blink.cmp.CompletionItem
 --- @return lsp.TextEdit
 function text_edits.get_from_item(item)
-  local text_edit = vim.deepcopy(item.textEdit)
-
   -- Guess the text edit if the item doesn't define it
-  if text_edit == nil then return text_edits.guess(item) end
+  if not item.textEdit then return text_edits.guess(item) end
+
+  local item_text_edit = vim.deepcopy(item.textEdit)
 
   -- FIXME: temporarily convert insertReplaceEdit to regular textEdit
-  if text_edit.range == nil then
-    if config.completion.keyword.range == 'full' and text_edit.replace ~= nil then
-      text_edit.range = text_edit.replace
+  local range ---@type lsp.Range
+  if item_text_edit.range == nil then
+    --- @cast item_text_edit lsp.InsertReplaceEdit
+    if config.completion.keyword.range == 'full' and item_text_edit.replace ~= nil then
+      range = item_text_edit.replace
     else
-      text_edit.range = text_edit.insert or text_edit.replace
+      range = item_text_edit.insert or item_text_edit.replace
     end
   end
-  text_edit.insert = nil
-  text_edit.replace = nil
-  --- @cast text_edit lsp.TextEdit
 
-  local offset_encoding = text_edits.offset_encoding_from_item(item)
+  ---@type lsp.TextEdit
+  local text_edit = {
+    newText = item_text_edit.newText,
+    range = range or item_text_edit.range,
+  }
+  assert(text_edit.range ~= nil, 'Invalid text edit: missing range')
+
   text_edit = text_edits.compensate_for_cursor_movement(text_edit, item.cursor_column, context.get_cursor()[2])
 
   -- convert the offset encoding to utf-8
   -- TODO: we have to do this last because it applies a max on the position based on the length of the line
   -- so it would break the offset code when removing characters at the end of the line
+  local offset_encoding = text_edits.offset_encoding_from_item(item)
   text_edit = text_edits.to_utf_8(text_edit, offset_encoding)
 
   text_edit.range = text_edits.clamp_range_to_bounds(text_edit.range)

--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -185,12 +185,10 @@ end
 --- @param item blink.cmp.CompletionItem
 --- @return "utf-8"|"utf-16"|"utf-32"
 function text_edits.offset_encoding_from_item(item)
-  if item.client_id then
-    local client = vim.lsp.get_client_by_id(item.client_id)
-    return client ~= nil and client.offset_encoding or 'utf-8'
-  end
+  if not item.client_id then return 'utf-8' end
 
-  return 'utf-8'
+  local client = vim.lsp.get_client_by_id(item.client_id)
+  return client ~= nil and client.offset_encoding or 'utf-8'
 end
 
 --- @param text_edit lsp.TextEdit

--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -69,6 +69,7 @@ end
 
 --- Gets the range for undoing an applied text edit
 --- @param text_edit lsp.TextEdit
+--- @return lsp.Range
 function text_edits.get_undo_range(text_edit)
   text_edit = vim.deepcopy(text_edit)
   local lines = vim.split(text_edit.newText, '\n')
@@ -119,6 +120,7 @@ local function get_line_byte_from_position(position, offset_encoding)
 
   local line = nvim.buf_get_lines(bufnr, position.line, position.line + 1, false)[1] or ''
   col = vim.str_byteindex(line, offset_encoding or 'utf-16', col, false) or 0
+
   return math.min(col, #line)
 end
 
@@ -180,9 +182,15 @@ function text_edits.compensate_for_cursor_movement(text_edit, old_cursor_col, ne
   return text_edit
 end
 
+--- @param item blink.cmp.CompletionItem
+--- @return "utf-8"|"utf-16"|"utf-32"
 function text_edits.offset_encoding_from_item(item)
-  local client = vim.lsp.get_client_by_id(item.client_id)
-  return client ~= nil and client.offset_encoding or 'utf-8'
+  if item.client_id then
+    local client = vim.lsp.get_client_by_id(item.client_id)
+    return client ~= nil and client.offset_encoding or 'utf-8'
+  end
+
+  return 'utf-8'
 end
 
 --- @param text_edit lsp.TextEdit

--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -1,9 +1,11 @@
+local lib = require('blink.lib')
+
 local utils = {}
 
-function utils.to_string_or_empty(v) return (utils.is_not_nil(v) and type(v) == 'string') and v or '' end
+function utils.to_string_or_empty(v) return (lib.is_not_nil(v) and type(v) == 'string') and v or '' end
 
 function utils.schedule_if_needed(fn)
-  if vim.in_fast_event() then
+  if vim.in_fast_event() == true then
     vim.schedule(fn)
   else
     fn()
@@ -59,8 +61,10 @@ end
 --- @return T
 function utils.defer_neovide_redraw(fn)
   -- don't do anything special when not running inside neovide
+  ---@diagnostic disable-next-line: undefined-global
   if not _G.neovide or not neovide.enable_redraw or not neovide.disable_redraw then return fn() end
 
+  ---@diagnostic disable-next-line: undefined-global
   neovide.disable_redraw()
 
   local success, result = pcall(fn)
@@ -68,6 +72,7 @@ function utils.defer_neovide_redraw(fn)
   -- make sure that the screen is updated and the mouse cursor returned to the right position before re-enabling redrawing
   pcall(vim.api.nvim__redraw, { cursor = true, flush = true })
 
+  ---@diagnostic disable-next-line: undefined-global
   neovide.enable_redraw()
 
   if not success then error(result) end

--- a/lua/blink/cmp/lib/window/cursor_line.lua
+++ b/lua/blink/cmp/lib/window/cursor_line.lua
@@ -7,12 +7,12 @@ local nvim = require('blink.lib.nvim')
 --- This behavior is generally undesirable, so we instead draw the background above all highlights.
 --- @class blink.cmp.CursorLine
 --- @field name string
---- @field priority number
---- @field ns number
+--- @field priority integer
+--- @field ns integer
 local cursor_line = {}
 
 --- @param name string
---- @param priority number Priority of the background highlight for the cursorline, defaults to 10000. Setting this to 0 will render it below other highlights
+--- @param priority? integer Priority of the background highlight for the cursorline, defaults to 10000. Setting this to 0 will render it below other highlights
 --- @return blink.cmp.CursorLine
 function cursor_line.new(name, priority)
   local self = setmetatable({}, { __index = cursor_line })
@@ -22,7 +22,7 @@ function cursor_line.new(name, priority)
   return self
 end
 
---- @param win number
+--- @param win integer
 function cursor_line:update(win)
   if not nvim.win_is_valid(win) then return end
 

--- a/lua/blink/cmp/lib/window/docs.lua
+++ b/lua/blink/cmp/lib/window/docs.lua
@@ -5,17 +5,17 @@ local highlight_ns = require('blink.cmp.config').appearance.highlight_ns
 local docs = {}
 
 --- @class blink.cmp.RenderDetailAndDocumentationOpts
---- @field bufnr number
+--- @field bufnr integer
 --- @field detail? string|string[]
 --- @field documentation? lsp.MarkupContent | string
---- @field max_width number
+--- @field max_width integer
 --- @field use_treesitter_highlighting boolean?
 
 --- @class blink.cmp.RenderDetailAndDocumentationOptsPartial
---- @field bufnr? number
+--- @field bufnr? integer
 --- @field detail? string
 --- @field documentation? lsp.MarkupContent | string
---- @field max_width? number
+--- @field max_width? integer
 --- @field use_treesitter_highlighting boolean?
 
 --- @param opts blink.cmp.RenderDetailAndDocumentationOpts

--- a/lua/blink/cmp/lib/window/docs.lua
+++ b/lua/blink/cmp/lib/window/docs.lua
@@ -6,25 +6,29 @@ local docs = {}
 
 --- @class blink.cmp.RenderDetailAndDocumentationOpts
 --- @field bufnr integer
---- @field detail? string|string[]
+--- @field detail? string | string[]
 --- @field documentation? lsp.MarkupContent | string
 --- @field max_width integer
---- @field use_treesitter_highlighting boolean?
+--- @field use_treesitter_highlighting? boolean
 
 --- @class blink.cmp.RenderDetailAndDocumentationOptsPartial
 --- @field bufnr? integer
 --- @field detail? string
 --- @field documentation? lsp.MarkupContent | string
 --- @field max_width? integer
---- @field use_treesitter_highlighting boolean?
+--- @field use_treesitter_highlighting? boolean
 
 --- @param opts blink.cmp.RenderDetailAndDocumentationOpts
 function docs.render_detail_and_documentation(opts)
+  ---@type string[]
   local detail_lines = {}
   local details = lib.is_not_nil(opts.detail) and (type(opts.detail) == 'string' and { opts.detail } or opts.detail)
     or {}
   --- @cast details string[]
+
   details = lib.list.dedup(details)
+  --- @cast details string[]
+
   for _, v in ipairs(details) do
     vim.list_extend(detail_lines, docs.split_lines(v))
   end
@@ -36,8 +40,7 @@ function docs.render_detail_and_documentation(opts)
     vim.lsp.util.convert_input_to_markdown_lines(doc, doc_lines)
   end
 
-  ---@type string[]
-  local combined_lines = vim.list_extend({}, detail_lines)
+  local combined_lines = vim.list_extend({} --[[@as string[] ]], detail_lines)
 
   -- add a blank line for the --- separator
   local doc_already_has_separator = #doc_lines > 1 and (doc_lines[1] == '---' or doc_lines[1] == '***')
@@ -72,12 +75,12 @@ function docs.render_detail_and_documentation(opts)
 end
 
 --- Highlights the given range with treesitter with the given filetype
---- @param bufnr number
---- @param filetype string
---- @param start_line number
---- @param end_line number
 --- TODO: fallback to regex highlighting if treesitter fails
 --- TODO: only render what's visible
+--- @param bufnr integer
+--- @param filetype string
+--- @param start_line integer
+--- @param end_line integer
 function docs.highlight_with_treesitter(bufnr, filetype, start_line, end_line)
   local Range = require('vim.treesitter._range')
   local treesitter_priority = vim.hl.priorities.treesitter
@@ -104,14 +107,15 @@ function docs.highlight_with_treesitter(bufnr, filetype, start_line, end_line)
       local capture, node, metadata, _ = iter(line)
       if capture == nil then break end
 
+      ---@type Range
       local range = { root_end_row + 1, 0, root_end_row + 1, 0 }
-      if node then range = vim.treesitter.get_range(node, bufnr, metadata and metadata[capture]) end
+      if node ~= nil then range = vim.treesitter.get_range(node, bufnr, metadata and metadata[capture]) end
       local start_row, start_col, end_row, end_col = Range.unpack4(range)
 
-      if capture then
+      if capture ~= nil then
         local name = highlighter_query.captures[capture]
         local hl = 0
-        if not vim.startswith(name, '_') then hl = nvim.get_hl_id_by_name('@' .. name .. '.' .. lang) end
+        if name and not vim.startswith(name, '_') then hl = nvim.get_hl_id_by_name('@' .. name .. '.' .. lang) end
 
         -- The "priority" attribute can be set at the pattern level or on a particular capture
         local priority = (
@@ -129,7 +133,7 @@ function docs.highlight_with_treesitter(bufnr, filetype, start_line, end_line)
             hl_group = hl,
             priority = priority,
             conceal = conceal,
-          })
+          } --[[@as vim.api.keyset.set_extmark]])
         end
       end
 
@@ -138,11 +142,15 @@ function docs.highlight_with_treesitter(bufnr, filetype, start_line, end_line)
   end)
 end
 
+--- @param text string
+--- @return string[]
 function docs.split_lines(text)
+  --- @type string[]
   local lines = {}
   for s in text:gmatch('[^\r\n]+') do
     table.insert(lines, s)
   end
+
   return lines
 end
 

--- a/lua/blink/cmp/lib/window/docs.lua
+++ b/lua/blink/cmp/lib/window/docs.lua
@@ -34,9 +34,10 @@ function docs.render_detail_and_documentation(opts)
   end
 
   local doc_lines = {}
-  if type(opts.documentation) == 'string' or type(opts.documentation) == 'table' then
-    local doc = opts.documentation
-    if type(opts.documentation) == 'string' then doc = { kind = 'plaintext', value = opts.documentation } end
+  local doc = opts.documentation
+  if type(doc) == 'string' then
+    vim.lsp.util.convert_input_to_markdown_lines({ kind = 'plaintext', value = doc }, doc_lines)
+  elseif type(doc) == 'table' then
     vim.lsp.util.convert_input_to_markdown_lines(doc, doc_lines)
   end
 

--- a/lua/blink/cmp/lib/window/init.lua
+++ b/lua/blink/cmp/lib/window/init.lua
@@ -5,50 +5,50 @@ local nvim = require('blink.lib.nvim')
 local utils = require('blink.cmp.lib.window.utils')
 
 --- @class blink.cmp.WindowOptions
---- @field min_width? number
---- @field max_width? number
---- @field max_height? number
+--- @field min_width? integer
+--- @field max_width? integer
+--- @field max_height? integer
 --- @field cursorline? boolean
---- @field cursorline_priority? number
+--- @field cursorline_priority? integer
 --- @field default_border? blink.cmp.WindowBorder
 --- @field border? blink.cmp.WindowBorder
 --- @field wrap? boolean
 --- @field linebreak? boolean
---- @field winblend? number
+--- @field winblend? integer
 --- @field winhighlight? string
---- @field scrolloff? number
+--- @field scrolloff? integer
 --- @field scrollbar? boolean
 --- @field filetype string
 
 --- @class blink.cmp.Window
---- @field id? number
---- @field buf? number
+--- @field id? integer
+--- @field buf? integer
 --- @field config blink.cmp.WindowOptions
 --- @field scrollbar? blink.cmp.Scrollbar
 --- @field cursor_line blink.cmp.CursorLine
 --- @field redraw_queued boolean
 ---
 --- @field new fun(name: string, config: blink.cmp.WindowOptions): blink.cmp.Window
---- @field get_buf fun(self: blink.cmp.Window): number
---- @field get_win fun(self: blink.cmp.Window): number
+--- @field get_buf fun(self: blink.cmp.Window): integer
+--- @field get_win fun(self: blink.cmp.Window): integer?
 --- @field is_open fun(self: blink.cmp.Window): boolean
 --- @field open fun(self: blink.cmp.Window)
 --- @field close fun(self: blink.cmp.Window)
 --- @field set_option_value fun(self: blink.cmp.Window, option: string, value: any)
 --- @field update_size fun(self: blink.cmp.Window)
---- @field get_content_height fun(self: blink.cmp.Window): number
---- @field get_border_size fun(self: blink.cmp.Window, border?: 'none' | 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'bold' | 'padded' | string[]): { vertical: number, horizontal: number, left: number, right: number, top: number, bottom: number }
+--- @field get_content_height fun(self: blink.cmp.Window): integer
+--- @field get_border_size fun(self: blink.cmp.Window, border?: 'none' | 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'bold' | 'padded' | string[]): { vertical: integer, horizontal: integer, left: integer, right: integer, top: integer, bottom: integer }
 --- @field expand_border_chars fun(border: string[]): string[]
---- @field get_height fun(self: blink.cmp.Window): number
---- @field get_content_width fun(self: blink.cmp.Window): number
---- @field get_width fun(self: blink.cmp.Window): number
---- @field get_cursor_screen_position fun(): { distance_from_top: number, distance_from_bottom: number }
---- @field set_cursor fun(self: blink.cmp.Window, cursor: number[])
---- @field set_height fun(self: blink.cmp.Window, height: number)
---- @field set_width fun(self: blink.cmp.Window, width: number)
+--- @field get_height fun(self: blink.cmp.Window): integer
+--- @field get_content_width fun(self: blink.cmp.Window): integer
+--- @field get_width fun(self: blink.cmp.Window): integer
+--- @field get_cursor_screen_position fun(): { distance_from_top: integer, distance_from_bottom: integer }
+--- @field set_cursor fun(self: blink.cmp.Window, cursor: blink.cmp.CursorPos)
+--- @field set_height fun(self: blink.cmp.Window, height: integer)
+--- @field set_width fun(self: blink.cmp.Window, width: integer)
 --- @field set_win_config fun(self: blink.cmp.Window, config: table)
---- @field get_vertical_direction_and_height fun(self: blink.cmp.Window, direction_priority: blink.cmp.WindowDirectionPriority, max_height: number): { height: number, direction: 'n' | 's' }?
---- @field get_direction_with_window_constraints fun(self: blink.cmp.Window, anchor_win: blink.cmp.Window, direction_priority: ("n" | "s" | "e" | "w")[], desired_min_size?: { width: number, height: number }): { width: number, height: number, direction: 'n' | 's' | 'e' | 'w' }?
+--- @field get_vertical_direction_and_height fun(self: blink.cmp.Window, direction_priority: blink.cmp.WindowDirectionPriority, max_height: integer): { height: integer, direction: 'n' | 's' }?
+--- @field get_direction_with_window_constraints fun(self: blink.cmp.Window, anchor_win: blink.cmp.Window, direction_priority: ("n" | "s" | "e" | "w")[], desired_min_size?: { width: integer, height: integer }): { width: integer, height: integer, direction: 'n' | 's' | 'e' | 'w' }?
 --- @field redraw_if_needed fun(self: blink.cmp.Window)
 
 --- @alias blink.cmp.WindowDirectionPriority ("n"|"s")[] | fun(): ("n"|"s")[]
@@ -67,6 +67,7 @@ function win.new(name, config)
     max_width = config.max_width,
     max_height = config.max_height or 10,
     cursorline = config.cursorline or false,
+    default_border = config.default_border,
     border = utils.pick_border(config.border, config.default_border),
     wrap = config.wrap or false,
     linebreak = config.linebreak or false,
@@ -164,7 +165,7 @@ function win:update_size()
   local winnr = self:get_win()
   local config = self.config
 
-  -- todo: never go above the screen width and height
+  -- TODO: never go above the screen width and height
 
   -- set width to current content width, bounded by min and max
   local width = self:get_content_width()
@@ -177,15 +178,15 @@ function win:update_size()
   nvim.win_set_height(winnr, height)
 end
 
--- todo: fix nvim_win_text_height
--- @return number
+-- TODO: fix nvim_win_text_height
+-- @return integer
 function win:get_content_height()
   if not self:is_open() then return 0 end
   return nvim.win_text_height(self:get_win(), {}).all
 end
 
 --- Gets the size of the borders around the window
---- @return { vertical: number, horizontal: number, left: number, right: number, top: number, bottom: number }
+--- @return { vertical: integer, horizontal: integer, left: integer, right: integer, top: integer, bottom: integer }
 function win:get_border_size()
   if not self:is_open() then return { vertical = 0, horizontal = 0, left = 0, right = 0, top = 0, bottom = 0 } end
 
@@ -232,7 +233,7 @@ function win.expand_border_chars(border)
   local resolved_border = {}
   while #resolved_border <= 8 do
     for _, b in ipairs(border) do
-      table.insert(resolved_border, type(b) == 'string' and b or b[1])
+      table.insert(resolved_border, type(b) == 'table' and b[1] or b)
     end
   end
   return resolved_border
@@ -280,7 +281,7 @@ function win.get_cursor_screen_position()
 
   -- default
   local cursor_line, cursor_column = unpack(nvim.win_get_cursor(0))
-  -- todo: convert cursor_column to byte index
+  -- TODO: convert cursor_column to byte index
   local pos = vim.fn.screenpos(0, cursor_line, cursor_column)
 
   return {

--- a/lua/blink/cmp/lib/window/init.lua
+++ b/lua/blink/cmp/lib/window/init.lua
@@ -7,7 +7,7 @@ local utils = require('blink.cmp.lib.window.utils')
 --- @class blink.cmp.WindowOptions
 --- @field min_width? integer
 --- @field max_width? integer
---- @field max_height? integer
+--- @field max_height integer
 --- @field cursorline? boolean
 --- @field cursorline_priority? integer
 --- @field default_border? blink.cmp.WindowBorder
@@ -37,8 +37,8 @@ local utils = require('blink.cmp.lib.window.utils')
 --- @field set_option_value fun(self: blink.cmp.Window, option: string, value: any)
 --- @field update_size fun(self: blink.cmp.Window)
 --- @field get_content_height fun(self: blink.cmp.Window): integer
---- @field get_border_size fun(self: blink.cmp.Window, border?: 'none' | 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'bold' | 'padded' | string[]): { vertical: integer, horizontal: integer, left: integer, right: integer, top: integer, bottom: integer }
---- @field expand_border_chars fun(border: string[]): string[]
+--- @field get_border_size fun(self: blink.cmp.Window): { vertical: integer, horizontal: integer, left: integer, right: integer, top: integer, bottom: integer }
+--- @field expand_border_chars fun(border: blink.cmp.WindowBorderChar[]): string[]
 --- @field get_height fun(self: blink.cmp.Window): integer
 --- @field get_content_width fun(self: blink.cmp.Window): integer
 --- @field get_width fun(self: blink.cmp.Window): integer
@@ -48,10 +48,12 @@ local utils = require('blink.cmp.lib.window.utils')
 --- @field set_width fun(self: blink.cmp.Window, width: integer)
 --- @field set_win_config fun(self: blink.cmp.Window, config: table)
 --- @field get_vertical_direction_and_height fun(self: blink.cmp.Window, direction_priority: blink.cmp.WindowDirectionPriority, max_height: integer): { height: integer, direction: 'n' | 's' }?
---- @field get_direction_with_window_constraints fun(self: blink.cmp.Window, anchor_win: blink.cmp.Window, direction_priority: ("n" | "s" | "e" | "w")[], desired_min_size?: { width: integer, height: integer }): { width: integer, height: integer, direction: 'n' | 's' | 'e' | 'w' }?
+--- @field get_direction_with_window_constraints fun(self: blink.cmp.Window, anchor_win: blink.cmp.Window, direction_priority: ('n' | 's' | 'e' | 'w')[], desired_min_size: { width: integer, height: integer }): { width: integer, height: integer, direction: 'n' | 's' | 'e' | 'w' }?
 --- @field redraw_if_needed fun(self: blink.cmp.Window)
 
---- @alias blink.cmp.WindowDirectionPriority ("n"|"s")[] | fun(): ("n"|"s")[]
+--- @alias blink.cmp.WindowDirectionPriority ('n'|'s')[] | fun(): ('n'|'s')[]
+--- @alias blink.cmp.WindowBorderChar string | string[]
+--- @alias blink.cmp.WindowBorder nil | 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'bold' | 'padded' | 'none' | blink.cmp.WindowBorderChar[] When set to `nil`, uses the `vim.o.winborder` value on nvim 0.11+
 
 --- @type blink.cmp.Window
 --- @diagnostic disable-next-line: missing-fields
@@ -98,7 +100,7 @@ end
 
 function win:get_buf()
   -- create buffer if it doesn't exist
-  if self.buf == nil or not nvim.buf_is_valid(self.buf) then
+  if not self.buf or not nvim.buf_is_valid(self.buf) then
     self.buf = nvim.create_buf(false, true)
     nvim.set_option_value('tabstop', 1, { buf = self.buf }) -- prevents tab widths from being unpredictable
   end
@@ -125,7 +127,7 @@ function win:open()
     row = 1,
     col = 1,
     zindex = 1001,
-    border = self.config.border == 'padded' and { ' ', '', '', ' ', '', '', ' ', ' ' } or self.config.border,
+    border = self.config.border == 'padded' and { ' ', '', '', ' ', '', '', ' ', ' ' } or self.config.border --[[@as vim.api.keyset.win_config.border]],
   })
   nvim.set_option_value('winblend', self.config.winblend, { win = self.id })
   nvim.set_option_value('winhighlight', self.config.winhighlight, { win = self.id })
@@ -146,7 +148,8 @@ function win:open()
 end
 
 function win:set_option_value(option, value)
-  if self.id == nil or not nvim.win_is_valid(self.id) then return end
+  if not self.id or not nvim.win_is_valid(self.id) then return end
+
   nvim.set_option_value(option, value, { win = self.id })
 end
 
@@ -162,7 +165,10 @@ end
 --- Updates the size of the window to match the max width and height of the content/config
 function win:update_size()
   if not self:is_open() then return end
+
   local winnr = self:get_win()
+  assert(winnr ~= nil, 'Window must be open to update size')
+
   local config = self.config
 
   -- TODO: never go above the screen width and height
@@ -178,11 +184,15 @@ function win:update_size()
   nvim.win_set_height(winnr, height)
 end
 
--- TODO: fix nvim_win_text_height
--- @return integer
+--- TODO: fix nvim_win_text_height
+--- @return integer
 function win:get_content_height()
   if not self:is_open() then return 0 end
-  return nvim.win_text_height(self:get_win(), {}).all
+
+  local winnr = self:get_win()
+  assert(winnr ~= nil, 'Window must be open to get the content height')
+
+  return nvim.win_text_height(winnr, {}).all
 end
 
 --- Gets the size of the borders around the window
@@ -242,12 +252,16 @@ end
 --- Gets the height of the window, taking into account the border
 function win:get_height()
   if not self:is_open() then return 0 end
-  return nvim.win_get_height(self:get_win()) + self:get_border_size().vertical
+
+  local winnr = self:get_win()
+  assert(winnr ~= nil, 'Window must be open to get the height')
+
+  return nvim.win_get_height(winnr) + self:get_border_size().vertical
 end
 
 --- Gets the width of the longest line in the window
 function win:get_content_width()
-  if not self:is_open() then return 0 end
+  if not self:is_open() or not self.buf then return 0 end
   local max_width = 0
   for _, line in ipairs(nvim.buf_get_lines(self.buf, 0, -1, false)) do
     max_width = math.max(max_width, nvim.strwidth(line))
@@ -258,7 +272,11 @@ end
 --- Gets the width of the window, taking into account the border
 function win:get_width()
   if not self:is_open() then return 0 end
-  return nvim.win_get_width(self:get_win()) + self:get_border_size().horizontal
+
+  local winnr = self:get_win()
+  assert(winnr ~= nil, 'Window must be open to get the width')
+
+  return nvim.win_get_width(winnr) + self:get_border_size().horizontal
 end
 
 --- Gets the cursor's distance from all sides of the screen
@@ -336,6 +354,8 @@ end
 --- direction_priority list
 function win:get_vertical_direction_and_height(direction_priority, max_height)
   if type(direction_priority) == 'function' then direction_priority = direction_priority() end
+  ---@cast direction_priority ('n'|'s')[]
+
   local constraints = self.get_cursor_screen_position()
   local border_size = self:get_border_size()
   local function get_distance(direction)
@@ -348,21 +368,25 @@ function win:get_vertical_direction_and_height(direction_priority, max_height)
     return (distance_a < distance_b) and 1 or (distance_a > distance_b) and -1 or 0
   end)
 
-  local direction = direction_priority_by_space[1]
+  local direction = assert(direction_priority_by_space[1])
   local height = math.min(self:get_height(), get_distance(direction), max_height)
   if height <= border_size.vertical then return end
+
   return { height = height - border_size.vertical, direction = direction }
 end
 
 function win:get_direction_with_window_constraints(anchor_win, direction_priority, desired_min_size)
   local cursor_constraints = self.get_cursor_screen_position()
 
-  -- nnvim.win_get_position doesn't return the correct position most of the time
+  -- nvim.win_get_position doesn't return the correct position most of the time
   -- so we calculate the position ourselves
   local anchor_config
-  local anchor_win_config = nvim.win_get_config(anchor_win:get_win())
+  local anchor_win_config = nvim.win_get_config(assert(anchor_win:get_win()))
+  assert(anchor_win_config.row)
+  assert(anchor_win_config.col)
+
   if anchor_win_config.relative == 'win' then
-    local anchor_relative_win_position = nvim.win_get_position(anchor_win_config.win)
+    local anchor_relative_win_position = nvim.win_get_position(assert(anchor_win_config.win))
     anchor_config = {
       row = anchor_win_config.row + anchor_relative_win_position[1] + 1,
       col = anchor_win_config.col + anchor_relative_win_position[2] + 1,
@@ -381,8 +405,8 @@ function win:get_direction_with_window_constraints(anchor_win, direction_priorit
   end
 
   local anchor_border_size = anchor_win:get_border_size()
-  local anchor_col = anchor_config.col - anchor_border_size.left
-  local anchor_row = anchor_config.row - anchor_border_size.top
+  local anchor_col = math.floor(anchor_config.col - anchor_border_size.left)
+  local anchor_row = math.floor(anchor_config.row - anchor_border_size.top)
   local anchor_height = anchor_win:get_height()
   local anchor_width = anchor_win:get_width()
 
@@ -443,7 +467,7 @@ function win:get_direction_with_window_constraints(anchor_win, direction_priorit
   end)
 
   local border_size = self:get_border_size()
-  local direction = direction_priority_by_space[1]
+  local direction = assert(direction_priority_by_space[1])
   local height = math.min(max_height, direction_constraints[direction].vertical)
   if height <= border_size.vertical then return end
   local width = math.min(max_width, direction_constraints[direction].horizontal)
@@ -458,7 +482,7 @@ end
 
 --- In cmdline mode, the window won't be redrawn automatically so we redraw ourselves on schedule
 function win:redraw_if_needed()
-  if self.redraw_queued or nvim.get_mode().mode ~= 'c' or self:get_win() == nil then return end
+  if self.redraw_queued or nvim.get_mode().mode ~= 'c' or not self:get_win() then return end
 
   -- We redraw on schedule to avoid the cmdline disappearing during redraw
   -- and to batch multiple redraws together

--- a/lua/blink/cmp/lib/window/scrollbar/geometry.lua
+++ b/lua/blink/cmp/lib/window/scrollbar/geometry.lua
@@ -3,18 +3,18 @@
 local nvim = require('blink.lib.nvim')
 
 --- @class blink.cmp.ScrollbarGeometry
---- @field width number
---- @field height number
---- @field row number
---- @field col number
---- @field zindex number
+--- @field width integer
+--- @field height integer
+--- @field row integer
+--- @field col integer
+--- @field zindex integer
 --- @field relative string
---- @field win number
+--- @field win integer
 
 local M = {}
 
---- @param target_win number
---- @return number
+--- @param target_win integer
+--- @return integer
 local function get_win_buf_height(target_win)
   local buf = nvim.win_get_buf(target_win)
 
@@ -32,7 +32,7 @@ local function get_win_buf_height(target_win)
 end
 
 --- @param border string|string[]
---- @return number
+--- @return integer
 local function get_col_offset(border)
   -- we only need an extra offset when working with a padded window
   if type(border) == 'table' and border[1] == ' ' and border[4] == ' ' and border[7] == ' ' and border[8] == ' ' then
@@ -42,9 +42,9 @@ local function get_col_offset(border)
 end
 
 --- Gets the starting line, handling line wrapping if enabled
---- @param target_win number
---- @param width number
---- @return number
+--- @param target_win integer
+--- @param width integer
+--- @return integer
 local get_content_start_line = function(target_win, width)
   local start_line = math.max(1, vim.fn.line('w0', target_win))
   if not vim.wo[target_win].wrap then return start_line end
@@ -59,7 +59,7 @@ local get_content_start_line = function(target_win, width)
   return wrapped_start_line
 end
 
---- @param target_win number
+--- @param target_win integer
 --- @return { should_hide: boolean, thumb: blink.cmp.ScrollbarGeometry, gutter: blink.cmp.ScrollbarGeometry }
 function M.get_geometry(target_win)
   local config = nvim.win_get_config(target_win)

--- a/lua/blink/cmp/lib/window/scrollbar/geometry.lua
+++ b/lua/blink/cmp/lib/window/scrollbar/geometry.lua
@@ -31,13 +31,14 @@ local function get_win_buf_height(target_win)
   return height
 end
 
---- @param border string|string[]
+--- @param border? blink.cmp.WindowBorder
 --- @return integer
 local function get_col_offset(border)
   -- we only need an extra offset when working with a padded window
-  if type(border) == 'table' and border[1] == ' ' and border[4] == ' ' and border[7] == ' ' and border[8] == ' ' then
-    return 1
+  if type(border) == 'table' then
+    return border[1] == ' ' and border[4] == ' ' and border[7] == ' ' and border[8] == ' ' and 1 or 0
   end
+
   return 0
 end
 
@@ -65,7 +66,7 @@ function M.get_geometry(target_win)
   local config = nvim.win_get_config(target_win)
   local width = config.width
   local height = config.height
-  local zindex = config.zindex
+  local zindex = config.zindex or 50 -- default nvim_open_win() value
 
   local buf_height = get_win_buf_height(target_win)
   local thumb_height = math.max(1, math.floor(height * height / buf_height + 0.5) - 1)
@@ -85,11 +86,14 @@ function M.get_geometry(target_win)
     win = target_win,
   }
 
-  return {
-    should_hide = height >= buf_height,
-    thumb = vim.tbl_deep_extend('force', common_geometry, { height = thumb_height, zindex = zindex + 2 }),
-    gutter = vim.tbl_deep_extend('force', common_geometry, { row = 0, height = height, zindex = zindex + 1 }),
-  }
+  local thumb_geometry = vim.tbl_deep_extend('force', common_geometry, { height = thumb_height, zindex = zindex + 2 })
+  --- @cast thumb_geometry blink.cmp.ScrollbarGeometry
+
+  local gutter_geometry =
+    vim.tbl_deep_extend('force', common_geometry, { row = 0, height = height, zindex = zindex + 1 })
+  --- @cast gutter_geometry blink.cmp.ScrollbarGeometry
+
+  return { should_hide = height >= buf_height, thumb = thumb_geometry, gutter = gutter_geometry }
 end
 
 return M

--- a/lua/blink/cmp/lib/window/scrollbar/init.lua
+++ b/lua/blink/cmp/lib/window/scrollbar/init.lua
@@ -10,7 +10,7 @@
 ---
 --- @field new fun(opts: blink.cmp.ScrollbarConfig): blink.cmp.Scrollbar
 --- @field is_visible fun(self: blink.cmp.Scrollbar): boolean
---- @field update fun(self: blink.cmp.Scrollbar, target_win: number | nil)
+--- @field update fun(self: blink.cmp.Scrollbar, target_win: integer?)
 
 --- @type blink.cmp.Scrollbar
 --- @diagnostic disable-next-line: missing-fields

--- a/lua/blink/cmp/lib/window/scrollbar/win.lua
+++ b/lua/blink/cmp/lib/window/scrollbar/win.lua
@@ -4,8 +4,8 @@ local nvim = require('blink.lib.nvim')
 
 --- @class blink.cmp.ScrollbarWin
 --- @field enable_gutter boolean
---- @field thumb_win? number
---- @field gutter_win? number
+--- @field thumb_win? integer
+--- @field gutter_win? integer
 --- @field buf? integer
 ---
 --- @field new fun(opts: blink.cmp.ScrollbarConfig): blink.cmp.ScrollbarWin
@@ -15,7 +15,7 @@ local nvim = require('blink.lib.nvim')
 --- @field hide_thumb fun(self: blink.cmp.ScrollbarWin)
 --- @field hide_gutter fun(self: blink.cmp.ScrollbarWin)
 --- @field hide fun(self: blink.cmp.ScrollbarWin)
---- @field _make_win fun(self: blink.cmp.ScrollbarWin, geometry: blink.cmp.ScrollbarGeometry, hl_group: string): number
+--- @field _make_win fun(self: blink.cmp.ScrollbarWin, geometry: blink.cmp.ScrollbarGeometry, hl_group: string): integer
 --- @field redraw_if_needed fun(self: blink.cmp.ScrollbarWin)
 
 --- @type blink.cmp.ScrollbarWin
@@ -85,7 +85,7 @@ function scrollbar_win:_make_win(geometry, hl_group)
     focusable = false,
     noautocmd = true,
     border = 'none',
-  })
+  } --[[@as blink.cmp.ScrollbarGeometry]])
   local win = nvim.open_win(self.buf, false, win_config)
   nvim.set_option_value('winhighlight', 'Normal:' .. hl_group .. ',EndOfBuffer:' .. hl_group, { win = win })
   return win

--- a/lua/blink/cmp/lib/window/scrollbar/win.lua
+++ b/lua/blink/cmp/lib/window/scrollbar/win.lua
@@ -85,7 +85,7 @@ function scrollbar_win:_make_win(geometry, hl_group)
     focusable = false,
     noautocmd = true,
     border = 'none',
-  } --[[@as blink.cmp.ScrollbarGeometry]])
+  })
   local win = nvim.open_win(self.buf, false, win_config)
   nvim.set_option_value('winhighlight', 'Normal:' .. hl_group .. ',EndOfBuffer:' .. hl_group, { win = win })
   return win

--- a/lua/blink/cmp/lib/window/scrollbar/win.lua
+++ b/lua/blink/cmp/lib/window/scrollbar/win.lua
@@ -6,7 +6,7 @@ local nvim = require('blink.lib.nvim')
 --- @field enable_gutter boolean
 --- @field thumb_win? number
 --- @field gutter_win? number
---- @field buf? number
+--- @field buf? integer
 ---
 --- @field new fun(opts: blink.cmp.ScrollbarConfig): blink.cmp.ScrollbarWin
 --- @field is_visible fun(self: blink.cmp.ScrollbarWin): boolean

--- a/lua/blink/cmp/signature/init.lua
+++ b/lua/blink/cmp/signature/init.lua
@@ -11,6 +11,7 @@ function signature.setup()
     local context = event.context
     sources.cancel_signature_help()
     sources.get_signature_help(context):map(function(signature_helps)
+      ---@cast signature_helps lsp.SignatureHelp[]
       -- TODO: pick intelligently
       local signature_help = signature_helps[1]
       if signature_help ~= nil and trigger.context ~= nil and trigger.context.id == context.id then

--- a/lua/blink/cmp/signature/trigger.lua
+++ b/lua/blink/cmp/signature/trigger.lua
@@ -119,7 +119,7 @@ end
 
 function trigger.show_if_on_trigger_character()
   if require('blink.cmp.completion.trigger.context').get_mode() ~= 'default' then return end
-  if not config.enabled and trigger.context == nil then return end
+  if not config.enabled or not trigger.context then return end
 
   local cursor_col = nvim.win_get_cursor(0)[2]
   local char_under_cursor = nvim.get_current_line():sub(cursor_col, cursor_col)

--- a/lua/blink/cmp/signature/trigger.lua
+++ b/lua/blink/cmp/signature/trigger.lua
@@ -7,16 +7,16 @@
 local nvim = require('blink.lib.nvim')
 
 --- @class blink.cmp.SignatureHelpContext
---- @field id number
---- @field bufnr number
---- @field cursor number[]
+--- @field id integer
+--- @field bufnr integer
+--- @field cursor blink.cmp.CursorPos
 --- @field line string
 --- @field is_retrigger boolean
 --- @field active_signature_help lsp.SignatureHelp | nil
 --- @field trigger { kind: lsp.SignatureHelpTriggerKind, character?: string }
 
 --- @class blink.cmp.SignatureTrigger
---- @field current_context_id number
+--- @field current_context_id integer
 --- @field context? blink.cmp.SignatureHelpContext
 --- @field show_emitter blink.cmp.EventEmitter<{ context: blink.cmp.SignatureHelpContext }>
 --- @field hide_emitter blink.cmp.EventEmitter<{}>
@@ -25,9 +25,13 @@ local nvim = require('blink.lib.nvim')
 --- @field activate fun()
 --- @field is_trigger_character fun(char: string, is_retrigger?: boolean): boolean
 --- @field show_if_on_trigger_character fun()
---- @field show fun(opts?: { trigger_character: string, force?: boolean })
+--- @field show fun(opts?: blink.cmp.SignatureTriggerShowOpts)
 --- @field hide fun()
 --- @field set_active_signature_help fun(signature_help: lsp.SignatureHelp)
+
+--- @class blink.cmp.SignatureTriggerShowOpts
+--- @field trigger_character? string
+--- @field force? boolean
 
 local root_config = require('blink.cmp.config')
 local config = require('blink.cmp.config').signature.trigger
@@ -144,7 +148,7 @@ function trigger.show(opts)
     },
     is_retrigger = trigger.context ~= nil,
     active_signature_help = trigger.context and trigger.context.active_signature_help or nil,
-  }
+  } --[[@as blink.cmp.SignatureHelpContext]]
 
   trigger.show_emitter:emit({ context = trigger.context })
 end

--- a/lua/blink/cmp/signature/trigger.lua
+++ b/lua/blink/cmp/signature/trigger.lua
@@ -12,7 +12,7 @@ local nvim = require('blink.lib.nvim')
 --- @field cursor blink.cmp.CursorPos
 --- @field line string
 --- @field is_retrigger boolean
---- @field active_signature_help lsp.SignatureHelp | nil
+--- @field active_signature_help lsp.SignatureHelp?
 --- @field trigger { kind: lsp.SignatureHelpTriggerKind, character?: string }
 
 --- @class blink.cmp.SignatureTrigger
@@ -42,7 +42,7 @@ local fuzzy = require('blink.cmp.fuzzy')
 --- @diagnostic disable-next-line: missing-fields
 local trigger = {
   current_context_id = -1,
-  --- @type blink.cmp.SignatureHelpContext | nil
+  --- @type blink.cmp.SignatureHelpContext?
   context = nil,
   show_emitter = require('blink.cmp.lib.event_emitter').new('signature_help_show'),
   hide_emitter = require('blink.cmp.lib.event_emitter').new('signature_help_hide'),

--- a/lua/blink/cmp/signature/window.lua
+++ b/lua/blink/cmp/signature/window.lua
@@ -6,8 +6,8 @@ local nvim = require('blink.lib.nvim')
 ---
 --- @field open_with_signature_help fun(context: blink.cmp.SignatureHelpContext, signature_help?: lsp.SignatureHelp)
 --- @field close fun()
---- @field scroll_up fun(amount: number): boolean
---- @field scroll_down fun(amount: number): boolean
+--- @field scroll_up fun(amount: integer): boolean
+--- @field scroll_down fun(amount: integer): boolean
 --- @field update_position fun()
 
 local config = require('blink.cmp.config').signature.window
@@ -27,10 +27,11 @@ local signature = {
     wrap = true,
     filetype = 'blink-cmp-signature',
   }),
+  ---@type blink.cmp.SignatureHelpContext?
   context = nil,
 }
 
--- todo: deduplicate this
+-- TODO: deduplicate this
 menu.position_update_emitter:on(function() signature.update_position() end)
 nvim.create_autocmd({ 'CursorMovedI', 'WinScrolled', 'WinResized' }, {
   callback = function()
@@ -39,7 +40,7 @@ nvim.create_autocmd({ 'CursorMovedI', 'WinScrolled', 'WinResized' }, {
 })
 
 --- @param context blink.cmp.SignatureHelpContext
---- @param signature_help lsp.SignatureHelp | nil
+--- @param signature_help? lsp.SignatureHelp
 function signature.open_with_signature_help(context, signature_help)
   signature.context = context
   -- check if there are any signatures in signature_help, since
@@ -54,8 +55,9 @@ function signature.open_with_signature_help(context, signature_help)
   end
 
   local active_signature = signature_help.signatures[(signature_help.activeSignature or 0) + 1]
+  assert(active_signature, 'Unable to find the active signature')
 
-  local labels = vim.tbl_map(function(signature) return signature.label end, signature_help.signatures)
+  local labels = vim.tbl_map(function(sign) return sign.label end, signature_help.signatures)
 
   if signature.shown_signature ~= active_signature then
     require('blink.cmp.lib.window.docs').render_detail_and_documentation({
@@ -99,7 +101,7 @@ function signature.close()
   signature.win:close()
 end
 
---- @param amount number
+--- @param amount integer
 --- @return boolean
 function signature.scroll_up(amount)
   local winnr = signature.win:get_win()
@@ -112,7 +114,7 @@ function signature.scroll_up(amount)
   return vim.fn.line('w0', winnr) < top_line
 end
 
---- @param amount number
+--- @param amount integer
 --- @return boolean
 function signature.scroll_down(amount)
   local winnr = signature.win:get_win()
@@ -129,15 +131,19 @@ end
 function signature.update_position()
   local win = signature.win
   if not win:is_open() then return end
+
   local winnr = win:get_win()
+  assert(winnr, 'window id not found for signature help')
 
   win:update_size()
 
+  local menu_winnr = menu.win:get_win()
+  local menu_win_config = menu_winnr and nvim.win_get_config(menu_winnr)
   local direction_priority = config.direction_priority
 
   -- if the menu window is open, we want to place the signature window on the opposite side
-  local menu_win_config = menu.win:get_win() and nvim.win_get_config(menu.win:get_win())
   if menu.win:is_open() then
+    assert(menu_win_config and menu_win_config.row)
     local cursor_screen_row = vim.fn.winline()
     local menu_win_is_up = menu_win_config.row - cursor_screen_row < 0
     direction_priority = menu_win_is_up and { 's' } or { 'n' }
@@ -164,8 +170,9 @@ function signature.update_position()
   local height = win:get_height()
 
   -- default to the user's preference but attempt to use the other options
-  if menu_win_config then
+  if menu_win_config ~= nil then
     assert(menu_win_config.relative == 'win', 'The menu window must be relative to a window')
+    assert(menu_win_config and menu_win_config.row)
     local cursor_screen_row = vim.fn.winline()
     local menu_win_is_up = menu_win_config.row - cursor_screen_row < 0
     nvim.win_set_config(winnr, {

--- a/lua/blink/cmp/signature/window.lua
+++ b/lua/blink/cmp/signature/window.lua
@@ -1,5 +1,3 @@
-local nvim = require('blink.lib.nvim')
-
 --- @class blink.cmp.SignatureWindow
 --- @field win blink.cmp.Window
 --- @field context? blink.cmp.SignatureHelpContext
@@ -10,6 +8,7 @@ local nvim = require('blink.lib.nvim')
 --- @field scroll_down fun(amount: integer): boolean
 --- @field update_position fun()
 
+local nvim = require('blink.lib.nvim')
 local config = require('blink.cmp.config').signature.window
 local sources = require('blink.cmp.sources.lib')
 local menu = require('blink.cmp.completion.windows.menu')
@@ -40,19 +39,16 @@ nvim.create_autocmd({ 'CursorMovedI', 'WinScrolled', 'WinResized' }, {
 })
 
 --- @param context blink.cmp.SignatureHelpContext
---- @param signature_help? lsp.SignatureHelp
+--- @param signature_help lsp.SignatureHelp
 function signature.open_with_signature_help(context, signature_help)
-  signature.context = context
   -- check if there are any signatures in signature_help, since
   -- convert_signature_help_to_markdown_lines errors with no signatures
-  if
-    signature_help == nil
-    or #signature_help.signatures == 0
-    or signature_help.signatures[(signature_help.activeSignature or 0) + 1] == nil
-  then
-    signature.win:close()
+  if #signature_help.signatures == 0 or not signature_help.signatures[(signature_help.activeSignature or 0) + 1] then
+    signature.close()
     return
   end
+
+  signature.context = context
 
   local active_signature = signature_help.signatures[(signature_help.activeSignature or 0) + 1]
   assert(active_signature, 'Unable to find the active signature')
@@ -96,11 +92,6 @@ function signature.open_with_signature_help(context, signature_help)
   signature.scroll_up(1)
 end
 
-function signature.close()
-  if not signature.win:is_open() then return end
-  signature.win:close()
-end
-
 --- @param amount integer
 --- @return boolean
 function signature.scroll_up(amount)
@@ -131,6 +122,7 @@ end
 function signature.update_position()
   local win = signature.win
   if not win:is_open() then return end
+  if not signature.context then return end
 
   local winnr = win:get_win()
   assert(winnr, 'window id not found for signature help')
@@ -173,17 +165,26 @@ function signature.update_position()
   if menu_win_config ~= nil then
     assert(menu_win_config.relative == 'win', 'The menu window must be relative to a window')
     assert(menu_win_config and menu_win_config.row)
+
     local cursor_screen_row = vim.fn.winline()
     local menu_win_is_up = menu_win_config.row - cursor_screen_row < 0
-    nvim.win_set_config(winnr, {
+
+    win:set_win_config({
       relative = menu_win_config.relative,
       win = menu_win_config.win,
       row = menu_win_is_up and menu_win_config.row + menu.win:get_height() + 1 or menu_win_config.row - height - 1,
       col = menu_win_config.col,
     })
   else
-    nvim.win_set_config(winnr, { relative = 'cursor', row = pos.direction == 's' and 1 or -height, col = 0 })
+    win:set_win_config({ relative = 'cursor', row = pos.direction == 's' and 1 or -height, col = 0 })
   end
+end
+
+function signature.close()
+  if not signature.win:is_open() then return end
+
+  signature.win:close()
+  signature.context = nil
 end
 
 return signature

--- a/lua/blink/cmp/sources/buffer/init.lua
+++ b/lua/blink/cmp/sources/buffer/init.lua
@@ -1,4 +1,4 @@
--- todo: nvim-cmp only updates the lines that got changed which is better
+-- TODO: nvim-cmp only updates the lines that got changed which is better
 -- but this is *speeeeeed* and simple. should add the better way
 -- but ensure it doesn't add too much complexity
 
@@ -127,7 +127,7 @@ end
 
 --- @param bufnr integer
 --- @param exclude_word_under_cursor boolean
---- @return blink.lib.Task
+--- @return blink.lib.Task<string[]>
 function buffer:get_buf_items(bufnr, exclude_word_under_cursor)
   local changedtick
 
@@ -155,7 +155,6 @@ function buffer:get_buf_items(bufnr, exclude_word_under_cursor)
   return parser.get_buf_words(bufnr, exclude_word_under_cursor, self.opts):map(store_in_cache)
 end
 
---- @return boolean
 function buffer:enabled() return not cmdline_utils.is_command_line() or self:is_search_context() end
 
 function buffer:get_completions(_, callback)
@@ -193,7 +192,6 @@ function buffer:get_completions(_, callback)
 
     if self.opts.use_cache then self.cache:cleanup(selected_bufnrs) end
 
-    ---@diagnostic disable-next-line: missing-return
     callback({ is_incomplete_forward = false, is_incomplete_backward = false, items = items })
   end)
 end

--- a/lua/blink/cmp/sources/buffer/parser.lua
+++ b/lua/blink/cmp/sources/buffer/parser.lua
@@ -42,23 +42,21 @@ function parser.run_sync(text) return task.resolve(fuzzy.get_words(text)) end
 --- @param text string
 --- @return blink.lib.Task<string[]>
 function parser.run_async_rust(text)
-  return parser.run_sync(text)
-  -- TODO: fails to load in uv thread
-  -- return task.new(function(resolve)
-  --   local worker = uv.new_work(
-  --     -- must use rust module directly since the normal one requires the config which isn't present
-  --     function(text, cpath)
-  --       package.cpath = cpath
-  --       ---@diagnostic disable-next-line: redundant-return-value
-  --       return table.concat(require('blink.cmp.fuzzy.rust').get_words(text), '\n')
-  --     end,
-  --     ---@param words string
-  --     function(words)
-  --       vim.schedule(function() resolve(vim.split(words, '\n')) end)
-  --     end
-  --   )
-  --   worker:queue(text, package.cpath)
-  -- end)
+  local lib_name, lib_path = require('blink.cmp.fuzzy').get_lib()
+
+  return task.new(function(resolve)
+    local worker = vim.uv.new_work(function(txt, libname, libpath)
+      local loader, err = package.loadlib(libpath, 'luaopen_' .. libname)
+      assert(loader, err)
+
+      local rust = loader()
+      return table.concat(rust.get_words(txt), '\n')
+    end, function(words)
+      ---@cast words string?
+      vim.schedule(function() resolve(words and vim.split(words, '\n') or {}) end)
+    end)
+    worker:queue(text, lib_name, lib_path)
+  end) --[[@as blink.lib.Task<string[]>]]
 end
 
 --- @param text string

--- a/lua/blink/cmp/sources/buffer/parser.lua
+++ b/lua/blink/cmp/sources/buffer/parser.lua
@@ -1,6 +1,5 @@
 local task = require('blink.lib.task')
 local fuzzy = require('blink.cmp.fuzzy')
-local uv = vim.uv
 
 local parser = {}
 
@@ -15,6 +14,7 @@ function parser.get_buf_text(bufnr, exclude_word_under_cursor)
   -- exclude word under the cursor for the current buffer
   local line_number, column = unpack(vim.api.nvim_win_get_cursor(0))
   local line = lines[line_number]
+  assert(line, 'buffer source: Unable to find the line ' .. line_number)
 
   local start_col = column
   while start_col > 1 do
@@ -36,11 +36,11 @@ function parser.get_buf_text(bufnr, exclude_word_under_cursor)
 end
 
 --- @param text string
---- @return blink.lib.Task
+--- @return blink.lib.Task<string[]>
 function parser.run_sync(text) return task.resolve(fuzzy.get_words(text)) end
 
 --- @param text string
---- @return blink.lib.Task
+--- @return blink.lib.Task<string[]>
 function parser.run_async_rust(text)
   return parser.run_sync(text)
   -- TODO: fails to load in uv thread
@@ -62,7 +62,7 @@ function parser.run_async_rust(text)
 end
 
 --- @param text string
---- @return blink.lib.Task
+--- @return blink.lib.Task<string[]>
 function parser.run_async_lua(text)
   local min_chunk_size = 2000 -- Min chunk size in bytes
   local max_chunk_size = 4000 -- Max chunk size in bytes
@@ -70,6 +70,7 @@ function parser.run_async_lua(text)
 
   local cancelled = false
   local pos = 1
+  ---@type string[]
   local all_words = {}
 
   return task

--- a/lua/blink/cmp/sources/buffer/priority.lua
+++ b/lua/blink/cmp/sources/buffer/priority.lua
@@ -9,7 +9,8 @@ end
 function priority.visible()
   local visible = {}
   for _, win in ipairs(nvim.list_wins()) do
-    visible[nvim.win_get_buf(win)] = true
+    local bufnr = nvim.win_get_buf(win)
+    visible[bufnr] = true
   end
   return function(bufnr) return visible[bufnr] and 0 or 1 end
 end
@@ -27,7 +28,7 @@ end
 function priority.comparator(order, buf_sizes)
   local value_fns = {}
   for _, key in ipairs(order) do
-    if priority[key] then table.insert(value_fns, priority[key](buf_sizes)) end
+    if priority[key] ~= nil then table.insert(value_fns, priority[key](buf_sizes)) end
   end
 
   return function(a, b)

--- a/lua/blink/cmp/sources/buffer/recency.lua
+++ b/lua/blink/cmp/sources/buffer/recency.lua
@@ -1,8 +1,9 @@
 local nvim = require('blink.lib.nvim')
 
 local recency = {
+  --- @type boolean?
   is_tracking = false,
-  --- @type table<number, number>
+  --- @type table<integer, integer>
   bufs = {},
 }
 

--- a/lua/blink/cmp/sources/buffer/utils.lua
+++ b/lua/blink/cmp/sources/buffer/utils.lua
@@ -40,7 +40,7 @@ function utils.retain_buffers(bufnrs, max_total_size, max_buffer_size, retention
 
   local selected, total_size = {}, 0
   for _, bufnr in ipairs(sorted_bufnrs) do
-    local size = buf_sizes[bufnr]
+    local size = buf_sizes[bufnr] or 0
     if total_size + size > max_total_size then break end
     total_size = total_size + size
     table.insert(selected, bufnr)

--- a/lua/blink/cmp/sources/cmdline/help.lua
+++ b/lua/blink/cmp/sources/cmdline/help.lua
@@ -6,7 +6,7 @@ local help = {}
 
 --- Processes a help file and returns a list of tags asynchronously
 --- @param file string
---- @return blink.lib.Task
+--- @return blink.lib.Task<string[]>
 local function read_tags_from_file(file)
   return fs.read(file, help_file_byte_limit)
     :map(function(data)
@@ -18,7 +18,7 @@ local function read_tags_from_file(file)
       end
       return tags
     end)
-    :catch(function() return {} end)
+    :catch(function() return {} end) --[[@as blink.lib.Task<string[]>]]
 end
 
 --- @param arg_prefix string

--- a/lua/blink/cmp/sources/cmdline/init.lua
+++ b/lua/blink/cmp/sources/cmdline/init.lua
@@ -22,18 +22,13 @@ function cmdline.new()
   self.offset = -1
   self.ctype = ''
   self.items = {}
-  return self --[[@as blink.cmp.Source]]
+  return self
 end
 
----@return boolean
 function cmdline:enabled() return vim.bo.ft == 'vim' or utils.is_command_line({ ':', '@' }) end
 
----@return string[]
 function cmdline:get_trigger_characters() return { ' ', '.', '#', '&', '-', '=', '/', ':', '!', '%', '~' } end
 
----@param context blink.cmp.Context
----@param callback fun(result?: blink.cmp.CompletionResponse)
----@return fun()
 function cmdline:get_completions(context, callback)
   local completion_type = utils.get_completion_type(context)
 
@@ -306,7 +301,7 @@ function cmdline:get_completions(context, callback)
               start = { line = line_pos, character = start_pos },
               ['end'] = { line = line_pos, character = replace_end_pos },
             },
-          },
+          } --[[@as lsp.InsertReplaceEdit]],
           kind = require('blink.cmp.types').CompletionItemKind.Property,
         }
         items[#items + 1] = item

--- a/lua/blink/cmp/sources/cmdline/init.lua
+++ b/lua/blink/cmp/sources/cmdline/init.lua
@@ -16,14 +16,7 @@ local cmdline = {
   options = nvim.get_all_options_info(),
 }
 
-function cmdline.new()
-  local self = setmetatable({}, { __index = cmdline })
-  self.before_line = ''
-  self.offset = -1
-  self.ctype = ''
-  self.items = {}
-  return self
-end
+function cmdline.new() return setmetatable({}, { __index = cmdline }) end
 
 function cmdline:enabled() return vim.bo.ft == 'vim' or utils.is_command_line({ ':', '@' }) end
 

--- a/lua/blink/cmp/sources/cmdline/man.lua
+++ b/lua/blink/cmp/sources/cmdline/man.lua
@@ -3,6 +3,7 @@ local man = {}
 
 ---@param arg string
 ---@param line string
+---@return blink.lib.Task<string[]>
 function man.get_completions(arg, line)
   return task.resolve():map(function()
     if not arg or arg == '' then return {} end

--- a/lua/blink/cmp/sources/cmdline/utils.lua
+++ b/lua/blink/cmp/sources/cmdline/utils.lua
@@ -190,7 +190,7 @@ end
 --- @param func_str string v:lua expression (e.g. "v:lua.foo.bar" or "v:lua.require'bar'.foo")
 --- @param prefix string
 --- @param line string
---- @param col number
+--- @param col integer
 --- @return boolean success
 --- @return table|string|nil result
 function utils.call_vlua(func_str, prefix, line, col)

--- a/lua/blink/cmp/sources/cmdline/utils.lua
+++ b/lua/blink/cmp/sources/cmdline/utils.lua
@@ -161,7 +161,8 @@ end
 function utils.get_completions(pattern, type, completion_type)
   -- If a shell command is requested on Windows or WSL, update PATH to avoid performance issues.
   if completion_type == 'shellcmd' then
-    local separator, filter_fn
+    local separator ---@type ":" | ";"
+    local filter_fn ---@type fun()?
 
     if vim.fn.has('win32') == 1 then
       separator = ';'

--- a/lua/blink/cmp/sources/lib/init.lua
+++ b/lua/blink/cmp/sources/lib/init.lua
@@ -3,8 +3,8 @@ local task = require('blink.lib.task')
 local config = require('blink.cmp.config')
 
 --- @class blink.cmp.Sources
---- @field completions_queue blink.cmp.SourcesQueue | nil
---- @field current_signature_help blink.lib.Task | nil
+--- @field completions_queue? blink.cmp.SourcesQueue
+--- @field current_signature_help? blink.lib.Task<lsp.SignatureHelp?>
 --- @field providers table<string, blink.cmp.SourceProvider>
 --- @field per_filetype_provider_ids table<string, string[]>
 --- @field completions_emitter blink.cmp.EventEmitter<blink.cmp.SourceCompletionsEvent>
@@ -16,16 +16,16 @@ local config = require('blink.cmp.config')
 --- @field get_trigger_characters fun(mode: blink.cmp.Mode): string[]
 --- @field add_filetype_provider_id fun(filetype: string, provider_id: string)
 ---
---- @field emit_completions fun(context: blink.cmp.Context, responses: table<string, blink.cmp.CompletionResponse>)
+--- @field emit_completions fun(context: blink.cmp.Context, responses: table<string, blink.cmp.CompletionItem[]>)
 --- @field request_completions fun(context: blink.cmp.Context)
 --- @field cancel_completions fun()
 --- @field apply_max_items_for_completions fun(context: blink.cmp.Context, items: blink.cmp.CompletionItem[]): blink.cmp.CompletionItem[]
 --- @field listen_on_completions fun(callback: fun(context: blink.cmp.Context, items: blink.cmp.CompletionItem[]))
---- @field resolve fun(context: blink.cmp.Context, item: blink.cmp.CompletionItem): blink.lib.Task
---- @field execute fun(context: blink.cmp.Context, item: blink.cmp.CompletionItem, default_implementation: fun(context?: blink.cmp.Context, item?: blink.cmp.CompletionItem)): blink.lib.Task
+--- @field resolve fun(context: blink.cmp.Context, item: blink.cmp.CompletionItem): blink.lib.Task<blink.cmp.CompletionItem>
+--- @field execute fun(context: blink.cmp.Context, item: blink.cmp.CompletionItem, default_implementation: fun(context?: blink.cmp.Context, item?: blink.cmp.CompletionItem)): blink.lib.Task<blink.cmp.CompletionItem?>
 ---
 --- @field get_signature_help_trigger_characters fun(mode: blink.cmp.Mode): { trigger_characters: string[], retrigger_characters: string[] }
---- @field get_signature_help fun(context: blink.cmp.SignatureHelpContext): blink.lib.Task
+--- @field get_signature_help fun(context: blink.cmp.SignatureHelpContext): blink.lib.Task<lsp.SignatureHelp?>
 --- @field cancel_signature_help fun()
 ---
 --- @field reload fun(provider?: string)
@@ -151,12 +151,9 @@ function sources.request_completions(context)
     if sources.completions_queue ~= nil then sources.completions_queue:destroy() end
     sources.completions_queue = require('blink.cmp.sources.lib.queue').new(context, sources.emit_completions)
   -- send cached completions if they exist to immediately trigger updates
-  elseif sources.completions_queue:get_cached_completions() ~= nil then
-    sources.emit_completions(
-      context,
-      --- @diagnostic disable-next-line: param-type-mismatch
-      sources.completions_queue:get_cached_completions()
-    )
+  else
+    local cached_completions = sources.completions_queue:get_cached_completions()
+    if cached_completions then sources.emit_completions(context, cached_completions) end
   end
 
   sources.completions_queue:get_completions(context)
@@ -172,18 +169,19 @@ end
 --- Limits the number of items per source as configured
 function sources.apply_max_items_for_completions(context, items)
   -- get the configured max items for each source
-  local total_items_for_sources = {}
-  local max_items_for_sources = {}
+  local total_items_for_sources = {} ---@type table<string, integer>
+  local max_items_for_sources = {} ---@type table<string, integer>
   for id, source in pairs(sources.providers) do
+    assert(type(source.config.max_items) == 'function')
     max_items_for_sources[id] = source.config.max_items(context, items)
     total_items_for_sources[id] = 0
   end
 
   -- no max items configured, return as-is
-  if #vim.tbl_keys(max_items_for_sources) == 0 then return items end
+  if vim.tbl_count(max_items_for_sources) == 0 then return items end
 
   -- apply max items
-  local filtered_items = {}
+  local filtered_items = {} ---@type blink.cmp.CompletionItem[]
   for _, item in ipairs(items) do
     local max_items = max_items_for_sources[item.source_id]
     total_items_for_sources[item.source_id] = total_items_for_sources[item.source_id] + 1
@@ -206,17 +204,18 @@ function sources.resolve(context, item)
     end
   end
   if item_source == nil then
-    return task.new(function(resolve) resolve(item) end)
+    return task.new(function(resolve) resolve(item) end) --[[@as blink.lib.Task<blink.cmp.CompletionItem>]]
   end
 
   return item_source
     :resolve(context, item)
-    :catch(function(err) vim.print('failed to resolve item with error: ' .. err) end)
+    :catch(function(err) vim.print('failed to resolve item with error: ' .. err) end) --[[@as blink.lib.Task<blink.cmp.CompletionItem>]]
 end
 
 --- Execute ---
 
 function sources.execute(context, item, default_implementation)
+  ---@type blink.cmp.SourceProvider?
   local item_source = nil
   for _, source in pairs(sources.providers) do
     if source.id == item.source_id then
@@ -224,13 +223,13 @@ function sources.execute(context, item, default_implementation)
       break
     end
   end
-  if item_source == nil then
+  if not item_source then
     return task.new(function(resolve) resolve() end)
   end
 
   return item_source
     :execute(context, item, default_implementation)
-    :catch(function(err) vim.print('failed to execute item with error: ' .. err) end)
+    :catch(function(err) vim.print('failed to execute item with error: ' .. err) end) --[[@as blink.lib.Task<blink.cmp.CompletionItem>]]
 end
 
 --- Signature help ---
@@ -239,7 +238,7 @@ function sources.get_signature_help_trigger_characters(mode)
   local trigger_characters = {}
   local retrigger_characters = {}
 
-  -- todo: should this be all sources? or should it follow fallbacks?
+  -- TODO: should this be all sources? or should it follow fallbacks?
   for _, source in pairs(sources.get_enabled_providers(mode)) do
     local res = source:get_signature_help_trigger_characters()
     vim.list_extend(trigger_characters, res.trigger_characters)
@@ -256,7 +255,8 @@ function sources.get_signature_help(context)
 
   sources.current_signature_help = task.all(tasks):map(function(signature_helps)
     return vim.tbl_filter(function(signature_help) return signature_help ~= nil end, signature_helps)
-  end)
+  end) --[[@as blink.lib.Task<lsp.SignatureHelp?>]]
+
   return sources.current_signature_help
 end
 
@@ -272,7 +272,7 @@ end
 --- For external integrations to force reloading the source
 function sources.reload(provider)
   -- Reload specific provider
-  if provider ~= nil then
+  if provider then
     assert(type(provider) == 'string', 'Expected string for provider')
     assert(
       sources.providers[provider] ~= nil or config.sources.providers[provider] ~= nil,
@@ -294,12 +294,12 @@ function sources.get_lsp_capabilities(override, include_nvim_defaults)
       completion = {
         completionItem = {
           snippetSupport = true,
-          commitCharactersSupport = false, -- todo:
+          commitCharactersSupport = false, -- TODO:
           documentationFormat = { 'markdown', 'plaintext' },
           deprecatedSupport = true,
-          preselectSupport = false, -- todo:
+          preselectSupport = false, -- TODO:
           tagSupport = { valueSet = { 1 } }, -- deprecated
-          insertReplaceSupport = true, -- todo:
+          insertReplaceSupport = true, -- TODO:
           resolveSupport = {
             properties = {
               'documentation',
@@ -307,11 +307,11 @@ function sources.get_lsp_capabilities(override, include_nvim_defaults)
               'additionalTextEdits',
               'command',
               'data',
-              -- todo: support more properties? should test if it improves latency
+              -- TODO: support more properties? should test if it improves latency
             },
           },
           insertTextModeSupport = {
-            -- todo: support adjustIndentation
+            -- TODO: support adjustIndentation
             valueSet = { 1 }, -- asIs
           },
           labelDetailsSupport = true,

--- a/lua/blink/cmp/sources/lib/provider/config.lua
+++ b/lua/blink/cmp/sources/lib/provider/config.lua
@@ -5,15 +5,16 @@
 --- @field module string
 --- @field enabled boolean | fun(): boolean
 --- @field async fun(ctx: blink.cmp.Context): boolean
---- @field timeout_ms fun(ctx: blink.cmp.Context): number
+--- @field timeout_ms fun(ctx: blink.cmp.Context): integer
 --- @field transform_items fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): blink.cmp.CompletionItem[]
 --- @field should_show_items fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): boolean
---- @field max_items? fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): number
---- @field min_keyword_length fun(ctx: blink.cmp.Context): number
+--- @field max_items? fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): integer
+--- @field min_keyword_length fun(ctx: blink.cmp.Context): integer
 --- @field fallbacks fun(ctx: blink.cmp.Context): string[]
---- @field score_offset fun(ctx: blink.cmp.Context): number
+--- @field score_offset fun(ctx: blink.cmp.Context): integer
 
---- @class blink.cmp.SourceProviderConfigWrapper
+--- @type blink.cmp.SourceProviderConfigWrapper
+---@diagnostic disable-next-line: missing-fields
 local wrapper = {}
 
 function wrapper.new(config)
@@ -28,8 +29,6 @@ function wrapper.new(config)
   end
 
   local self = setmetatable({}, { __index = config })
-  ---@cast self blink.cmp.SourceProviderConfigWrapper
-
   self.name = config.name
   self.module = config.module
   self.enabled = config.enabled

--- a/lua/blink/cmp/sources/lib/provider/init.lua
+++ b/lua/blink/cmp/sources/lib/provider/init.lua
@@ -4,9 +4,9 @@
 --- @field name string
 --- @field config blink.cmp.SourceProviderConfigWrapper
 --- @field module blink.cmp.Source
---- @field list blink.cmp.SourceProviderList | nil
---- @field resolve_cache_context_id number | nil
---- @field resolve_cache table<blink.cmp.CompletionItem, blink.lib.Task>
+--- @field list? blink.cmp.SourceProviderList
+--- @field resolve_cache_context_id? integer
+--- @field resolve_cache table<blink.cmp.CompletionItem, blink.lib.Task<blink.cmp.CompletionItem?>>
 ---
 --- @field new fun(id: string, config: blink.cmp.SourceProviderConfig): blink.cmp.SourceProvider
 --- @field enabled fun(self: blink.cmp.SourceProvider): boolean
@@ -14,11 +14,11 @@
 --- @field get_completions fun(self: blink.cmp.SourceProvider, context: blink.cmp.Context, on_items: fun(items: blink.cmp.CompletionItem[], is_cached: boolean))
 --- @field should_show_items fun(self: blink.cmp.SourceProvider, context: blink.cmp.Context, items: blink.cmp.CompletionItem[]): boolean
 --- @field transform_items fun(self: blink.cmp.SourceProvider, context: blink.cmp.Context, items: blink.cmp.CompletionItem[]): blink.cmp.CompletionItem[]
---- @field resolve fun(self: blink.cmp.SourceProvider, context: blink.cmp.Context, item: blink.cmp.CompletionItem): blink.lib.Task
---- @field execute fun(self: blink.cmp.SourceProvider, context: blink.cmp.Context, item: blink.cmp.CompletionItem, default_implementation: fun(context?: blink.cmp.Context, item?: blink.cmp.CompletionItem)): blink.lib.Task
+--- @field resolve fun(self: blink.cmp.SourceProvider, context: blink.cmp.Context, item: blink.cmp.CompletionItem): blink.lib.Task<blink.cmp.CompletionItem?>
+--- @field execute fun(self: blink.cmp.SourceProvider, context: blink.cmp.Context, item: blink.cmp.CompletionItem, default_implementation: fun(context?: blink.cmp.Context, item?: blink.cmp.CompletionItem)): blink.lib.Task<nil>
 --- @field get_signature_help_trigger_characters fun(self: blink.cmp.SourceProvider): { trigger_characters: string[], retrigger_characters: string[] }
---- @field get_signature_help fun(self: blink.cmp.SourceProvider, context: blink.cmp.SignatureHelpContext): blink.lib.Task
---- @field reload (fun(self: blink.cmp.SourceProvider): nil) | nil
+--- @field get_signature_help fun(self: blink.cmp.SourceProvider, context: blink.cmp.SignatureHelpContext): blink.lib.Task<lsp.SignatureHelp?>
+--- @field reload fun(self: blink.cmp.SourceProvider)
 
 --- @type blink.cmp.SourceProvider
 --- @diagnostic disable-next-line: missing-fields
@@ -51,7 +51,7 @@ function source:enabled()
   -- Skip during fast events, many implementations use Vim APIs
   -- (nvim_get_current_buf, win_gettype, etc.) which are forbidden and crash with E5560.
   -- This is re-evaluated safely in the scheduled completion phase.
-  if vim.in_fast_event() then return false end
+  if vim.in_fast_event() == true then return false end
 
   -- user defined
   local user_enabled = self.config.enabled
@@ -89,8 +89,13 @@ function source:get_completions(context, on_items)
   -- The TriggerForIncompleteCompletions kind is handled by the source provider itself
   local source_context = lib.tbl.copy(context)
   source_context.trigger = trigger_character
-      and { kind = vim.lsp.protocol.CompletionTriggerKind.TriggerCharacter, character = context.trigger.character }
-    or { kind = vim.lsp.protocol.CompletionTriggerKind.Invoked }
+      and {
+        kind = vim.lsp.protocol.CompletionTriggerKind.TriggerCharacter,
+        character = context.trigger.character,
+      } --[[@as blink.cmp.ContextTrigger]]
+    or {
+      kind = vim.lsp.protocol.CompletionTriggerKind.Invoked,
+    } --[[@as blink.cmp.ContextTrigger]]
 
   local async_initial_items = self.list ~= nil and self.list.context.id == context.id and self.list.items or {}
   if self.list ~= nil then self.list:destroy() end
@@ -158,13 +163,14 @@ function source:resolve(context, item)
 
       return self.module:resolve(item, function(resolved_item)
         -- HACK: it's out of spec to update keys not in resolveSupport.properties but some LSPs do it anyway
-        local merged_item = vim.tbl_deep_extend('force', item, resolved_item or {})
+        local merged_item = vim.tbl_deep_extend('force', item, resolved_item or {} --[[@as blink.cmp.CompletionItem]])
         local transformed_item = self:transform_items(context, { merged_item })[1] or merged_item
         vim.schedule(function() resolve(transformed_item) end)
       end)
     end)
   end
-  return self.resolve_cache[item]
+
+  return self.resolve_cache[item] --[[@as blink.lib.Task<blink.cmp.CompletionItem>]]
 end
 
 --- Execute ---
@@ -175,7 +181,7 @@ function source:execute(context, item, default_implementation)
     return task.resolve()
   end
 
-  return task.new(function(resolve) return self.module:execute(context, item, resolve, default_implementation) end)
+  return task.new(function(resolve) return self.module:execute(context, item, resolve, default_implementation) end) --[[@as blink.lib.Task<nil>]]
 end
 
 --- Signature help ---

--- a/lua/blink/cmp/sources/lib/queue.lua
+++ b/lua/blink/cmp/sources/lib/queue.lua
@@ -3,7 +3,7 @@ local task = require('blink.lib.task')
 --- @class blink.cmp.SourcesQueue
 --- @field id integer
 --- @field providers table<string, blink.cmp.SourceProvider>
---- @field request blink.lib.Task<nil>
+--- @field request blink.lib.Task<nil>?
 --- @field queued_request_context blink.cmp.Context?
 --- @field cached_items_by_provider table<string, blink.cmp.CompletionItem[]>?
 --- @field on_completions_callback fun(context: blink.cmp.Context, responses: table<string, blink.cmp.CompletionItem[]>)

--- a/lua/blink/cmp/sources/lib/queue.lua
+++ b/lua/blink/cmp/sources/lib/queue.lua
@@ -1,7 +1,7 @@
 local task = require('blink.lib.task')
 
 --- @class blink.cmp.SourcesQueue
---- @field id number
+--- @field id integer
 --- @field providers table<string, blink.cmp.SourceProvider>
 --- @field request blink.lib.Task<nil>
 --- @field queued_request_context blink.cmp.Context?

--- a/lua/blink/cmp/sources/lib/queue.lua
+++ b/lua/blink/cmp/sources/lib/queue.lua
@@ -3,13 +3,13 @@ local task = require('blink.lib.task')
 --- @class blink.cmp.SourcesQueue
 --- @field id number
 --- @field providers table<string, blink.cmp.SourceProvider>
---- @field request blink.lib.Task | nil
---- @field queued_request_context blink.cmp.Context | nil
---- @field cached_items_by_provider table<string, blink.cmp.CompletionResponse> | nil
---- @field on_completions_callback fun(context: blink.cmp.Context, responses: table<string, blink.cmp.CompletionResponse>)
+--- @field request blink.lib.Task<nil>
+--- @field queued_request_context blink.cmp.Context?
+--- @field cached_items_by_provider table<string, blink.cmp.CompletionItem[]>?
+--- @field on_completions_callback fun(context: blink.cmp.Context, responses: table<string, blink.cmp.CompletionItem[]>)
 ---
---- @field new fun(context: blink.cmp.Context, on_completions_callback: fun(context: blink.cmp.Context, responses: table<string, blink.cmp.CompletionResponse>)): blink.cmp.SourcesQueue
---- @field get_cached_completions fun(self: blink.cmp.SourcesQueue): table<string, blink.cmp.CompletionResponse> | nil
+--- @field new fun(context: blink.cmp.Context, on_completions_callback: fun(context: blink.cmp.Context, responses: table<string, blink.cmp.CompletionItem[]>)): blink.cmp.SourcesQueue
+--- @field get_cached_completions fun(self: blink.cmp.SourcesQueue): table<string, blink.cmp.CompletionItem[]>?
 --- @field get_completions fun(self: blink.cmp.SourcesQueue, context: blink.cmp.Context)
 --- @field destroy fun(self: blink.cmp.SourcesQueue)
 
@@ -20,7 +20,6 @@ local queue = {}
 function queue.new(context, on_completions_callback)
   local self = setmetatable({}, { __index = queue })
   self.id = context.id
-
   self.request = nil
   self.queued_request_context = nil
   self.on_completions_callback = on_completions_callback
@@ -53,7 +52,7 @@ function queue:get_completions(context)
     local queued_context = self.queued_request_context
     if queued_context ~= nil then
       self.queued_request_context = nil
-      self.request:cancel()
+      if self.request ~= nil then self.request:cancel() end
       self:get_completions(queued_context)
     end
   end)

--- a/lua/blink/cmp/sources/lib/tree.lua
+++ b/lua/blink/cmp/sources/lib/tree.lua
@@ -7,7 +7,7 @@
 --- @class blink.cmp.SourceTree
 --- @field nodes blink.cmp.SourceTreeNode[]
 --- @field new fun(context: blink.cmp.Context): blink.cmp.SourceTree
---- @field get_completions fun(self: blink.cmp.SourceTree, context: blink.cmp.Context, on_items_by_provider: fun(items_by_provider: table<string, blink.cmp.CompletionItem[]>)): blink.lib.Task
+--- @field get_completions fun(self: blink.cmp.SourceTree, context: blink.cmp.Context, on_items_by_provider: fun(items_by_provider: table<string, blink.cmp.CompletionItem[]>)): blink.lib.Task<nil>
 --- @field emit_completions fun(self: blink.cmp.SourceTree, items_by_provider: table<string, blink.cmp.CompletionItem[]>, on_items_by_provider: fun(items_by_provider: table<string, blink.cmp.CompletionItem[]>)): nil
 --- @field get_top_level_nodes fun(self: blink.cmp.SourceTree): blink.cmp.SourceTreeNode[]
 --- @field detect_cycle fun(node: blink.cmp.SourceTreeNode, visited?: table<string, boolean>, path?: table<string, boolean>): boolean
@@ -92,17 +92,20 @@ function tree:get_completions(context, on_items_by_provider)
     :map(function()
       should_push_upstream = true
 
-      -- if atleast one of the results wasn't cached, emit the results
+      -- if at least one of the results wasn't cached, emit the results
       if not is_all_cached then self:emit_completions(items_by_provider, on_items_by_provider) end
     end)
-    :catch(function(err) vim.print('failed to get completions with error: ' .. err) end)
+    :catch(function(err) vim.print('failed to get completions with error: ' .. err) end) --[[@as blink.lib.Task<nil>]]
 end
 
 function tree:emit_completions(items_by_provider, on_items_by_provider)
   local nodes_falling_back = {}
   local final_items_by_provider = {}
 
+  ---@type fun(node: blink.cmp.SourceTreeNode)?
   local add_node_items
+
+  ---@param node blink.cmp.SourceTreeNode
   add_node_items = function(node)
     for _, dependency in ipairs(node.dependencies) do
       if not nodes_falling_back[dependency.id] then return end
@@ -113,7 +116,7 @@ function tree:emit_completions(items_by_provider, on_items_by_provider)
     else
       nodes_falling_back[node.id] = true
       for _, dependent in ipairs(node.dependents) do
-        add_node_items(dependent)
+        assert(add_node_items)(dependent)
       end
     end
   end

--- a/lua/blink/cmp/sources/lib/types.lua
+++ b/lua/blink/cmp/sources/lib/types.lua
@@ -1,6 +1,6 @@
 --- @class blink.cmp.CompletionTriggerContext
 --- @field kind number
---- @field character string | nil
+--- @field character? string
 
 --- @class blink.cmp.CompletionResponse
 --- @field is_incomplete_forward boolean
@@ -15,7 +15,7 @@
 --- @field should_show_items? fun(self: blink.cmp.Source, context: blink.cmp.Context, items: blink.cmp.CompletionItem[]): boolean
 --- @field resolve? fun(self: blink.cmp.Source, item: blink.cmp.CompletionItem, callback: fun(resolved_item?: lsp.CompletionItem)): ((fun(): nil) | nil)
 --- @field execute? fun(self: blink.cmp.Source, context: blink.cmp.Context, item: blink.cmp.CompletionItem, callback: fun(), default_implementation: fun(context?: blink.cmp.Context, item?: blink.cmp.CompletionItem)): ((fun(): nil) | nil)
---- @field get_signature_help_trigger_characters? fun(self: blink.cmp.Source): string[]
+--- @field get_signature_help_trigger_characters? fun(self: blink.cmp.Source): { trigger_characters: string[], retrigger_characters: string[] }
 --- @field get_signature_help? fun(self: blink.cmp.Source, context: blink.cmp.SignatureHelpContext, callback: fun(signature_help: lsp.SignatureHelp | nil)): (fun(): nil) | nil
 --- @field reload? fun(self: blink.cmp.Source): nil
 

--- a/lua/blink/cmp/sources/lib/types.lua
+++ b/lua/blink/cmp/sources/lib/types.lua
@@ -1,7 +1,3 @@
---- @class blink.cmp.CompletionTriggerContext
---- @field kind number
---- @field character? string
-
 --- @class blink.cmp.CompletionResponse
 --- @field is_incomplete_forward boolean
 --- @field is_incomplete_backward boolean

--- a/lua/blink/cmp/sources/lib/types.lua
+++ b/lua/blink/cmp/sources/lib/types.lua
@@ -16,7 +16,7 @@
 --- @field resolve? fun(self: blink.cmp.Source, item: blink.cmp.CompletionItem, callback: fun(resolved_item?: lsp.CompletionItem)): ((fun(): nil) | nil)
 --- @field execute? fun(self: blink.cmp.Source, context: blink.cmp.Context, item: blink.cmp.CompletionItem, callback: fun(), default_implementation: fun(context?: blink.cmp.Context, item?: blink.cmp.CompletionItem)): ((fun(): nil) | nil)
 --- @field get_signature_help_trigger_characters? fun(self: blink.cmp.Source): { trigger_characters: string[], retrigger_characters: string[] }
---- @field get_signature_help? fun(self: blink.cmp.Source, context: blink.cmp.SignatureHelpContext, callback: fun(signature_help: lsp.SignatureHelp | nil)): (fun(): nil) | nil
+--- @field get_signature_help? fun(self: blink.cmp.Source, context: blink.cmp.SignatureHelpContext, callback: fun(signature_help: lsp.SignatureHelp?)): (fun(): nil) | nil
 --- @field reload? fun(self: blink.cmp.Source): nil
 
 --- @class blink.cmp.SourceOverride
@@ -24,7 +24,7 @@
 --- @field get_trigger_characters? fun(self: blink.cmp.Source): string[]
 --- @field get_completions? fun(self: blink.cmp.Source, context: blink.cmp.Context, callback: fun(response: blink.cmp.CompletionResponse | nil)): (fun(): nil) | nil
 --- @field should_show_items? fun(self: blink.cmp.Source, context: blink.cmp.Context, items: blink.cmp.CompletionItem[]): boolean
---- @field resolve? fun(self: blink.cmp.Source, item: blink.cmp.CompletionItem, callback: fun(resolved_item: lsp.CompletionItem | nil)): ((fun(): nil) | nil)
+--- @field resolve? fun(self: blink.cmp.Source, item: blink.cmp.CompletionItem, callback: fun(resolved_item: lsp.CompletionItem?)): ((fun(): nil) | nil)
 --- @field execute? fun(self: blink.cmp.Source, context: blink.cmp.Context, item: blink.cmp.CompletionItem, callback: fun(), default_implementation: fun(context?: blink.cmp.Context, item?: blink.cmp.CompletionItem)): ((fun(): nil) | nil)
 --- @field get_signature_help_trigger_characters? fun(self: blink.cmp.Source): string[]
 --- @field get_signature_help? fun(self: blink.cmp.Source, context: blink.cmp.SignatureHelpContext, callback: fun(signature_help: lsp.SignatureHelp | nil)): (fun(): nil) | nil

--- a/lua/blink/cmp/sources/lsp/cache.lua
+++ b/lua/blink/cmp/sources/lsp/cache.lua
@@ -4,10 +4,12 @@
 
 --- @class blink.cmp.LSPCache
 local cache = {
-  --- @type table<number, blink.cmp.LSPCacheEntry>
+  --- @type table<integer, blink.cmp.LSPCacheEntry>
   entries = {},
 }
 
+---@param context blink.cmp.Context
+---@param client vim.lsp.Client
 function cache.get(context, client)
   local entry = cache.entries[client.id]
   if entry == nil then return end

--- a/lua/blink/cmp/sources/lsp/completion.lua
+++ b/lua/blink/cmp/sources/lsp/completion.lua
@@ -1,20 +1,31 @@
 local lib = require('blink.lib')
 local task = require('blink.lib.task')
-local utils = require('blink.cmp.lib.utils')
 local cache = require('blink.cmp.sources.lsp.cache')
 
 local CompletionTriggerKind = vim.lsp.protocol.CompletionTriggerKind
+---@type table<string, boolean>
+local known_defaults = {
+  commitCharacters = true,
+  insertTextFormat = true,
+  insertTextMode = true,
+  data = true,
+}
+
 --- @param context blink.cmp.Context
 --- @param client vim.lsp.Client
---- @return blink.lib.Task
+--- @return blink.lib.Task<{ err: lsp.ResponseError?, result: lsp.CompletionList? }>
 local function request(context, client)
   return task.new(function(resolve)
     local params = vim.lsp.util.make_position_params(0, client.offset_encoding)
+    ---@diagnostic disable-next-line: inject-field
     params.context = {
       triggerKind = context.trigger.kind == 'trigger_character' and CompletionTriggerKind.TriggerCharacter
         or CompletionTriggerKind.Invoked,
     }
-    if context.trigger.kind == 'trigger_character' then params.context.triggerCharacter = context.trigger.character end
+    if context.trigger.kind == 'trigger_character' then
+      ---@diagnostic disable-next-line: undefined-field
+      params.context.triggerCharacter = context.trigger.character
+    end
 
     local _, request_id = client:request(
       'textDocument/completion',
@@ -24,15 +35,9 @@ local function request(context, client)
     return function()
       if request_id ~= nil then client:cancel_request(request_id) end
     end
-  end)
+  end) --[[@as blink.lib.Task<{ err: lsp.ResponseError?, result: lsp.CompletionList? }>]]
 end
 
-local known_defaults = {
-  'commitCharacters',
-  'insertTextFormat',
-  'insertTextMode',
-  'data',
-}
 --- @param context blink.cmp.Context
 --- @param client vim.lsp.Client
 --- @param res lsp.CompletionList
@@ -41,6 +46,7 @@ local function process_response(context, client, res)
   local items = res.items or res
   local default_edit_range = res.itemDefaults and res.itemDefaults.editRange
   for _, item in ipairs(items) do
+    ---@cast item blink.cmp.CompletionItem
     item.client_id = client.id
     item.client_name = client.name
     -- we must set the cursor column because this will be cached and used later
@@ -48,18 +54,19 @@ local function process_response(context, client, res)
     item.cursor_column = context.cursor[2]
 
     -- score offset for deprecated items
-    -- todo: make configurable
+    -- TODO: make configurable
     if
       (lib.is_not_nil(item.deprecated) and item.deprecated)
-      or (lib.is_not_nil(item.tags) and vim.tbl_contains(item.tags, 1))
+      or (lib.is_not_nil(item.tags) and vim.tbl_contains(item.tags or {}, 1))
     then
       item.score_offset = -2
     end
 
     -- set defaults
     for key, value in pairs(res.itemDefaults or {}) do
-      if vim.tbl_contains(known_defaults, key) then item[key] = item[key] or value end
+      if known_defaults[key] then item[key] = item[key] or value end
     end
+
     if default_edit_range and item.textEdit == nil then
       local new_text = item.textEditText or item.insertText or item.label
       if default_edit_range.replace ~= nil then
@@ -67,12 +74,12 @@ local function process_response(context, client, res)
           replace = default_edit_range.replace,
           insert = default_edit_range.insert,
           newText = new_text,
-        }
+        } --[[@as lsp.InsertReplaceEdit]]
       else
         item.textEdit = {
           range = res.itemDefaults.editRange,
           newText = new_text,
-        }
+        } --[[@as lsp.TextEdit]]
       end
     end
   end
@@ -89,7 +96,7 @@ local completion = {}
 --- @param context blink.cmp.Context
 --- @param client vim.lsp.Client
 --- @param opts blink.cmp.LSPSourceOpts
---- @return blink.lib.Task
+--- @return blink.lib.Task<blink.cmp.CompletionResponse>
 function completion.get_completion_for_client(context, client, opts)
   -- We have multiple clients and some may return isIncomplete = false while others return isIncomplete = true
   -- If any are marked as incomplete, we must tell blink.cmp, but this will cause a fetch on every keystroke
@@ -98,8 +105,10 @@ function completion.get_completion_for_client(context, client, opts)
   if cache_entry ~= nil then return task.resolve(cache_entry) end
 
   return request(context, client):map(function(res)
+    ---@cast res { err: lsp.ResponseError?, result: lsp.CompletionList? }
+
     if res.err or res.result == nil then
-      return { is_incomplete_forward = true, is_incomplete_backward = true, items = {} }
+      return { is_incomplete_forward = true, is_incomplete_backward = true, items = {} } --[[@as blink.cmp.CompletionResponse]]
     end
 
     local response = process_response(context, client, res.result)
@@ -117,7 +126,7 @@ function completion.get_completion_for_client(context, client, opts)
     cache.set(context, client, response)
 
     return response
-  end)
+  end) --[[@as blink.lib.Task<blink.cmp.CompletionResponse>]]
 end
 
 return completion

--- a/lua/blink/cmp/sources/lsp/hacks/clangd.lua
+++ b/lua/blink/cmp/sources/lsp/hacks/clangd.lua
@@ -1,7 +1,7 @@
 local clangd = {}
 
---- @param response blink.cmp.CompletionResponse | nil
---- @return blink.cmp.CompletionResponse | nil
+--- @param response blink.cmp.CompletionResponse?
+--- @return blink.cmp.CompletionResponse?
 function clangd.process_response(response)
   if not response then return response end
 

--- a/lua/blink/cmp/sources/lsp/hacks/docs.lua
+++ b/lua/blink/cmp/sources/lsp/hacks/docs.lua
@@ -3,34 +3,36 @@ local docs = {}
 --- Gets the start and end row of the code block for the given row
 --- Or returns nil if there's no code block
 --- @param lines string[]
---- @param row number
---- @return number?, number?
+--- @param row integer
+--- @return integer?, integer?
 function docs.get_code_block_range(lines, row)
   if row < 1 or row > #lines then return end
+
+  ---@type integer?, integer?
+  local code_block_start, code_block_end
+
   -- get the start of the code block
-  local code_block_start = nil
   for i = 1, row do
     local line = lines[i]
-    if line:match('^%s*```') then
-      if code_block_start == nil then
-        code_block_start = i
-      else
+    if line and line:match('^%s*```') then
+      if code_block_start then
         code_block_start = nil
+      else
+        code_block_start = i
       end
     end
   end
-  if code_block_start == nil then return end
+  if not code_block_start then return end
 
   -- get the end of the code block
-  local code_block_end = nil
   for i = row, #lines do
     local line = lines[i]
-    if line:match('^%s*```') then
+    if line and line:match('^%s*```') then
       code_block_end = i
       break
     end
   end
-  if code_block_end == nil then return end
+  if not code_block_end then return end
 
   return code_block_start, code_block_end
 end

--- a/lua/blink/cmp/sources/lsp/hacks/docs.lua
+++ b/lua/blink/cmp/sources/lsp/hacks/docs.lua
@@ -40,19 +40,19 @@ end
 --- Avoids showing the detail if it's part of the documentation
 --- or, if the detail is in a code block in the doc,
 --- extracts the code block into the detail
----@param detail string
----@param documentation string
----@return string, string
---- TODO: Also move the code block into detail if it's at the start of the doc
---- and we have no detail
+--- TODO: Also move the code block into detail if it's at the start of the doc and we have no detail
+--- @param detail string
+--- @param documentation string?
+--- @return string, string?
 function docs.extract_detail_from_doc(detail, documentation)
+  if not documentation then return detail, documentation end
+
   local detail_lines = docs.split_lines(detail)
   local doc_lines = docs.split_lines(documentation)
-
   local doc_str_detail_row = documentation:find(detail, 1, true)
 
-  -- didn't find the detail in the doc, so return as is
-  if doc_str_detail_row == nil or #detail == 0 or #documentation == 0 then return detail, documentation end
+  -- Nothing to extract. Detail or documentation is empty, or detail not found in documentation
+  if #detail == 0 or #documentation == 0 or not doc_str_detail_row then return detail, documentation end
 
   -- get the line of the match
   -- hack: surely there's a better way to do this but it's late
@@ -83,6 +83,8 @@ function docs.extract_detail_from_doc(detail, documentation)
   return table.concat(detail_lines, '\n'), table.concat(doc_lines, '\n')
 end
 
+--- @param text string
+--- @return string[]
 function docs.split_lines(text)
   local lines = {}
   for s in text:gmatch('[^\r\n]+') do

--- a/lua/blink/cmp/sources/lsp/hacks/lua_ls.lua
+++ b/lua/blink/cmp/sources/lsp/hacks/lua_ls.lua
@@ -1,7 +1,7 @@
 local lua_ls = {}
 
---- @param response blink.cmp.CompletionResponse | nil
---- @return blink.cmp.CompletionResponse | nil
+--- @param response blink.cmp.CompletionResponse?
+--- @return blink.cmp.CompletionResponse?
 function lua_ls.process_response(response)
   if not response or not response.items then return response end
 

--- a/lua/blink/cmp/sources/lsp/hacks/tailwind.lua
+++ b/lua/blink/cmp/sources/lsp/hacks/tailwind.lua
@@ -2,11 +2,11 @@ local tailwind = {}
 
 local kinds = require('blink.cmp.types').CompletionItemKind
 
---- @param response blink.cmp.CompletionResponse | nil
---- @param icon string
---- @return blink.cmp.CompletionResponse | nil
+--- @param response? blink.cmp.CompletionResponse
+--- @param icon? string
+--- @return blink.cmp.CompletionResponse?
 function tailwind.process_response(response, icon)
-  if not response then return response end
+  if not response or not icon then return response end
 
   local items = response.items
   if not items then return response end

--- a/lua/blink/cmp/sources/lsp/init.lua
+++ b/lua/blink/cmp/sources/lsp/init.lua
@@ -103,8 +103,9 @@ function lsp:resolve(item, callback)
 
     -- Snippet with no detail, fill in the detail with the snippet
     if resolved_item.detail == nil and resolved_item.insertTextFormat == vim.lsp.protocol.InsertTextFormat.Snippet then
-      local parsed_snippet = require('blink.cmp.sources.snippets.utils').safe_parse(item.insertText)
-      local snippet = parsed_snippet and tostring(parsed_snippet) or item.insertText
+      local text_edit = require('blink.cmp.lib.text_edits').get_from_item(item)
+      local parsed_snippet = require('blink.cmp.sources.snippets.utils').safe_parse(text_edit.newText)
+      local snippet = parsed_snippet and tostring(parsed_snippet) or text_edit.newText
       resolved_item.detail = snippet
     end
 

--- a/lua/blink/cmp/sources/lsp/init.lua
+++ b/lua/blink/cmp/sources/lsp/init.lua
@@ -95,6 +95,7 @@ function lsp:resolve(item, callback)
   -- strip blink specific fields to avoid decoding errors on some LSPs
   item = require('blink.cmp.sources.lib.utils').blink_item_to_lsp_item(item)
 
+  --- @param resolved_item lsp.CompletionItem
   local success, request_id = client:request('completionItem/resolve', item, function(error, resolved_item)
     if error or resolved_item == nil then
       callback(item)
@@ -103,10 +104,15 @@ function lsp:resolve(item, callback)
 
     -- Snippet with no detail, fill in the detail with the snippet
     if resolved_item.detail == nil and resolved_item.insertTextFormat == vim.lsp.protocol.InsertTextFormat.Snippet then
-      local text_edit = require('blink.cmp.lib.text_edits').get_from_item(item)
-      local parsed_snippet = require('blink.cmp.sources.snippets.utils').safe_parse(text_edit.newText)
-      local snippet = parsed_snippet and tostring(parsed_snippet) or text_edit.newText
-      resolved_item.detail = snippet
+      -- Follows spec using textEdit.newText if available then insertText as fallback.
+      -- Deliberately excludes label, it's a display string, not governed by InsertTextFormat
+      local snippet_text = (resolved_item.textEdit and resolved_item.textEdit.newText)
+        or resolved_item.insertText
+        or item.insertText
+      if snippet_text ~= nil then
+        local parsed_snippet = require('blink.cmp.sources.snippets.utils').safe_parse(snippet_text)
+        resolved_item.detail = parsed_snippet and tostring(parsed_snippet) or snippet_text
+      end
     end
 
     -- Lua LSP returns the detail like `table` while the documentation contains the signature

--- a/lua/blink/cmp/sources/lsp/init.lua
+++ b/lua/blink/cmp/sources/lsp/init.lua
@@ -33,7 +33,7 @@ function lsp:get_trigger_characters()
   local trigger_characters = {}
 
   for _, client in pairs(clients) do
-    local completion_provider = client.server_capabilities.completionProvider
+    local completion_provider = client.server_capabilities and client.server_capabilities.completionProvider
     if completion_provider and completion_provider.triggerCharacters then
       for _, trigger_character in pairs(completion_provider.triggerCharacters) do
         table.insert(trigger_characters, trigger_character)
@@ -46,10 +46,10 @@ end
 
 function lsp:get_completions(context, callback)
   local completion_lib = require('blink.cmp.sources.lsp.completion')
-  local clients = vim.tbl_filter(
-    function(client) return client.server_capabilities and client.server_capabilities.completionProvider end,
-    vim.lsp.get_clients({ bufnr = 0, method = 'textDocument/completion' })
-  )
+  local clients = vim.tbl_filter(function(client)
+    local caps = client.server_capabilities
+    return caps ~= nil and caps.completionProvider ~= nil
+  end, vim.lsp.get_clients({ bufnr = 0, method = 'textDocument/completion' }))
 
   -- TODO: implement a timeout before returning the menu as-is. In the future, it would be neat
   -- to detect slow LSPs and consistently run them async
@@ -76,8 +76,18 @@ end
 --- Resolve ---
 
 function lsp:resolve(item, callback)
+  if not item.client_id then
+    callback(item)
+    return
+  end
+
   local client = vim.lsp.get_client_by_id(item.client_id)
-  if client == nil or not client.server_capabilities.completionProvider.resolveProvider then
+  if
+    not client
+    or not client.server_capabilities
+    or not client.server_capabilities.completionProvider
+    or not client.server_capabilities.completionProvider.resolveProvider
+  then
     callback(item)
     return
   end
@@ -122,7 +132,7 @@ function lsp:get_signature_help_trigger_characters()
   local retrigger_characters = {}
 
   for _, client in pairs(clients) do
-    local signature_help_provider = client.server_capabilities.signatureHelpProvider
+    local signature_help_provider = client.server_capabilities and client.server_capabilities.signatureHelpProvider
     if signature_help_provider and signature_help_provider.triggerCharacters then
       for _, trigger_character in pairs(signature_help_provider.triggerCharacters) do
         table.insert(trigger_characters, trigger_character)
@@ -150,6 +160,8 @@ function lsp:get_signature_help(context, callback)
   local offset_encoding = first_client and first_client.offset_encoding or 'utf-16'
 
   local params = vim.lsp.util.make_position_params(nil, offset_encoding)
+
+  ---@diagnostic disable-next-line: inject-field
   params.context = {
     triggerKind = context.trigger.kind,
     triggerCharacter = context.trigger.character,
@@ -178,12 +190,16 @@ end
 function lsp:execute(ctx, item, callback, default_implementation)
   default_implementation()
 
-  local client = vim.lsp.get_client_by_id(item.client_id)
-  if client and lib.is_not_nil(item.command) then
-    client:exec_cmd(item.command, { bufnr = ctx.bufnr }, function() callback() end)
-  else
-    callback()
+  if item.client_id then
+    local client = vim.lsp.get_client_by_id(item.client_id)
+    local cmd = item.command
+    if client and lib.is_not_nil(cmd) then
+      client:exec_cmd(cmd, { bufnr = ctx.bufnr }, function() callback() end)
+      return
+    end
   end
+
+  callback()
 end
 
 return lsp

--- a/lua/blink/cmp/sources/path/init.lua
+++ b/lua/blink/cmp/sources/path/init.lua
@@ -1,4 +1,4 @@
--- credit to https://github.com/hrsh7th/cmp-path for the original implementation
+-- Credit to https://github.com/hrsh7th/cmp-path for the original implementation
 -- and https://codeberg.org/FelipeLema/cmp-async-path for the async implementation
 
 -- TODO: more advanced detection of windows vs unix paths to resolve escape sequences
@@ -10,9 +10,9 @@
 --- @field get_cwd fun(context: blink.cmp.Context): string
 --- @field show_hidden_files_by_default boolean
 --- @field ignore_root_slash boolean
---- @field max_entries number  Maximum number of files/directories to return. This limits memory use and responsiveness for very large folders. Defaults to 10000
+--- @field max_entries integer Maximum number of files/directories to return. This limits memory use and responsiveness for very large folders. Defaults to 10000
 
---- @class blink.cmp.Source
+--- @class blink.cmp.PathSource : blink.cmp.Source
 --- @field opts blink.cmp.PathOpts
 local path = {}
 
@@ -38,7 +38,7 @@ function path.new(opts)
   -- }, opts)
 
   self.opts = opts
-  return self --[[@as blink.cmp.Source]]
+  return self
 end
 
 function path:get_trigger_characters() return { '/', '.', '\\' } end

--- a/lua/blink/cmp/sources/path/lib.lua
+++ b/lua/blink/cmp/sources/path/lib.lua
@@ -1,4 +1,3 @@
-local task = require('blink.lib.task')
 local regex = require('blink.cmp.sources.path.regex')
 local lib = require('blink.lib')
 

--- a/lua/blink/cmp/sources/path/lib.lua
+++ b/lua/blink/cmp/sources/path/lib.lua
@@ -198,12 +198,7 @@ end
 function path_lib:compute_unique_suffixes(paths)
   local is_windows = vim.fn.has('win32') == 1
   local sep = is_windows and '\\' or '/'
-  if is_windows then
-    paths = vim.tbl_map(function(path)
-      local p = path:gsub('/', '\\')
-      return p
-    end, paths)
-  end
+  if is_windows then paths = vim.tbl_map(function(path) return (path:gsub('/', '\\')) end, paths) end
 
   -- if not enough paths, return as is
   local n = #paths

--- a/lua/blink/cmp/sources/path/lib.lua
+++ b/lua/blink/cmp/sources/path/lib.lua
@@ -66,36 +66,36 @@ function path_lib.candidates(context, dirname, include_hidden, opts)
         local kind = entry.type == 'directory' and ranges.directory or ranges.file
         return path_lib.entry_to_completion_item(entry, dirname, kind, opts)
       end
-    end, entries)
-  end)
+    end)
+  end) --[[@as blink.lib.Task<blink.lib.fs.DirEntry[]>]]
 end
 
 function path_lib.is_slash_comment()
   local commentstring = vim.bo.commentstring or ''
   local no_filetype = vim.bo.filetype == ''
-  local is_slash_comment = false
-  is_slash_comment = is_slash_comment or commentstring:match('/%*')
-  is_slash_comment = is_slash_comment or commentstring:match('//')
+  local is_slash_comment = commentstring:match('/%*') ~= nil
+  is_slash_comment = is_slash_comment or commentstring:match('//') ~= nil
   return is_slash_comment and not no_filetype
 end
 
 --- @param entry { name: string, type: string, stat: table }
 --- @param dirname string
 --- @param range lsp.Range
---- @param opts table
---- @return blink.cmp.CompletionItem[]
+--- @param opts blink.cmp.PathOpts
+--- @return blink.cmp.CompletionItem
 function path_lib.entry_to_completion_item(entry, dirname, range, opts)
   local is_dir = entry.type == 'directory'
   local CompletionItemKind = require('blink.cmp.types').CompletionItemKind
   local insert_text = is_dir and opts.trailing_slash and entry.name .. '/' or entry.name
+
   return {
-    label = (opts.label_trailing_slash and is_dir) and entry.name .. '/' or entry.name,
+    label = opts.label_trailing_slash and is_dir and entry.name .. '/' or entry.name,
     kind = is_dir and CompletionItemKind.Folder or CompletionItemKind.File,
     insertText = insert_text,
     textEdit = { newText = insert_text, range = range },
     sortText = (is_dir and '1' or '2') .. entry.name:lower(), -- Sort directories before files
     data = { path = entry.name, full_path = dirname .. '/' .. entry.name, type = entry.type },
-  }
+  } --[[@as blink.cmp.CompletionItem]]
 end
 
 --- @param context blink.cmp.Context
@@ -121,7 +121,7 @@ function path_lib.get_text_edit_ranges(context)
 end
 
 --- @param path string
---- @return number
+--- @return integer
 function path_lib.get_last_path_part(path)
   local i = #path
   local start_pos = 1
@@ -199,7 +199,12 @@ end
 function path_lib:compute_unique_suffixes(paths)
   local is_windows = vim.fn.has('win32') == 1
   local sep = is_windows and '\\' or '/'
-  if is_windows then paths = vim.tbl_map(function(path) return path:gsub('/', '\\') end, paths) end
+  if is_windows then
+    paths = vim.tbl_map(function(path)
+      local p = path:gsub('/', '\\')
+      return p
+    end, paths)
+  end
 
   -- if not enough paths, return as is
   local n = #paths
@@ -210,10 +215,10 @@ function path_lib:compute_unique_suffixes(paths)
   end
 
   -- reverse the paths and sort so that similar suffixes are adjacent
-  local reversed_paths = {}
-  local original_to_reversed = {}
+  local reversed_paths = {} ---@type string[]
+  local original_to_reversed = {} ---@type table<string, string>
   for i = 1, n do
-    local path = paths[i]
+    local path = assert(paths[i])
     local rev = path:reverse()
     table.insert(reversed_paths, rev)
     original_to_reversed[path] = rev
@@ -221,14 +226,14 @@ function path_lib:compute_unique_suffixes(paths)
   table.sort(reversed_paths)
 
   -- find minimum suffix length for each path
-  local min_lengths = {}
+  local min_lengths = {} ---@type table<string, integer>
   for i = 1, n do
-    local rev = reversed_paths[i]
+    local rev = assert(reversed_paths[i])
     local max_common = 0
 
     -- check previous neighbor
     if i > 1 then
-      local prev = reversed_paths[i - 1]
+      local prev = assert(reversed_paths[i - 1])
       local common = 0
       local min_len = math.min(#rev, #prev)
       while common < min_len and rev:byte(common + 1) == prev:byte(common + 1) do
@@ -239,7 +244,7 @@ function path_lib:compute_unique_suffixes(paths)
 
     -- check next neighbor
     if i < n then
-      local next = reversed_paths[i + 1]
+      local next = assert(reversed_paths[i + 1])
       local common = 0
       local min_len = math.min(#rev, #next)
       while common < min_len and rev:byte(common + 1) == next:byte(common + 1) do
@@ -264,15 +269,11 @@ function path_lib:compute_unique_suffixes(paths)
   -- build mapping of original_str -> unique_suffix_str
   local result = {}
   for i = 1, n do
-    local path = paths[i]
+    local path = assert(paths[i])
     local rev = original_to_reversed[path]
-
     local suffix_len = min_lengths[rev]
-    if suffix_len > #path then
-      result[path] = path
-    else
-      result[path] = path:sub(#path - suffix_len + 1)
-    end
+
+    result[path] = suffix_len > #path and path or path:sub(#path - suffix_len + 1)
   end
 
   return result

--- a/lua/blink/cmp/sources/snippets/default/builtin.lua
+++ b/lua/blink/cmp/sources/snippets/default/builtin.lua
@@ -27,16 +27,22 @@ builtin.lazy.TM_FILENAME = cached(function() return vim.fn.expand('%:t') end)
 builtin.lazy.TM_FILENAME_BASE = cached(function() return vim.fn.expand('%:t:s?\\.[^\\.]\\+$??') end)
 builtin.lazy.TM_DIRECTORY = cached(function() return vim.fn.expand('%:p:h') end)
 builtin.lazy.TM_FILEPATH = cached(function() return vim.fn.expand('%:p') end)
-builtin.lazy.TM_SELECTED_TEXT = cached(function() return vim.fn.trim(vim.fn.getreg(vim.v.register, true), '\n', 2) end)
+builtin.lazy.TM_SELECTED_TEXT = cached(function()
+  return vim.fn.trim(vim.fn.getreg(vim.v.register) --[[@as string]], '\n', 2)
+end)
 builtin.lazy.CLIPBOARD = cached(
-  function(opts) return vim.fn.getreg(opts.clipboard_register or vim.v.register, true) end
+  ---@param opts blink.cmp.SnippetsOpts
+  ---@return string
+  function(opts)
+    return vim.fn.getreg(opts.clipboard_register or vim.v.register) --[[@as string]]
+  end
 )
 
 local function buf_to_ws_part()
   local LSP_WORKSPACE_PARTS = 'LSP_WORKSPACE_PARTS'
   local ok, ws_parts = pcall(nvim.buf_get_var, 0, LSP_WORKSPACE_PARTS)
   if not ok then
-    local file_path = vim.fn.expand('%:p')
+    local file_path = vim.fn.expand('%:p') --[[@as string]]
 
     for _, ws in pairs(vim.lsp.buf.list_workspace_folders()) do
       if file_path:find(ws, 1, true) == 1 then

--- a/lua/blink/cmp/sources/snippets/default/registry.lua
+++ b/lua/blink/cmp/sources/snippets/default/registry.lua
@@ -12,6 +12,8 @@ local registry = {
 }
 
 local utils = require('blink.cmp.sources.snippets.utils')
+
+---@type blink.cmp.SnippetsOpts
 local default_config = {
   friendly_snippets = true,
   search_paths = { vim.fn.stdpath('config') .. '/snippets' },
@@ -127,7 +129,6 @@ function registry:snippet_to_completion_item(snippet, context)
     end
   end
 
-  ---@type blink.cmp.CompletionItem
   return {
     kind = require('blink.cmp.types').CompletionItemKind.Snippet,
     label = snippet.prefix,
@@ -143,7 +144,7 @@ function registry:snippet_to_completion_item(snippet, context)
       },
       newText = new_text,
     },
-  }
+  } --[[@as blink.cmp.CompletionItem]]
 end
 
 --- @param snippet string
@@ -173,7 +174,7 @@ function registry:expand_vars(snippet, cache_key)
 
       if eager_vars[data.name] then
         replacement = eager_vars[data.name]
-      elseif lazy_vars[data.name] then
+      elseif lazy_vars[data.name] ~= nil then
         replacement = lazy_vars[data.name](cache_key, { clipboard_register = self.config.clipboard_register })
       end
 

--- a/lua/blink/cmp/sources/snippets/default/registry.lua
+++ b/lua/blink/cmp/sources/snippets/default/registry.lua
@@ -119,7 +119,7 @@ function registry:snippet_to_completion_item(snippet, context)
   local cur_line, cur_col = unpack(context.cursor)
 
   -- Find the position of the (longest partial) prefix just before the cursor
-  local start_col
+  local start_col ---@type integer?
   local line = context.get_line():sub(1, cur_col)
   for i = #snippet.prefix, 1, -1 do
     local pos = cur_col - i + 1
@@ -148,7 +148,7 @@ function registry:snippet_to_completion_item(snippet, context)
 end
 
 --- @param snippet string
---- @param cache_key number
+--- @param cache_key integer
 --- @return string
 function registry:expand_vars(snippet, cache_key)
   local lazy_vars = self.builtin_vars.lazy

--- a/lua/blink/cmp/sources/snippets/default/scan.lua
+++ b/lua/blink/cmp/sources/snippets/default/scan.lua
@@ -8,7 +8,7 @@ function scan.register_snippets(search_paths)
     local files = scan.load_package_json(path) or scan.scan_for_snippets(path)
     for ft, file in pairs(files) do
       local key
-      if type(ft) == 'number' then
+      if type(ft) == 'number' and files[ft] then
         key = vim.fn.fnamemodify(files[ft], ':t:r')
       else
         key = ft
@@ -28,10 +28,11 @@ function scan.register_snippets(search_paths)
   return registry
 end
 
----@type fun(self: utils, dir: string, result?: string[]): string[]
+---@param dir string
+---@param result string[]?
 ---@return string[]
 function scan.scan_for_snippets(dir, result)
-  result = result or {}
+  result = result or {} --[[@as string[] ]]
 
   local stat = vim.uv.fs_stat(dir)
   if not stat then return result end
@@ -68,7 +69,7 @@ end
 ---@param path string
 function scan.load_package_json(path)
   local file = path .. '/package.json'
-  -- todo: ideally this is async, although it takes 0.5ms on my system so it might not matter
+  -- TODO: ideally this is async, although it takes 0.5ms on my system so it might not matter
   local data = utils.read_file(file)
   if not data then return end
 

--- a/lua/blink/cmp/sources/snippets/luasnip.lua
+++ b/lua/blink/cmp/sources/snippets/luasnip.lua
@@ -15,7 +15,7 @@ local kind_snippet = require('blink.cmp.types').CompletionItemKind.Snippet
 --- @field use_label_description? boolean Whether to put the snippet description in the label description
 
 ---@class blink.cmp.LuasnipItemData
----@field snip_id number
+---@field snip_id integer
 ---@field show_condition function
 ---@field raw_text string
 
@@ -26,7 +26,7 @@ local kind_snippet = require('blink.cmp.types').CompletionItemKind.Snippet
 local source = {}
 
 ---@param snippet table
----@param event number
+---@param event integer
 ---@param callback fun(table, table)
 local function add_luasnip_callback(snippet, event, callback)
   -- not defined for autosnippets

--- a/lua/blink/cmp/sources/snippets/luasnip.lua
+++ b/lua/blink/cmp/sources/snippets/luasnip.lua
@@ -1,3 +1,6 @@
+-- FIXME: Some annotations are based on an ummerged PR: https://github.com/L3MON4D3/LuaSnip/pull/1396
+---@diagnostic disable: undefined-field
+
 ---@type LuaSnip.API
 local luasnip
 local cmp = require('blink.cmp')
@@ -60,7 +63,12 @@ local function choice_callback(snippet, events)
           -- FIXME: Defer showing the completion menu when jumping to the next choice node.
           -- This is needed if the previous node is also a choice node. Possible race condition?
           -- e.g., previous node (menu shown) -> jump -> (menu hidden) -> next node (menu shown)
-          vim.defer_fn(function() cmp.show({ initial_selected_item_idx = index, providers = { 'snippets' } }) end, 50)
+          vim.defer_fn(function()
+            cmp.show({
+              initial_selected_item_idx = index,
+              providers = { 'snippets' },
+            } --[[@as blink.cmp.ShowOpts]])
+          end, 50)
         end,
         [events.change_choice] = function()
           -- Auto-jump after accepting the choice value
@@ -68,7 +76,7 @@ local function choice_callback(snippet, events)
         end,
         [events.leave] = function(n)
           --[[@cast n LuaSnip.ChoiceNode]]
-          n:set_text(n.active_choice.static_text)
+          if n.active_choice then n:set_text(n.active_choice.static_text) end
         end,
       }
     end
@@ -149,8 +157,6 @@ end
 
 function source:enabled() return self.has_loaded end
 
----@param ctx blink.cmp.Context
----@param callback fun(result?: blink.cmp.CompletionResponse)
 function source:get_completions(ctx, callback)
   --- @type blink.cmp.CompletionItem[]
   local items = {}
@@ -262,8 +268,6 @@ function source:get_completions(ctx, callback)
   })
 end
 
----@param item blink.cmp.CompletionItem
----@param callback fun(resolved_item?: lsp.CompletionItem)
 function source:resolve(item, callback)
   local snip = luasnip.get_id_snippet(item.data.snip_id)
 
@@ -284,8 +288,6 @@ function source:resolve(item, callback)
   callback(resolved_item)
 end
 
----@param ctx blink.cmp.Context
----@param item blink.cmp.CompletionItem
 function source:execute(ctx, item)
   if item.data.choice_index then
     luasnip.set_choice(item.data.choice_index)
@@ -298,7 +300,7 @@ function source:execute(ctx, item)
   if snip.regTrig then
     local docTrig = snip.docTrig
     snip = snip:get_pattern_expand_helper()
-    if docTrig then add_luasnip_callback(snip, events.pre_expand, function(s) regex_callback(s, docTrig) end) end
+    if docTrig ~= nil then add_luasnip_callback(snip, events.pre_expand, function(s) regex_callback(s, docTrig) end) end
   else
     add_luasnip_callback(snip, events.pre_expand, function(s) choice_callback(s, events) end)
   end

--- a/lua/blink/cmp/sources/snippets/utils.lua
+++ b/lua/blink/cmp/sources/snippets/utils.lua
@@ -19,7 +19,8 @@ function utils.parse_json_with_error_msg(path, json)
   return parsed
 end
 
----@type fun(path: string): string|nil
+---@param path string
+---@return string?
 function utils.read_file(path)
   local file = io.open(path, 'r')
   if not file then return nil end
@@ -28,7 +29,8 @@ function utils.read_file(path)
   return content
 end
 
----@type fun(input: string): vim.snippet.Node<vim.snippet.SnippetData>|nil
+---@param input string
+---@return vim.snippet.Node<vim.snippet.SnippetData>?
 function utils.safe_parse(input)
   if utils.parse_cache[input] then return utils.parse_cache[input] end
 
@@ -39,7 +41,9 @@ function utils.safe_parse(input)
   return parsed
 end
 
----@type fun(snippet: blink.cmp.Snippet, fallback: string): table
+---@param snippet blink.cmp.Snippet
+---@param fallback string
+---@return table
 function utils.read_snippet(snippet, fallback)
   local snippets = {}
   local prefix = snippet.prefix or fallback
@@ -66,9 +70,9 @@ function utils.read_snippet(snippet, fallback)
   return snippets
 end
 
--- Add the current line's indentation to all but the first line of
--- the provided text
+-- Add the current line's indentation to all but the first line of the provided text
 ---@param text string
+---@return string
 function utils.add_current_line_indentation(text)
   local base_indent = vim.api.nvim_get_current_line():match('^%s*') or ''
   local snippet_lines = vim.split(text, '\n', { plain = true })
@@ -89,27 +93,6 @@ function utils.add_current_line_indentation(text)
   end
 
   return table.concat(lines, '\n')
-end
-
-function utils.get_tab_stops(snippet)
-  local expanded_snippet = require('blink.cmp.sources.snippets.utils').safe_parse(snippet)
-  if not expanded_snippet then return end
-
-  local tabstops = {}
-  local grammar = require('vim.lsp._snippet_grammar')
-  local line = 1
-  local character = 1
-  for _, child in ipairs(expanded_snippet.data.children) do
-    local lines = tostring(child) == '' and {} or vim.split(tostring(child), '\n')
-    line = line + math.max(#lines - 1, 0)
-    character = #lines == 0 and character or #lines > 1 and #lines[#lines] or (character + #lines[#lines])
-    if child.type == grammar.NodeType.Placeholder or child.type == grammar.NodeType.Tabstop then
-      table.insert(tabstops, { index = child.data.tabstop, line = line, character = character })
-    end
-  end
-
-  table.sort(tabstops, function(a, b) return a.index < b.index end)
-  return tabstops
 end
 
 return utils

--- a/lua/blink/cmp/types.lua
+++ b/lua/blink/cmp/types.lua
@@ -3,7 +3,7 @@
 --- @alias blink.cmp.CursorPos { [1]: integer, [2]: integer }
 
 --- @class blink.cmp.CompletionItem : lsp.CompletionItem
---- @field documentation? string | { kind: lsp.MarkupKind, value: string, draw?: fun(opts?: blink.cmp.CompletionDocumentationDrawOpts) }
+--- @field documentation? string | blink.cmp.CompletionDocumentationMarkupContent
 --- @field score_offset? integer
 --- @field source_id string
 --- @field source_name string

--- a/lua/blink/cmp/types.lua
+++ b/lua/blink/cmp/types.lua
@@ -1,18 +1,20 @@
 --- @alias blink.cmp.Mode 'cmdline' | 'cmdwin' | 'term' | 'default'
 
+--- @alias blink.cmp.CursorPos { [1]: integer, [2]: integer }
+
 --- @class blink.cmp.CompletionItem : lsp.CompletionItem
 --- @field documentation? string | { kind: lsp.MarkupKind, value: string, draw?: fun(opts?: blink.cmp.CompletionDocumentationDrawOpts) }
---- @field score_offset? number
+--- @field score_offset? integer
 --- @field source_id string
 --- @field source_name string
---- @field cursor_column number
---- @field client_id? number
+--- @field cursor_column integer
+--- @field client_id? integer
 --- @field client_name? string
 --- @field kind_name? string
 --- @field kind_icon? string
 --- @field kind_hl? string
 --- @field exact? boolean
---- @field score? number
+--- @field score? integer
 
 return {
   -- some plugins mutate the vim.lsp.protocol.CompletionItemKind table

--- a/plugin/blink-cmp.lua
+++ b/plugin/blink-cmp.lua
@@ -14,9 +14,10 @@ vim.api.nvim_create_user_command('BlinkCmp', function(cmd)
   local subcmd_name = cmd.fargs[1]
   local subcmd = subcommands[subcmd_name]
 
-  if subcmd then
+  if type(subcmd) == 'function' then
     subcmd()
   else
-    vim.notify("[blink.cmp] invalid subcommand '" .. tostring(subcmd_name) .. "'", vim.log.levels.ERROR)
+    local logger = require('blink.cmp.logger')
+    logger:notify(vim.log.levels.ERROR, "Invalid subcommand '" .. tostring(subcmd_name) .. "'")
   end
 end, { nargs = 1, complete = function() return vim.tbl_keys(subcommands) end, desc = 'blink.cmp' })


### PR DESCRIPTION
Update type annotations across the codebase and fix relevant `emmylua-analyzer-rust` warnings. Main goal is better type coverage and fewer analyzer warnings but a few small robustness tweaks and cleanups slipped in along the way :) 

I admit the diff is quite large but most changes are mechanical type fixes rather than risky refactors, so no behavior changes are expected and it should stay reasonably easy to review.
