### PR TITLE
refactor: migrate cursor handling to vim.Pos

### DIFF
--- a/lua/blink/cmp/completion/accept/init.lua
+++ b/lua/blink/cmp/completion/accept/init.lua
@@ -64,12 +64,9 @@ local function apply_item(ctx, item)
 
     -- OR Normal: Apply the text edit and move the cursor
   else
-    local new_cursor = text_edits_lib.get_apply_end_position(item.textEdit, all_text_edits)
-    new_cursor[2] = new_cursor[2]
-
+    local new_pos = text_edits_lib.get_apply_end_position(item.textEdit, all_text_edits)
     text_edits_lib.apply(item.textEdit, all_text_edits)
-
-    ctx.set_cursor(new_cursor)
+    ctx.set_cursor(new_pos)
     text_edits_lib.move_cursor_in_dot_repeat(offset)
   end
 

--- a/lua/blink/cmp/completion/accept/preview.lua
+++ b/lua/blink/cmp/completion/accept/preview.lua
@@ -1,7 +1,7 @@
 local nvim = require('blink.lib.nvim')
 
 --- @param item blink.cmp.CompletionItem
---- @return lsp.TextEdit, blink.cmp.CursorPos?
+--- @return lsp.TextEdit, vim.Pos?
 local function preview(item)
   local text_edits_lib = require('blink.cmp.lib.text_edits')
   local text_edit = text_edits_lib.get_from_item(item)
@@ -16,7 +16,7 @@ local function preview(item)
   -- only keep the first line.
   text_edit.newText = vim.split(text_edit.newText, '\n', { plain = true, trimempty = true })[1] or '' -- vim.split returns an empty list if the string was empty, making [1] nil
 
-  local original_cursor = nvim.win_get_cursor(0)
+  local original_pos = vim.pos.cursor(0)
   local cursor_pos = {
     text_edit.range.start.line + 1,
     text_edit.range.start.character + #text_edit.newText,
@@ -33,7 +33,7 @@ local function preview(item)
     cursor_moved = true
   end
 
-  return undo_text_edit, cursor_moved and original_cursor or nil
+  return undo_text_edit, cursor_moved and original_pos or nil
 end
 
 return preview

--- a/lua/blink/cmp/completion/brackets/config.lua
+++ b/lua/blink/cmp/completion/brackets/config.lua
@@ -1,5 +1,5 @@
 local css_exceptions = function(ctx)
-  local str = string.sub(ctx.line, 1, ctx.cursor[2] or #ctx.line)
+  local str = string.sub(ctx.line, 1, ctx.pos.col or #ctx.line)
   return not str:find('[%w_-]*::?[%w-]*$')
 end
 local typescript_exceptions = function(ctx) return ctx.line:find('^%s*import%s') == nil end

--- a/lua/blink/cmp/completion/brackets/semantic.lua
+++ b/lua/blink/cmp/completion/brackets/semantic.lua
@@ -4,7 +4,7 @@ local config = require('blink.cmp.config').completion.accept.auto_brackets
 local utils = require('blink.cmp.completion.brackets.utils')
 
 --- @class blink.cmp.SemanticRequest
---- @field cursor blink.cmp.CursorPos
+--- @field pos vim.Pos
 --- @field item blink.cmp.CompletionItem
 --- @field filetype string
 --- @field callback fun(added: boolean)
@@ -34,17 +34,18 @@ function semantic.process_request(tokens)
   local request = semantic.request
   if request == nil then return end
 
-  local cursor = nvim.win_get_cursor(0)
+  local pos = vim.pos.cursor(0)
+
   -- cancel if the cursor moved
-  if request.cursor[1] ~= cursor[1] or request.cursor[2] ~= cursor[2] then return semantic.finish_request() end
+  if request.pos ~= pos then return semantic.finish_request() end
 
   for _, token in ipairs(tokens) do
     if
       (token.type == 'function' or token.type == 'method')
-      and cursor[1] - 1 == token.line
-      and cursor[2] >= token.start_col
+      and pos.row == token.line
+      and pos.col >= token.start_col
       -- we do <= to check 1 character before the cursor (`bar|` would check `r`)
-      and cursor[2] <= token.end_col
+      and pos.col <= token.end_col
     then
       -- add the brackets
       -- TODO: make dot repeatable
@@ -55,12 +56,12 @@ function semantic.process_request(tokens)
         {
           newText = brackets_for_filetype[1] .. brackets_for_filetype[2],
           range = {
-            start = { line = cursor[1] - 1, character = start_col },
-            ['end'] = { line = cursor[1] - 1, character = start_col },
+            start = { line = pos.row, character = start_col },
+            ['end'] = { line = pos.row, character = start_col },
           },
         },
       }, nvim.get_current_buf(), 'utf-8')
-      nvim.win_set_cursor(0, { cursor[1], start_col + #brackets_for_filetype[1] })
+      nvim.win_set_cursor(0, { pos.row + 1, start_col + #brackets_for_filetype[1] })
       return semantic.finish_request()
     end
   end
@@ -89,9 +90,9 @@ function semantic.add_brackets_via_semantic_token(ctx, filetype, item)
     if highlighter == nil then return resolve(false) end
 
     semantic.timer:stop()
-    local cursor = nvim.win_get_cursor(0)
+    local pos = vim.pos.cursor(0)
     semantic.request = {
-      cursor = nvim.win_get_cursor(0),
+      pos = pos,
       filetype = filetype,
       item = item,
       callback = resolve,
@@ -102,7 +103,7 @@ function semantic.add_brackets_via_semantic_token(ctx, filetype, item)
 
     -- first check if a semantic token already exists at the current cursor position
     -- we get the token 1 character before the cursor (`bar|` would check `r`)
-    local tokens = vim.lsp.semantic_tokens.get_at_pos(0, cursor[1] - 1, cursor[2] - 1)
+    local tokens = vim.lsp.semantic_tokens.get_at_pos(0, pos.row, pos.col - 1)
     if tokens ~= nil then semantic.process_request(tokens) end
     if semantic.request == nil then
       -- a matching token exists, and brackets were added

--- a/lua/blink/cmp/completion/list.lua
+++ b/lua/blink/cmp/completion/list.lua
@@ -140,9 +140,12 @@ end
 
 function list.fuzzy(ctx, items_by_source)
   local fuzzy = require('blink.cmp.fuzzy')
-  local pos = ctx.get_pos()
-  local filtered_items =
-    fuzzy.fuzzy(ctx.get_line(), pos.col, items_by_source, require('blink.cmp.config').completion.keyword.range)
+  local filtered_items = fuzzy.fuzzy(
+    ctx.get_line(),
+    ctx.get_pos().col,
+    items_by_source,
+    require('blink.cmp.config').completion.keyword.range
+  )
 
   -- apply the per source max_items
   filtered_items = require('blink.cmp.sources.lib').apply_max_items_for_completions(ctx, filtered_items)

--- a/lua/blink/cmp/completion/list.lua
+++ b/lua/blink/cmp/completion/list.lua
@@ -10,7 +10,7 @@
 --- @field items blink.cmp.CompletionItem[]
 --- @field selected_item_idx? integer
 --- @field is_explicitly_selected boolean
---- @field preview_undo? { text_edit: lsp.TextEdit, cursor_before?: blink.cmp.CursorPos, cursor_after: blink.cmp.CursorPos }
+--- @field preview_undo? { text_edit: lsp.TextEdit, pos_before?: vim.Pos, pos_after: vim.Pos }
 ---
 --- @field show fun(context: blink.cmp.Context, items: table<string, blink.cmp.CompletionItem[]>)
 --- @field fuzzy fun(context: blink.cmp.Context, items: table<string, blink.cmp.CompletionItem[]>): blink.cmp.CompletionItem[]
@@ -140,12 +140,9 @@ end
 
 function list.fuzzy(ctx, items_by_source)
   local fuzzy = require('blink.cmp.fuzzy')
-  local filtered_items = fuzzy.fuzzy(
-    ctx.get_line(),
-    ctx.get_cursor()[2],
-    items_by_source,
-    require('blink.cmp.config').completion.keyword.range
-  )
+  local pos = ctx.get_pos()
+  local filtered_items =
+    fuzzy.fuzzy(ctx.get_line(), pos.col, items_by_source, require('blink.cmp.config').completion.keyword.range)
 
   -- apply the per source max_items
   filtered_items = require('blink.cmp.sources.lib').apply_max_items_for_completions(ctx, filtered_items)
@@ -328,13 +325,13 @@ function list.undo_preview()
   -- The text edit may be out of date due to the user typing more characters
   -- so we adjust the range to compensate
   -- TODO: Set offset_encoding
-  local old_cursor_col = list.preview_undo.cursor_after[2]
-  local new_cursor_col = context.get_cursor()[2]
-  text_edit = text_edits_lib.compensate_for_cursor_movement(text_edit, old_cursor_col, new_cursor_col)
+  local old_pos = list.preview_undo.pos_after
+  local new_pos = context.get_pos()
+  text_edit = text_edits_lib.compensate_for_cursor_movement(text_edit, old_pos, new_pos)
 
   require('blink.cmp.lib.text_edits').apply(text_edit)
-  if list.preview_undo.cursor_before ~= nil then
-    require('blink.cmp.completion.trigger.context').set_cursor(list.preview_undo.cursor_before)
+  if list.preview_undo.pos_before ~= nil then
+    require('blink.cmp.completion.trigger.context').set_cursor(list.preview_undo.pos_before)
   end
 
   list.preview_undo = nil
@@ -345,11 +342,12 @@ function list.apply_preview(item)
   list.undo_preview()
 
   -- apply the new preview
-  local undo_text_edit, undo_cursor = require('blink.cmp.completion.accept.preview')(item)
+  local undo_text_edit, undo_pos = require('blink.cmp.completion.accept.preview')(item)
+
   list.preview_undo = {
     text_edit = undo_text_edit,
-    cursor_before = undo_cursor,
-    cursor_after = context.get_cursor(),
+    pos_before = undo_pos,
+    pos_after = context.get_pos(),
   }
 end
 

--- a/lua/blink/cmp/completion/trigger/context.lua
+++ b/lua/blink/cmp/completion/trigger/context.lua
@@ -102,7 +102,6 @@ function context:within_query_bounds(include_start_bound)
   if cursor_col > end_col then return false end
 
   if include_start_bound then return cursor_col >= bounds.start_col end
-
   return cursor_col > bounds.start_col
 end
 
@@ -123,7 +122,6 @@ end
 function context.get_pos()
   local bufnr = context.bufnr or 0
   if context.get_mode() == 'cmdline' then return vim.pos(bufnr, 0, vim.fn.getcmdpos() - 1) end
-
   return vim.pos.cursor(bufnr)
 end
 
@@ -152,7 +150,6 @@ function context.get_line(num)
 
   -- This method works for normal buffers and the terminal prompt
   if not num then num = context.get_pos().row end
-
   return nvim.buf_get_lines(0, num, num + 1, false)[1] or ''
 end
 

--- a/lua/blink/cmp/completion/trigger/context.lua
+++ b/lua/blink/cmp/completion/trigger/context.lua
@@ -12,7 +12,8 @@ local nvim = require('blink.lib.nvim')
 --- @field mode blink.cmp.Mode
 --- @field id integer
 --- @field bufnr integer
---- @field cursor blink.cmp.CursorPos
+--- @field cursor { [1]: integer, [2]: integer } Deprecated, use `pos` instead
+--- @field pos vim.Pos
 --- @field line string
 --- @field term blink.cmp.ContextTerm
 --- @field bounds blink.cmp.ContextBounds
@@ -23,11 +24,12 @@ local nvim = require('blink.lib.nvim')
 ---
 --- @field new fun(opts: blink.cmp.ContextOpts): blink.cmp.Context
 --- @field get_keyword fun(): string
---- @field within_query_bounds fun(self: blink.cmp.Context, cursor: blink.cmp.CursorPos, include_start_bound?: boolean): boolean
+--- @field within_query_bounds fun(self: blink.cmp.Context, include_start_bound?: boolean): boolean
 ---
 --- @field get_mode fun(): blink.cmp.Mode
---- @field get_cursor fun(): blink.cmp.CursorPos
---- @field set_cursor fun(cursor: blink.cmp.CursorPos)
+--- @field get_pos fun(): vim.Pos
+--- @field get_cursor fun(): { [1]: integer, [2]: integer } Deprecated, use `get_pos` instead
+--- @field set_cursor fun(pos: vim.Pos)
 --- @field get_line fun(num?: integer): string
 --- @field get_bounds fun(range: blink.cmp.CompletionKeywordRange): blink.cmp.ContextBounds
 --- @field get_term_command fun(): blink.cmp.ContextTermCommand?
@@ -60,15 +62,15 @@ local nvim = require('blink.lib.nvim')
 local context = {}
 
 function context.new(opts)
-  local cursor = context.get_cursor()
-  local line = context.get_line()
+  local pos = context.get_pos()
 
   return setmetatable({
     mode = context.get_mode(),
     id = opts.id,
     bufnr = nvim.get_current_buf(),
-    cursor = cursor,
-    line = line,
+    pos = pos,
+    cursor = pos:to_cursor(),
+    line = context.get_line(),
     term = { command = context.get_term_command() },
     bounds = context.get_bounds('full'),
     trigger = {
@@ -89,18 +91,19 @@ function context.get_keyword()
   return string.sub(context.get_line(), range.start_col, range.start_col + range.length - 1)
 end
 
---- @param cursor blink.cmp.CursorPos
 --- @param include_start_bound? boolean Whether to include the start boundary as inside of the query. E.g. start_col = 1 (one indexed), cursor[2] = 0 (zero indexed) would be considered within the query bounds with this flag enabled.
 --- @return boolean
-function context:within_query_bounds(cursor, include_start_bound)
-  local row, col = cursor[1], cursor[2]
-  col = col + 1 -- Convert from 0-indexed to 1-indexed
+function context:within_query_bounds(include_start_bound)
+  local pos, bounds = self.pos, self.bounds
+  if pos.row + 1 ~= bounds.line_number then return false end
 
-  local bounds = self.bounds
-  if include_start_bound then
-    return row == bounds.line_number and col >= bounds.start_col and col <= (bounds.start_col + bounds.length)
-  end
-  return row == bounds.line_number and col > bounds.start_col and col <= (bounds.start_col + bounds.length)
+  local cursor_col = pos.col + 1
+  local end_col = bounds.start_col + bounds.length
+  if cursor_col > end_col then return false end
+
+  if include_start_bound then return cursor_col >= bounds.start_col end
+
+  return cursor_col > bounds.start_col
 end
 
 function context.get_mode()
@@ -117,20 +120,25 @@ function context.get_mode()
     or 'default'
 end
 
-function context.get_cursor()
-  return context.get_mode() == 'cmdline' and { 1, vim.fn.getcmdpos() - 1 } or nvim.win_get_cursor(0)
+function context.get_pos()
+  local bufnr = context.bufnr or 0
+  if context.get_mode() == 'cmdline' then return vim.pos(bufnr, 0, vim.fn.getcmdpos() - 1) end
+
+  return vim.pos.cursor(bufnr)
 end
 
-function context.set_cursor(cursor)
+function context.get_cursor() return context.get_pos():to_cursor() end
+
+function context.set_cursor(pos)
   local mode = context.get_mode()
   if vim.tbl_contains({ 'default', 'term', 'cmdwin' }, mode) then
-    nvim.win_set_cursor(0, cursor)
+    nvim.win_set_cursor(0, pos:to_cursor())
     return
   end
 
   assert(mode == 'cmdline', 'Unsupported mode for setting cursor: ' .. mode)
-  assert(cursor[1] == 1, 'Cursor must be on the first line in cmdline mode')
-  vim.fn.setcmdpos(cursor[2])
+  assert(pos.row == 0, 'Cursor must be on the first line in cmdline mode')
+  vim.fn.setcmdpos(pos.col + 1)
 end
 
 function context.get_line(num)
@@ -143,16 +151,18 @@ function context.get_line(num)
   end
 
   -- This method works for normal buffers and the terminal prompt
-  if num == nil then num = context.get_cursor()[1] - 1 end
+  if not num then num = context.get_pos().row end
+
   return nvim.buf_get_lines(0, num, num + 1, false)[1] or ''
 end
 
 --- Gets characters around the cursor and returns the range, 0-indexed
 function context.get_bounds(range)
   local line = context.get_line()
-  local cursor = context.get_cursor()
-  local start_col, end_col = require('blink.cmp.fuzzy').get_keyword_range(line, cursor[2], range)
-  return { line = line, line_number = cursor[1], start_col = start_col + 1, length = end_col - start_col }
+  local pos = context.get_pos()
+  local start_col, end_col = require('blink.cmp.fuzzy').get_keyword_range(line, pos.col, range)
+
+  return { line = line, line_number = pos.row + 1, start_col = start_col + 1, length = end_col - start_col }
 end
 
 --- Get the terminal command in the current line without the shell prompt.
@@ -168,18 +178,10 @@ end
 function context.get_term_command()
   if context.get_mode() ~= 'term' then return end
 
-  local cursor = context.get_cursor()
-  local cursor_row = cursor[1]
-  local cursor_col = cursor[2] + 1
-  local line = string.sub(context.get_line(), 1, cursor_col - 1)
-
-  local extmarks = nvim.buf_get_extmarks(
-    0,
-    nvim.create_namespace('blink_cmp_term_command_start'),
-    { cursor_row - 1, cursor_col - 1 },
-    { cursor_row - 1, 0 },
-    { limit = 1 }
-  )
+  local pos = context.get_pos()
+  local line = string.sub(context.get_line(), 1, pos.col)
+  local ns = nvim.create_namespace('blink_cmp_term_command_start')
+  local extmarks = nvim.buf_get_extmarks(0, ns, { pos.row, pos.col }, { pos.row, 0 }, { limit = 1 })
 
   --- If we find no mark for the start of the terminal command the terminal or shell
   --- probably does not support the FTCS_COMMAND_START escape sequence. The best effort

--- a/lua/blink/cmp/completion/trigger/init.lua
+++ b/lua/blink/cmp/completion/trigger/init.lua
@@ -67,11 +67,8 @@ local function on_char_added(char, is_ignored)
 end
 
 local function on_cursor_moved(event, is_ignored, is_backspace, last_event)
+  local pos = context.get_pos()
   local is_enter_event = event == 'InsertEnter' or event == 'TermEnter'
-
-  local cursor = context.get_cursor()
-  local cursor_col = cursor[2]
-
   local char_under_cursor = utils.get_char_at_cursor()
   local is_keyword = fuzzy.is_keyword_character(char_under_cursor)
 
@@ -100,7 +97,7 @@ local function on_cursor_moved(event, is_ignored, is_backspace, last_event)
   if
     trigger.context ~= nil
     and trigger.context.trigger.kind ~= 'prefetch'
-    and trigger.context:within_query_bounds(cursor, trigger.is_trigger_character(char_under_cursor))
+    and trigger.context:within_query_bounds(trigger.is_trigger_character(char_under_cursor))
   then
     trigger.show({ trigger_kind = 'keyword' })
 
@@ -110,7 +107,7 @@ local function on_cursor_moved(event, is_ignored, is_backspace, last_event)
     trigger.show({ trigger_kind = 'trigger_character', trigger_character = char_under_cursor })
 
   -- show if we currently have a context, and we've moved outside of it's bounds by 1 char
-  elseif is_keyword and trigger.context ~= nil and cursor_col == trigger.context.bounds.start_col - 1 then
+  elseif is_keyword and trigger.context ~= nil and pos.col == trigger.context.bounds.start_col - 1 then
     trigger.context = nil
     trigger.show({ trigger_kind = 'keyword' })
 
@@ -226,8 +223,8 @@ function trigger.show_if_on_trigger_character(opts)
     return
   end
 
-  local cursor_col = context.get_cursor()[2]
-  local char_under_cursor = context.get_line():sub(cursor_col, cursor_col)
+  local pos = context.get_pos()
+  local char_under_cursor = context.get_line():sub(pos.col, pos.col)
 
   if trigger.is_trigger_character(char_under_cursor, true) then
     trigger.show({ trigger_kind = 'trigger_character', trigger_character = char_under_cursor })
@@ -239,40 +236,29 @@ function trigger.show(opts)
 
   opts = opts or {} --[[@as blink.cmp.CompletionTriggerShowOptions]]
 
-  -- already triggered at this position, ignore
+  local ctx = trigger.context
   local mode = context.get_mode()
-  local cursor = context.get_cursor()
-  if
-    not opts.force
-    and trigger.context ~= nil
-    and trigger.context.mode == mode
-    and cursor[1] == trigger.context.cursor[1]
-    and cursor[2] == trigger.context.cursor[2]
-  then
-    return
-  end
+  local pos = context.get_pos()
+
+  -- already triggered at this position, ignore
+  if not opts.force and ctx ~= nil and ctx.mode == mode and ctx.pos == pos then return end
 
   -- update the context id to indicate a new context, and not an update to an existing context
-  if trigger.context == nil or opts.providers ~= nil then
-    trigger.current_context_id = trigger.current_context_id + 1
-  end
+  if not ctx or opts.providers ~= nil then trigger.current_context_id = trigger.current_context_id + 1 end
 
   local providers = opts.providers
-    or (trigger.context and trigger.context.providers)
-    or require('blink.cmp.sources.lib').get_enabled_provider_ids(context.get_mode())
+    or (ctx and ctx.providers)
+    or require('blink.cmp.sources.lib').get_enabled_provider_ids(mode)
 
-  local initial_trigger_kind = trigger.context and trigger.context.trigger.initial_kind or opts.trigger_kind
+  local initial_trigger_kind = ctx and ctx.trigger.initial_kind or opts.trigger_kind
   -- if we prefetched, don't keep that as the initial trigger kind
   if initial_trigger_kind == 'prefetch' then initial_trigger_kind = opts.trigger_kind end
   -- if we're manually triggering, set it as the initial trigger kind
   if opts.trigger_kind == 'manual' then initial_trigger_kind = 'manual' end
 
-  local initial_trigger_character = trigger.context and trigger.context.trigger.initial_character
-    or opts.trigger_character
+  local initial_trigger_character = ctx and ctx.trigger.initial_character or opts.trigger_character
   -- reset the initial character if the context id has changed
-  if trigger.context ~= nil and trigger.context.id ~= trigger.current_context_id then
-    initial_trigger_character = nil
-  end
+  if ctx ~= nil and ctx.id ~= trigger.current_context_id then initial_trigger_character = nil end
 
   trigger.context = context.new({
     id = trigger.current_context_id,

--- a/lua/blink/cmp/completion/windows/ghost_text/init.lua
+++ b/lua/blink/cmp/completion/windows/ghost_text/init.lua
@@ -96,7 +96,7 @@ function ghost_text.draw_preview()
 
   -- Determine the actual end position for typed text.
   -- Use cursor column if multiline, otherwise use LSP end character.
-  local typed_end_col = (range.start.line ~= range['end'].line) and ghost_text.context.get_cursor()[2] or end_col
+  local typed_end_col = (range.start.line ~= range['end'].line) and ghost_text.context.get_pos().col or end_col
   local typed_text = line:sub(start_col + 1, typed_end_col)
   local typed_length = math.max(0, math.min(vim.fn.strchars(typed_text), vim.fn.strchars(text_edit.newText)))
   local untyped_text = vim.fn.strcharpart(text_edit.newText, typed_length)

--- a/lua/blink/cmp/completion/windows/menu/init.lua
+++ b/lua/blink/cmp/completion/windows/menu/init.lua
@@ -105,7 +105,7 @@ function menu.open_loading(context)
 
       source_id = '',
       source_name = '',
-      cursor_column = 0,
+      pos = nil,
       score = 0,
       score_offset = 0,
       client_id = 0,
@@ -177,7 +177,7 @@ function menu.queue_auto_show(context, items)
 
   -- only start a new timer if the cursor has moved or the id has changed.
   -- note we should use timer, even for 0ms, to prevent synchronous geometry races
-  local timer_key = string.format('%d|%d|%d', context.id, context.cursor[1], context.cursor[2])
+  local timer_key = string.format('%d|%d|%d', context.id, context.pos.row, context.pos.col)
   if menu.auto_show.timer:is_active() and menu.auto_show.timer_key == timer_key then return end
 
   menu.auto_show.timer_key = timer_key

--- a/lua/blink/cmp/completion/windows/render/context.lua
+++ b/lua/blink/cmp/completion/windows/render/context.lua
@@ -25,7 +25,7 @@ local draw_context = {}
 function draw_context.get_from_items(context, draw, items)
   local matched_indices = require('blink.cmp.fuzzy').fuzzy_matched_indices(
     context.get_line(),
-    context.get_cursor()[2],
+    context.get_pos().col,
     vim.tbl_map(function(item) return item.label end, items),
     require('blink.cmp.config').completion.keyword.range
   )

--- a/lua/blink/cmp/fuzzy/init.lua
+++ b/lua/blink/cmp/fuzzy/init.lua
@@ -116,7 +116,7 @@ function fuzzy.fuzzy(line, cursor_col, haystacks_by_provider, range)
   end
 
   -- get the nearby words
-  local cursor_row = nvim.win_get_cursor(0)[1]
+  local cursor_row = vim.pos.cursor(0):to_cursor()[1]
   local start_row = math.max(0, cursor_row - 30)
   local end_row = math.min(cursor_row + 30, nvim.buf_line_count(0))
   local nearby_text = table.concat(nvim.buf_get_lines(0, start_row, end_row, false), '\n')

--- a/lua/blink/cmp/lib/buffer_events.lua
+++ b/lua/blink/cmp/lib/buffer_events.lua
@@ -214,12 +214,12 @@ end
 --- HACK: there's likely edge cases with this since we can't know for sure
 --- if the autocmds will fire for cursor_moved afaik
 function buffer_events:suppress_events_for_callback(cb)
-  local cursor_before = nvim.win_get_cursor(0)
+  local pos_before = vim.pos.cursor(0)
   local changed_tick_before = nvim.buf_get_changedtick(0)
 
   cb()
 
-  local cursor_after = nvim.win_get_cursor(0)
+  local pos_after = vim.pos.cursor(0)
   local changed_tick_after = nvim.buf_get_changedtick(0)
 
   local is_insert_mode = nvim.get_mode().mode:sub(1, 1) == 'i'
@@ -233,7 +233,7 @@ function buffer_events:suppress_events_for_callback(cb)
   -- that the CursorMovedI event will fire
   -- TODO: It could make sense to override the nvim_win_set_cursor function and mark as ignored if it's called
   -- on the current buffer
-  local cursor_moved = cursor_after[1] ~= cursor_before[1] or cursor_after[2] ~= cursor_before[2]
+  local cursor_moved = pos_after ~= pos_before
   self.ignore_next_cursor_moved = is_insert_mode
   if not cursor_moved then vim.defer_fn(function() self.ignore_next_cursor_moved = false end, 10) end
 end

--- a/lua/blink/cmp/lib/term_events.lua
+++ b/lua/blink/cmp/lib/term_events.lua
@@ -101,19 +101,18 @@ end
 --- HACK: there's likely edge cases with this since we can't know for sure
 --- if the autocmds will fire for cursor_moved afaik
 function term_events:suppress_events_for_callback(cb)
-  local cursor_before = nvim.win_get_cursor(0)
+  local pos_before = vim.pos.cursor(0)
   local changed_tick_before = nvim.buf_get_changedtick(0)
 
   cb()
 
-  local cursor_after = nvim.win_get_cursor(0)
+  local pos_after = vim.pos.cursor(0)
   local changed_tick_after = nvim.buf_get_changedtick(0)
 
   local is_term_mode = nvim.get_mode().mode == 't'
   self.ignore_next_text_changed = changed_tick_after ~= changed_tick_before and is_term_mode
   -- TODO: does this guarantee that the CursorMovedI event will fire?
-  self.ignore_next_cursor_moved = (cursor_after[1] ~= cursor_before[1] or cursor_after[2] ~= cursor_before[2])
-    and is_term_mode
+  self.ignore_next_cursor_moved = pos_after ~= pos_before and is_term_mode
 end
 
 return term_events

--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -46,8 +46,7 @@ function text_edits.apply(text_edit, additional_text_edits)
     assert(#additional_text_edits == 0, 'Terminal mode only supports one text edit. Contributions welcome!')
 
     if vim.bo.channel and vim.bo.channel ~= 0 then
-      local cur_col = nvim.win_get_cursor(0)[2]
-      local n_replaced = cur_col - text_edit.range.start.character
+      local n_replaced = vim.pos.cursor(0).col - text_edit.range.start.character
       local backspace_keycode = '\8'
 
       vim.fn.chansend(vim.bo.channel, backspace_keycode:rep(n_replaced) .. text_edit.newText)
@@ -152,7 +151,7 @@ function text_edits.get_from_item(item)
   }
   assert(text_edit.range ~= nil, 'Invalid text edit: missing range')
 
-  text_edit = text_edits.compensate_for_cursor_movement(text_edit, item.cursor_column, context.get_cursor()[2])
+  text_edit = text_edits.compensate_for_cursor_movement(text_edit, item.pos, context.get_pos())
 
   -- convert the offset encoding to utf-8
   -- TODO: we have to do this last because it applies a max on the position based on the length of the line
@@ -170,13 +169,13 @@ end
 --- from when the items were fetched versus the current.
 --- HACK: is there a better way?
 --- @param text_edit lsp.TextEdit
---- @param old_cursor_col integer Position of the cursor when the text edit was created
---- @param new_cursor_col integer New position of the cursor
+--- @param old_pos vim.Pos Position when the text edit was created
+--- @param new_pos vim.Pos New position
 --- @return lsp.TextEdit
-function text_edits.compensate_for_cursor_movement(text_edit, old_cursor_col, new_cursor_col)
+function text_edits.compensate_for_cursor_movement(text_edit, old_pos, new_pos)
   text_edit = vim.deepcopy(text_edit)
 
-  local offset = new_cursor_col - old_cursor_col
+  local offset = new_pos.col - old_pos.col
   text_edit.range['end'].character = text_edit.range['end'].character + offset
 
   return text_edit
@@ -212,19 +211,15 @@ function text_edits.guess(item)
     or (lib.is_not_nil(item.label) and item.label)
     or ''
 
-  local start_col, end_col = require('blink.cmp.fuzzy').guess_edit_range(
-    item,
-    context.get_line(),
-    context.get_cursor()[2],
-    config.completion.keyword.range
-  )
-  local current_line = context.get_cursor()[1]
+  local pos = context.get_pos()
+  local start_col, end_col =
+    require('blink.cmp.fuzzy').guess_edit_range(item, context.get_line(), pos.col, config.completion.keyword.range)
 
   -- convert to 0-index
   return {
     range = {
-      start = { line = current_line - 1, character = start_col },
-      ['end'] = { line = current_line - 1, character = end_col },
+      start = { line = pos.row, character = start_col },
+      ['end'] = { line = pos.row, character = end_col },
     },
     newText = word,
   }
@@ -256,13 +251,13 @@ end
 --- This means that the end position will be the range _before_ applying the edit.
 --- This function gets the end position of the range _after_ applying the edit.
 --- This may be used for placing the cursor after applying the edit.
---- Returns (1, 0) indexed line and column
+--- Returns 0-indexed line and column
 ---
 --- TODO: write tests cases, there are many uncommon cases it doesn't handle
 ---
 --- @param text_edit lsp.TextEdit
 --- @param additional_text_edits lsp.TextEdit[]
---- @return blink.cmp.CursorPos
+--- @return vim.Pos
 function text_edits.get_apply_end_position(text_edit, additional_text_edits)
   -- Calculate the end position of the range, ignoring the additional text edits
   local lines = vim.split(text_edit.newText, '\n')
@@ -314,8 +309,7 @@ function text_edits.get_apply_end_position(text_edit, additional_text_edits)
   end_line = end_line + line_offset
   end_col = end_col + col_offset
 
-  -- Convert from 0-indexed to (1, 0)-indexed to match nvim cursor api
-  return { end_line + 1, end_col }
+  return vim.pos(0, end_line, end_col)
 end
 
 ----- Dot repeat -----

--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -19,7 +19,7 @@ function utils.get_char_at_cursor()
 
   local line = context.get_line()
   if line == '' then return '' end
-  local cursor_col = context.get_cursor()[2]
+  local cursor_col = context.get_pos().col
 
   -- Find the start of the UTF-8 character
   local start_col = cursor_col

--- a/lua/blink/cmp/lib/window/cursor_line.lua
+++ b/lua/blink/cmp/lib/window/cursor_line.lua
@@ -35,17 +35,17 @@ function cursor_line:update(win)
   local hack_hl = 'BlinkCmpCursorLine' .. self.name:sub(1, 1):upper() .. self.name:sub(2) .. 'Hack'
   nvim.set_hl(0, hack_hl, { bg = hl_params.bg })
 
-  local cursor_line_number = 0
+  local pos ---@type vim.Pos?
   nvim.set_decoration_provider(self.ns, {
     on_win = function(_, maybe_win)
       if win ~= maybe_win then return false end
       if not nvim.win_is_valid(win) then return false end
       if not nvim.get_option_value('cursorline', { win = win }) then return false end
 
-      cursor_line_number = nvim.win_get_cursor(win)[1] - 1
+      pos = vim.pos.cursor(win)
     end,
     on_line = function(_, _, bufnr, line_number)
-      if line_number ~= cursor_line_number then return end
+      if pos and line_number ~= pos.row then return end
 
       nvim.buf_set_extmark(bufnr, self.ns, line_number, 0, {
         end_col = #nvim.buf_get_lines(bufnr, line_number, line_number + 1, true)[1],

--- a/lua/blink/cmp/lib/window/init.lua
+++ b/lua/blink/cmp/lib/window/init.lua
@@ -43,7 +43,7 @@ local utils = require('blink.cmp.lib.window.utils')
 --- @field get_content_width fun(self: blink.cmp.Window): integer
 --- @field get_width fun(self: blink.cmp.Window): integer
 --- @field get_cursor_screen_position fun(): { distance_from_top: integer, distance_from_bottom: integer }
---- @field set_cursor fun(self: blink.cmp.Window, cursor: blink.cmp.CursorPos)
+--- @field set_cursor fun(self: blink.cmp.Window, cursor: { [1]: integer, [2]: integer })
 --- @field set_height fun(self: blink.cmp.Window, height: integer)
 --- @field set_width fun(self: blink.cmp.Window, width: integer)
 --- @field set_win_config fun(self: blink.cmp.Window, config: table)
@@ -298,15 +298,15 @@ function win.get_cursor_screen_position()
   end
 
   -- default
-  local cursor_line, cursor_column = unpack(nvim.win_get_cursor(0))
+  local cursor_line, cursor_column = unpack(vim.pos.cursor(0):to_cursor())
   -- TODO: convert cursor_column to byte index
-  local pos = vim.fn.screenpos(0, cursor_line, cursor_column)
+  local screenpos = vim.fn.screenpos(0, cursor_line, cursor_column)
 
   return {
-    distance_from_top = pos.row - 1,
-    distance_from_bottom = screen_height - pos.row,
-    distance_from_left = pos.col,
-    distance_from_right = screen_width - pos.col,
+    distance_from_top = screenpos.row - 1,
+    distance_from_bottom = screen_height - screenpos.row,
+    distance_from_left = screenpos.col,
+    distance_from_right = screen_width - screenpos.col,
   }
 end
 

--- a/lua/blink/cmp/lib/window/init.lua
+++ b/lua/blink/cmp/lib/window/init.lua
@@ -300,13 +300,13 @@ function win.get_cursor_screen_position()
   -- default
   local cursor_line, cursor_column = unpack(vim.pos.cursor(0):to_cursor())
   -- TODO: convert cursor_column to byte index
-  local screenpos = vim.fn.screenpos(0, cursor_line, cursor_column)
+  local screen_pos = vim.fn.screenpos(0, cursor_line, cursor_column)
 
   return {
-    distance_from_top = screenpos.row - 1,
-    distance_from_bottom = screen_height - screenpos.row,
-    distance_from_left = screenpos.col,
-    distance_from_right = screen_width - screenpos.col,
+    distance_from_top = screen_pos.row - 1,
+    distance_from_bottom = screen_height - screen_pos.row,
+    distance_from_left = screen_pos.col,
+    distance_from_right = screen_width - screen_pos.col,
   }
 end
 

--- a/lua/blink/cmp/signature/trigger.lua
+++ b/lua/blink/cmp/signature/trigger.lua
@@ -9,7 +9,7 @@ local nvim = require('blink.lib.nvim')
 --- @class blink.cmp.SignatureHelpContext
 --- @field id integer
 --- @field bufnr integer
---- @field cursor blink.cmp.CursorPos
+--- @field pos vim.Pos
 --- @field line string
 --- @field is_retrigger boolean
 --- @field active_signature_help lsp.SignatureHelp?
@@ -91,8 +91,8 @@ function trigger.activate()
   })
 
   if config.show_on_accept then
-    require('blink.cmp.completion.list').accept_emitter:on(function()
-      local cursor_col = nvim.win_get_cursor(0)[2]
+    require('blink.cmp.completion.list').accept_emitter:on(function(ev)
+      local cursor_col = ev.context.get_pos().col
       local char_under_cursor = nvim.get_current_line():sub(cursor_col, cursor_col)
 
       local is_on_trigger = trigger.is_trigger_character(char_under_cursor)
@@ -121,7 +121,7 @@ function trigger.show_if_on_trigger_character()
   if require('blink.cmp.completion.trigger.context').get_mode() ~= 'default' then return end
   if not config.enabled or not trigger.context then return end
 
-  local cursor_col = nvim.win_get_cursor(0)[2]
+  local cursor_col = trigger.context.pos.col
   local char_under_cursor = nvim.get_current_line():sub(cursor_col, cursor_col)
   if trigger.is_trigger_character(char_under_cursor) then trigger.show({ trigger_character = char_under_cursor }) end
 end
@@ -134,13 +134,14 @@ function trigger.show(opts)
   end
 
   -- update context
-  local cursor = nvim.win_get_cursor(0)
+  local pos = vim.pos.cursor(0)
   if trigger.context == nil then trigger.current_context_id = trigger.current_context_id + 1 end
+
   trigger.context = {
     id = trigger.current_context_id,
     bufnr = nvim.get_current_buf(),
-    cursor = cursor,
-    line = nvim.buf_get_lines(0, cursor[1] - 1, cursor[1], false)[1],
+    pos = pos,
+    line = nvim.buf_get_lines(0, pos.row, pos.row + 1, false)[1] or '',
     trigger = {
       kind = opts.trigger_character and vim.lsp.protocol.CompletionTriggerKind.TriggerCharacter
         or vim.lsp.protocol.CompletionTriggerKind.Invoked,

--- a/lua/blink/cmp/sources/buffer/parser.lua
+++ b/lua/blink/cmp/sources/buffer/parser.lua
@@ -12,7 +12,7 @@ function parser.get_buf_text(bufnr, exclude_word_under_cursor)
   if bufnr ~= vim.api.nvim_get_current_buf() or not exclude_word_under_cursor then return table.concat(lines, '\n') end
 
   -- exclude word under the cursor for the current buffer
-  local line_number, column = unpack(vim.api.nvim_win_get_cursor(0))
+  local line_number, column = unpack(vim.pos.cursor(0):to_cursor())
   local line = lines[line_number]
   assert(line, 'buffer source: Unable to find the line ' .. line_number)
 

--- a/lua/blink/cmp/sources/cmdline/init.lua
+++ b/lua/blink/cmp/sources/cmdline/init.lua
@@ -35,7 +35,7 @@ function cmdline:get_completions(context, callback)
     and not is_filename_modifier_completion
     and not is_wildcard_completion
   local context_line, arguments = utils.smart_split(context.line, should_split_path)
-  local before_cursor = context_line:sub(1, context.cursor[2])
+  local before_cursor = context_line:sub(1, context.pos.col)
   local _, args_before_cursor = utils.smart_split(before_cursor, should_split_path)
   local arg_number = #args_before_cursor
 
@@ -48,7 +48,7 @@ function cmdline:get_completions(context, callback)
   local keyword = context.get_bounds(keyword_config.range)
   local current_arg_prefix = current_arg:sub(1, keyword.start_col - #text_before_argument - 1)
 
-  local line_pos = context.cursor[1] - 1
+  local line_pos = context.pos.row
   local start_pos = #text_before_argument + #leading_spaces
   -- Skip leading command range when computing start_pos
   if arg_number == 1 and completion_type == 'command' then
@@ -101,11 +101,11 @@ function cmdline:get_completions(context, callback)
           -- Handle v:lua functions (:h v:lua-call)
           if vim.startswith(custom_func, 'v:lua') then
             success, fn_completions =
-              utils.call_vlua(completion_func, current_arg_prefix, context.get_line(), context.cursor[2] + 1)
+              utils.call_vlua(completion_func, current_arg_prefix, context.get_line(), context.pos.col + 1)
           else
             -- Regular vimscript/Lua functions
             success, fn_completions =
-              pcall(vim.fn.call, completion_func, { current_arg_prefix, context.get_line(), context.cursor[2] + 1 })
+              pcall(vim.fn.call, completion_func, { current_arg_prefix, context.get_line(), context.pos.col + 1 })
           end
 
           -- Forward any error catch by pcall
@@ -288,7 +288,7 @@ function cmdline:get_completions(context, callback)
             newText = new_text,
             insert = {
               start = { line = line_pos, character = start_pos },
-              ['end'] = { line = line_pos, character = context.cursor[2] },
+              ['end'] = { line = line_pos, character = context.pos.col },
             },
             replace = {
               start = { line = line_pos, character = start_pos },

--- a/lua/blink/cmp/sources/complete_func.lua
+++ b/lua/blink/cmp/sources/complete_func.lua
@@ -45,7 +45,7 @@ end
 ---@overload fun(func: string, findstart: 1, base: ''): integer
 ---@overload fun(func: string, findstart: 0, base: string): table<{ words: blink.cmp.CompleteFuncWords, refresh: string }> | blink.cmp.CompleteFuncWords
 local function invoke_complete_func(func, findstart, base)
-  local prev_pos = nvim.win_get_cursor(0)
+  local prev_pos = vim.pos.cursor(0)
 
   local _, result = pcall(function()
     local args = { findstart, base }
@@ -58,8 +58,8 @@ local function invoke_complete_func(func, findstart, base)
     end
   end)
 
-  local next_pos = nvim.win_get_cursor(0)
-  if prev_pos[1] ~= next_pos[1] or prev_pos[2] ~= next_pos[2] then nvim.win_set_cursor(0, prev_pos) end
+  local next_pos = vim.pos.cursor(0)
+  if next_pos ~= prev_pos then nvim.win_set_cursor(0, prev_pos:to_cursor()) end
 
   return result
 end
@@ -88,31 +88,25 @@ function Source:get_completions(context, resolve)
     return nil
   end
 
-  local cur_line, cur_col = unpack(context.cursor)
+  local pos = context.get_pos()
 
   -- TODO: differentiate between staying in (-2) vs leaving (-3) completion mode?
   if start_col == -2 or start_col == -3 then
     resolve()
     return nil
-  elseif start_col < 0 or start_col > cur_col then
-    start_col = cur_col
+  elseif start_col < 0 or start_col > pos.col then
+    start_col = pos.col
   end
 
   -- for info on complete-func results see `:h complete-items`
   -- get the actual complete-func completion results
-  local cmp_results = invoke_complete_func(complete_func, 0, string.sub(context.line, start_col + 1, cur_col))
+  local cmp_results = invoke_complete_func(complete_func, 0, string.sub(context.line, start_col + 1, pos.col))
   cmp_results = cmp_results['words'] or cmp_results
   ---@cast cmp_results blink.cmp.CompleteFuncWords
 
   local range = {
-    ['start'] = {
-      line = cur_line - 1,
-      character = start_col,
-    },
-    ['end'] = {
-      line = cur_line - 1,
-      character = cur_col,
-    },
+    ['start'] = { line = pos.row, character = start_col },
+    ['end'] = { line = pos.row, character = pos.col },
   }
 
   local items = {} ---@type blink.cmp.CompletionItem[]

--- a/lua/blink/cmp/sources/lib/provider/list.lua
+++ b/lua/blink/cmp/sources/lib/provider/list.lua
@@ -79,7 +79,7 @@ function list:append(response)
   local source_score_offset = self.provider.config.score_offset(self.context) or 0
   for _, item in ipairs(response.items) do
     item.score_offset = (item.score_offset or 0) + source_score_offset
-    item.cursor_column = item.cursor_column or self.context.cursor[2]
+    item.pos = item.pos or self.context.pos
     item.source_id = self.provider.id
     item.source_name = self.provider.name
     item.kind = item.kind or require('blink.cmp.types').CompletionItemKind.Property
@@ -113,8 +113,8 @@ function list:is_valid_for_context(new_context)
   if self.context.id ~= new_context.id then return false end
 
   -- get the text for the current and queued context
-  local old_context_query = self.context.line:sub(self.context.bounds.start_col, self.context.cursor[2])
-  local new_context_query = new_context.line:sub(new_context.bounds.start_col, new_context.cursor[2])
+  local old_context_query = self.context.line:sub(self.context.bounds.start_col, self.context.pos.col)
+  local new_context_query = new_context.line:sub(new_context.bounds.start_col, new_context.pos.col)
 
   -- check if the texts are overlapping
   local is_before = vim.startswith(old_context_query, new_context_query)

--- a/lua/blink/cmp/sources/lib/utils.lua
+++ b/lua/blink/cmp/sources/lib/utils.lua
@@ -7,7 +7,7 @@ function utils.blink_item_to_lsp_item(item)
   lsp_item.score_offset = nil
   lsp_item.source_id = nil
   lsp_item.source_name = nil
-  lsp_item.cursor_column = nil
+  lsp_item.pos = nil
   lsp_item.client_id = nil
   lsp_item.client_name = nil
   lsp_item.exact = nil

--- a/lua/blink/cmp/sources/lsp/cache.lua
+++ b/lua/blink/cmp/sources/lsp/cache.lua
@@ -15,8 +15,8 @@ function cache.get(context, client)
   if entry == nil then return end
 
   if context.id ~= entry.context.id then return end
-  if entry.response.is_incomplete_forward and entry.context.cursor[2] ~= context.cursor[2] then return end
-  if not entry.response.is_incomplete_forward and entry.context.cursor[2] > context.cursor[2] then return end
+  if entry.response.is_incomplete_forward and entry.context.pos.col ~= context.pos.col then return end
+  if not entry.response.is_incomplete_forward and entry.context.pos.col > context.pos.col then return end
 
   return entry.response
 end

--- a/lua/blink/cmp/sources/lsp/completion.lua
+++ b/lua/blink/cmp/sources/lsp/completion.lua
@@ -49,9 +49,9 @@ local function process_response(context, client, res)
     ---@cast item blink.cmp.CompletionItem
     item.client_id = client.id
     item.client_name = client.name
-    -- we must set the cursor column because this will be cached and used later
-    -- by default, blink.cmp will use the cursor column at the time of the request
-    item.cursor_column = context.cursor[2]
+    -- Record the position at which this completion was requested.
+    -- This is used later to compensate text edits if the cursor moves before the item is accepted.
+    item.pos = context.pos
 
     -- score offset for deprecated items
     -- TODO: make configurable

--- a/lua/blink/cmp/sources/path/lib.lua
+++ b/lua/blink/cmp/sources/path/lib.lua
@@ -100,21 +100,21 @@ end
 --- @param context blink.cmp.Context
 --- @return { file: lsp.Range, directory: lsp.Range }
 function path_lib.get_text_edit_ranges(context)
-  local line_before_cursor = context.line:sub(1, context.cursor[2])
-  local next_letter_is_slash = context.line:sub(context.cursor[2] + 1, context.cursor[2] + 1) == '/'
+  local line_before_cursor = context.line:sub(1, context.pos.col)
+  local next_letter_is_slash = context.line:sub(context.pos.col + 1, context.pos.col + 1) == '/'
 
   local last_part_idx = path_lib.get_last_path_part(line_before_cursor)
 
   -- TODO: return the insert and replace ranges, instead of only the insert range
   return {
     file = {
-      start = { line = context.cursor[1] - 1, character = last_part_idx - 1 },
-      ['end'] = { line = context.cursor[1] - 1, character = context.cursor[2] },
+      start = { line = context.pos.row, character = last_part_idx - 1 },
+      ['end'] = { line = context.pos.row, character = context.pos.col },
     },
     directory = {
-      start = { line = context.cursor[1] - 1, character = last_part_idx - 1 },
+      start = { line = context.pos.row, character = last_part_idx - 1 },
       -- replace the slash after the cursor, if it exists
-      ['end'] = { line = context.cursor[1] - 1, character = context.cursor[2] + (next_letter_is_slash and 1 or 0) },
+      ['end'] = { line = context.pos.row, character = context.pos.col + (next_letter_is_slash and 1 or 0) },
     },
   }
 end

--- a/lua/blink/cmp/sources/snippets/default/builtin.lua
+++ b/lua/blink/cmp/sources/snippets/default/builtin.lua
@@ -152,18 +152,17 @@ builtin.lazy.LINE_COMMENT = cached(function() return buffer_comment_chars()[1] e
 builtin.lazy.BLOCK_COMMENT_START = cached(function() return buffer_comment_chars()[2] end)
 builtin.lazy.BLOCK_COMMENT_END = cached(function() return buffer_comment_chars()[3] end)
 
-local function get_cursor()
-  local c = nvim.win_get_cursor(0)
-  c[1] = c[1] - 1
-  return c
-end
+local function get_pos() return vim.pos.cursor(0) end
 
 local function get_current_line()
-  local pos = get_cursor()
-  return nvim.buf_get_lines(0, pos[1], pos[1] + 1, false)[1]
+  local pos = get_pos()
+  return nvim.buf_get_lines(0, pos.row, pos.row + 1, false)[1]
 end
 
-local function word_under_cursor(cur, line)
+---@param word_pos vim.Pos
+---@param line string?
+---@return string?
+local function word_under_cursor(word_pos, line)
   if line == nil then return end
 
   local ind_start = 1
@@ -172,11 +171,11 @@ local function word_under_cursor(cur, line)
   while true do
     local tmp = string.find(line, '%W%w', ind_start)
     if not tmp then break end
-    if tmp > cur[2] + 1 then break end
+    if tmp > word_pos.col + 1 then break end
     ind_start = tmp + 1
   end
 
-  local tmp = string.find(line, '%w%W', cur[2] + 1)
+  local tmp = string.find(line, '%w%W', word_pos.col + 1)
   if tmp then ind_end = tmp end
 
   return string.sub(line, ind_start, ind_end)
@@ -185,11 +184,13 @@ end
 nvim.create_autocmd('InsertEnter', {
   group = nvim.create_augroup('BlinkSnippetsEagerEnter', { clear = true }),
   callback = function()
+    local pos = get_pos()
+
     builtin.eager = {}
     builtin.eager.TM_CURRENT_LINE = get_current_line()
-    builtin.eager.TM_CURRENT_WORD = word_under_cursor(get_cursor(), builtin.eager.TM_CURRENT_LINE)
-    builtin.eager.TM_LINE_INDEX = tostring(get_cursor()[1])
-    builtin.eager.TM_LINE_NUMBER = tostring(get_cursor()[1] + 1)
+    builtin.eager.TM_CURRENT_WORD = word_under_cursor(pos, builtin.eager.TM_CURRENT_LINE)
+    builtin.eager.TM_LINE_INDEX = tostring(pos.row)
+    builtin.eager.TM_LINE_NUMBER = tostring(pos.row + 1)
   end,
 })
 

--- a/lua/blink/cmp/sources/snippets/default/registry.lua
+++ b/lua/blink/cmp/sources/snippets/default/registry.lua
@@ -116,15 +116,15 @@ function registry:snippet_to_completion_item(snippet, context)
     or table.concat(snippet.body --[[@as table]], '\n')
 
   local new_text = self:expand_vars(body, context.id)
-  local cur_line, cur_col = unpack(context.cursor)
+  local pos = context.get_pos()
 
   -- Find the position of the (longest partial) prefix just before the cursor
   local start_col ---@type integer?
-  local line = context.get_line():sub(1, cur_col)
+  local line = context.get_line():sub(1, pos.col)
   for i = #snippet.prefix, 1, -1 do
-    local pos = cur_col - i + 1
-    if line:sub(pos, cur_col) == snippet.prefix:sub(1, i) then
-      start_col = pos
+    local col = pos.col - i + 1
+    if line:sub(col, pos.col) == snippet.prefix:sub(1, i) then
+      start_col = col
       break
     end
   end
@@ -139,8 +139,8 @@ function registry:snippet_to_completion_item(snippet, context)
       or nil,
     textEdit = {
       range = {
-        start = { line = cur_line - 1, character = (start_col or context.bounds.start_col) - 1 },
-        ['end'] = { line = cur_line - 1, character = cur_col },
+        start = { line = pos.row, character = (start_col or context.bounds.start_col) - 1 },
+        ['end'] = { line = pos.row, character = pos.col },
       },
       newText = new_text,
     },

--- a/lua/blink/cmp/sources/snippets/luasnip.lua
+++ b/lua/blink/cmp/sources/snippets/luasnip.lua
@@ -248,7 +248,7 @@ function source:get_completions(ctx, callback)
 
   -- Filter items based on show_condition, if configured
   if self.opts.use_show_condition then
-    local line_to_cursor = ctx.line:sub(0, ctx.cursor[2] - 1)
+    local line_to_cursor = ctx.line:sub(0, ctx.pos.col - 1)
     items = vim.tbl_filter(function(item) return item.data.show_condition(line_to_cursor) end, items)
   end
 
@@ -305,20 +305,18 @@ function source:execute(ctx, item)
     add_luasnip_callback(snip, events.pre_expand, function(s) choice_callback(s, events) end)
   end
 
-  local cursor = ctx.get_cursor() --[[@as LuaSnip.BytecolBufferPosition]]
-  cursor[1] = cursor[1] - 1
-
+  local pos = ctx.get_pos()
   local range = text_edits.get_from_item(item).range
 
   ---@type LuaSnip.BufferRegion
   local clear_region = {
     from = { range.start.line, range.start.character },
-    to = cursor,
+    to = { pos.row, pos.col },
   }
 
   local line = ctx.get_line()
-  local line_to_cursor = line:sub(1, cursor[2])
-  local range_text = line:sub(range.start.character + 1, cursor[2])
+  local line_to_cursor = line:sub(1, pos.col)
+  local range_text = line:sub(range.start.character + 1, pos.col)
 
   local expand_params = snip:matches(line_to_cursor, {
     fallback_match = range_text ~= line_to_cursor and range_text or nil,
@@ -328,8 +326,7 @@ function source:execute(ctx, item)
     if expand_params.clear_region ~= nil then
       clear_region = expand_params.clear_region
     elseif expand_params.trigger ~= nil then
-      clear_region.from = { cursor[1], cursor[2] - #expand_params.trigger }
-      clear_region.to = cursor
+      clear_region.from = { pos.row, pos.col - #expand_params.trigger }
     end
   end
 

--- a/lua/blink/cmp/types.lua
+++ b/lua/blink/cmp/types.lua
@@ -1,13 +1,11 @@
 --- @alias blink.cmp.Mode 'cmdline' | 'cmdwin' | 'term' | 'default'
 
---- @alias blink.cmp.CursorPos { [1]: integer, [2]: integer }
-
 --- @class blink.cmp.CompletionItem : lsp.CompletionItem
 --- @field documentation? string | blink.cmp.CompletionDocumentationMarkupContent
 --- @field score_offset? integer
 --- @field source_id string
 --- @field source_name string
---- @field cursor_column integer
+--- @field pos? vim.Pos
 --- @field client_id? integer
 --- @field client_name? string
 --- @field kind_name? string


### PR DESCRIPTION
This migrates internal cursor handling from the legacy (line, col) tuple representation to Neovim's experimental `vim.Pos` API, discussed in https://github.com/saghen/blink.cmp/pull/2574#discussion_r3471427828.

Using it removes many of the recurring +1/-1 conversions and comparisons between the different coordinate systems, making the code easier to read and should reduce off-by-one mistakes.

For compatibility with existing community sources, `context.cursor` and `context.get_cursor()` are retained for now, while the implementation use `context.pos` and `context.get_pos()`.