### PR TITLE
fix: compatible with nvim-0.12 of vim.pos

### DIFF
--- a/lua/blink/cmp/completion/trigger/context.lua
+++ b/lua/blink/cmp/completion/trigger/context.lua
@@ -122,7 +122,7 @@ end
 
 function context.get_pos()
   local bufnr = context.bufnr or 0
-  if context.get_mode() == 'cmdline' then return vim.pos(bufnr, 0, vim.fn.getcmdpos() - 1) end
+  if context.get_mode() == 'cmdline' then return utils.get_vim_pos(bufnr, 0, vim.fn.getcmdpos() - 1) end
   return utils.get_vim_pos_cursor(bufnr)
 end
 

--- a/lua/blink/cmp/lib/text_edits.lua
+++ b/lua/blink/cmp/lib/text_edits.lua
@@ -309,7 +309,7 @@ function text_edits.get_apply_end_position(text_edit, additional_text_edits)
   end_line = end_line + line_offset
   end_col = end_col + col_offset
 
-  return vim.pos(0, end_line, end_col)
+  return utils.get_vim_pos(0, end_line, end_col)
 end
 
 ----- Dot repeat -----

--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -14,17 +14,16 @@ if vim.fn.has('nvim-0.13') == 1 then
   --- @return integer[]
   function utils.vim_pos_to_cursor(pos) return pos:to_cursor() end
 
-  ---@param buf integer
-  ---@param row integer 0-indexed
-  ---@param col integer 0-indexed
-  ---@return vim.Pos
+  --- @param buf integer
+  --- @param row integer 0-indexed
+  --- @param col integer 0-indexed
+  --- @return vim.Pos
   function utils.get_vim_pos(buf, row, col) return vim.pos(buf, row, col) end
 else
   --- @param buf integer
-  --- @param pos [integer, integer] (lnum, col) tuple
-  --- @return vim.Pos
-  --- @overload fun(win: integer): vim.Pos
-  function utils.get_vim_pos_cursor(buf, pos)
+  --- @param pos? [integer, integer]
+  --- @return integer, [integer, integer]
+  local function normalize_cursor_args(buf, pos)
     if pos then
       if buf == 0 then buf = vim.api.nvim_get_current_buf() end
     else
@@ -34,18 +33,36 @@ else
       pos = vim.api.nvim_win_get_cursor(win)
     end
 
-    return vim.pos.cursor(pos, { buf = buf })
+    return buf, pos
+  end
+
+  if vim.fn.has('nvim-0.12.2') == 1 then
+    --- @param buf integer
+    --- @param pos? [integer, integer] (lnum, col) tuple
+    --- @overload fun(win: integer): vim.Pos
+    --- @return vim.Pos
+    function utils.get_vim_pos_cursor(buf, pos)
+      buf, pos = normalize_cursor_args(buf, pos)
+      return vim.pos.cursor(buf, pos)
+    end
+
+    --- @param buf integer
+    --- @param row integer 0-indexed
+    --- @param col integer 0-indexed
+    --- @return vim.Pos
+    function utils.get_vim_pos(buf, row, col) return vim.pos(buf, row, col) end
+  else
+    function utils.get_vim_pos_cursor(buf, pos)
+      buf, pos = normalize_cursor_args(buf, pos)
+      return vim.pos.cursor(pos, { buf = buf })
+    end
+
+    function utils.get_vim_pos(buf, row, col) return vim.pos(row, col, { buf = buf }) end
   end
 
   --- @param pos vim.Pos
   --- @return integer[]
   function utils.vim_pos_to_cursor(pos) return { pos:to_cursor() } end
-
-  ---@param buf integer
-  ---@param row integer 0-indexed
-  ---@param col integer 0-indexed
-  ---@return vim.Pos
-  function utils.get_vim_pos(buf, row, col) return vim.pos(row, col, { buf = buf }) end
 end
 
 function utils.to_string_or_empty(v) return (lib.is_not_nil(v) and type(v) == 'string') and v or '' end

--- a/lua/blink/cmp/lib/utils.lua
+++ b/lua/blink/cmp/lib/utils.lua
@@ -4,26 +4,48 @@ local utils = {}
 
 -- TODO: vim.Pos API changed in nvim-0.13. Remove compat layer for vim.Pos API when we drop support for nvim 0.12
 if vim.fn.has('nvim-0.13') == 1 then
-  --- @param target integer
+  --- @param buf integer
+  --- @param pos [integer, integer] (lnum, col) tuple
   --- @return vim.Pos
-  function utils.get_vim_pos_cursor(target) return vim.pos.cursor(target) end
+  --- @overload fun(win: integer): vim.Pos
+  function utils.get_vim_pos_cursor(buf, pos) return vim.pos.cursor(buf, pos) end
 
   --- @param pos vim.Pos
   --- @return integer[]
   function utils.vim_pos_to_cursor(pos) return pos:to_cursor() end
+
+  ---@param buf integer
+  ---@param row integer 0-indexed
+  ---@param col integer 0-indexed
+  ---@return vim.Pos
+  function utils.get_vim_pos(buf, row, col) return vim.pos(buf, row, col) end
 else
-  --- @param win integer
+  --- @param buf integer
+  --- @param pos [integer, integer] (lnum, col) tuple
   --- @return vim.Pos
-  function utils.get_vim_pos_cursor(win)
-    if win == 0 then win = vim.api.nvim_get_current_win() end
-    local buf = vim.api.nvim_win_get_buf(win)
-    local pos = vim.api.nvim_win_get_cursor(win)
-    return vim.pos.cursor(buf, pos)
+  --- @overload fun(win: integer): vim.Pos
+  function utils.get_vim_pos_cursor(buf, pos)
+    if pos then
+      if buf == 0 then buf = vim.api.nvim_get_current_buf() end
+    else
+      local win = buf
+      if win == 0 then win = vim.api.nvim_get_current_win() end
+      buf = vim.api.nvim_win_get_buf(win)
+      pos = vim.api.nvim_win_get_cursor(win)
+    end
+
+    return vim.pos.cursor(pos, { buf = buf })
   end
 
   --- @param pos vim.Pos
   --- @return integer[]
   function utils.vim_pos_to_cursor(pos) return { pos:to_cursor() } end
+
+  ---@param buf integer
+  ---@param row integer 0-indexed
+  ---@param col integer 0-indexed
+  ---@return vim.Pos
+  function utils.get_vim_pos(buf, row, col) return vim.pos(row, col, { buf = buf }) end
 end
 
 function utils.to_string_or_empty(v) return (lib.is_not_nil(v) and type(v) == 'string') and v or '' end


### PR DESCRIPTION
### problem
not compatiable with nvim-0.12's `vim.pos`:
<img width="1272" height="682" alt="Snipaste_2026-07-14_21-31-01" src="https://github.com/user-attachments/assets/83341a02-da63-44ac-ad76-2d57f20a38c0" />

`vim.pos` and `vim.pos.cursor` api in nvim-0.12:
<img width="661" height="149" alt="Snipaste_2026-07-14_22-39-31" src="https://github.com/user-attachments/assets/125b8d91-c28b-42df-b959-f5e30d178100" />
<img width="632" height="161" alt="Snipaste_2026-07-14_22-39-48" src="https://github.com/user-attachments/assets/92d01bf9-ae29-48ba-9b27-e243f1072f59" />

### After this PR
<img width="590" height="527" alt="Snipaste_2026-07-14_22-45-25" src="https://github.com/user-attachments/assets/0162a30d-0454-42e8-8bb6-16e97c80267a" />
