### PR TITLE
fix(cmdline): avoid range prefix mangling

### DIFF
--- a/lua/blink/cmp/sources/cmdline/init.lua
+++ b/lua/blink/cmp/sources/cmdline/init.lua
@@ -50,14 +50,17 @@ function cmdline:get_completions(context, callback)
 
   local line_pos = context.pos.row
   local start_pos = #text_before_argument + #leading_spaces
+  local is_range_prefix_stale = false
   -- Skip leading command range when computing start_pos
   if arg_number == 1 and completion_type == 'command' then
-    local prefix = utils.longest_match(current_arg, {
+    local range_prefix = utils.longest_match(current_arg, {
       "^%s*'<%s*,%s*'>%s*", -- Visual range, e.g. '<,>'
       '^%s*%d+%s*,%s*%d+%s*', -- Numeric range, e.g. 3,5
-      '^%s*[%p]+%s*', -- One or more punctuation characters
+      '^%s*[%p]+%s*', -- One or more punctuation characters, e.g. % for whole buffer
     })
-    start_pos = start_pos + #prefix
+    start_pos = start_pos + #range_prefix
+    -- The text edit start moves forward if more of the range is typed, so cached items become stale
+    is_range_prefix_stale = range_prefix ~= '' and #range_prefix == #current_arg
   end
   local replace_end_pos = math.min(start_pos + #current_arg, context.bounds.start_col + context.bounds.length - 1)
 
@@ -313,7 +316,7 @@ function cmdline:get_completions(context, callback)
 
       callback({
         is_incomplete_backward = completion_type ~= 'help',
-        is_incomplete_forward = is_man_completion and current_arg == '' or false,
+        is_incomplete_forward = (is_man_completion and current_arg == '') or is_range_prefix_stale,
         items = items,
       })
     end)


### PR DESCRIPTION
# cmdline completions mangle numeric range

## Bug Description

`cmdline` completions following a numeric range can mangle the range. Original text-edit start position can become stale, causing the end of the range to be replaced when a completion is accepted.

## Reproduction
- Clone `main` into `/some/where/blink.cmp`
- Create a fresh directory `/some/where/new` and put the following files there:

```sh
#!/bin/bash
# This file: $PWD/mangle_bug.sh
# chmod u+x $PWD/mangle_bug.sh

TESTDIR="$PWD/.test"
export XDG_CONFIG_HOME="$TESTDIR/xdg/config"
export XDG_DATA_HOME="$TESTDIR/xdg/data"
export XDG_STATE_HOME="$TESTDIR/xdg/state"
export XDG_CACHE_HOME="$TESTDIR/xdg/cache"

rm -rf "$TESTDIR" # Fresh state every run
exec nvim -u "$PWD/mangle_bug.lua" -c "normal 40obla^["
```

*`^[` is Esc in the last line there.*

```lua
-- This file: $PWD/mangle_bug.lua
vim.o.number = true

vim.api.nvim_create_user_command("RangeTest", function(opts)
	print(("range: %d,%d"):format(opts.line1, opts.line2))
end, {
	range = true,
	desc = "Dummy user command for testing",
})

vim.pack.add(
	{ "https://github.com/saghen/blink.lib", "file:///some/where/blink.cmp" },
	{ confirm = false }
)
local cmp = require("blink.cmp")
cmp.build():pwait()
cmp.setup({
	cmdline = {
		completion = {
			menu = { auto_show = true },
		},
	},
})
```

- `cd` into `/some/where/new` and run the script with `./mangle_bug.sh`
- This will run a sandboxed `neovim` and install `blink.cmp` (*it builds from source so might take a bit*)
- You should see a bunch of `bla` lines.
- The "Before fix" below is on the main branch
- The "After fix" below is on the PR branch

### Before fix

- Type `:31,40Range`
- The completion menu will come up with the test user command:

<img width="257" height="124" alt="image" src="https://github.com/user-attachments/assets/9e72847d-5c23-4054-8e0e-8b6af2a36554" />

- Press `C-y` to accept completion. **Range mangled!**

<img width="244" height="94" alt="image" src="https://github.com/user-attachments/assets/84682202-ecc5-457f-9dbc-67b72265b54e" />

### After fix

- Type `:31,40Range`
- The completion menu will come up with the test user command:

<img width="257" height="124" alt="image" src="https://github.com/user-attachments/assets/9e72847d-5c23-4054-8e0e-8b6af2a36554" />

- Press `C-y` to accept completion. **Range not mangled!**
<img width="254" height="121" alt="image" src="https://github.com/user-attachments/assets/11ad1d37-0be7-408a-a265-2f9b152bd105" />

## Likely cause

`current_arg` gets captured before full range is typed and the `start_pos` later becomes stale and `is_incomplete_forward` is incorrectly reported as `false`.

```lua
-- /Users/esbn/projects/forks/blink.cmp/lua/blink/cmp/sources/cmdline/init.lua:46,46
  local current_arg = arguments[arg_number]
```

## Version information

- Neovim: `0.12.4`
- blink.cmp: `0f54bd7`

- Same bug is present in latest (v1.*) (`1.10.2`) and is resolved the same way.
