### PR TITLE
fix(completion): ignore range prefixes when fuzzy filtering

### DIFF
--- a/lua/blink/cmp/completion/list.lua
+++ b/lua/blink/cmp/completion/list.lua
@@ -140,12 +140,19 @@ end
 
 function list.fuzzy(ctx, items_by_source)
   local fuzzy = require('blink.cmp.fuzzy')
-  local filtered_items = fuzzy.fuzzy(
-    ctx.get_line(),
-    ctx.get_pos().col,
-    items_by_source,
-    require('blink.cmp.config').completion.keyword.range
-  )
+  local line = ctx.get_line()
+  local col = ctx.get_pos().col
+
+  -- Range prefixes in cmdline are not part of the keyword used for filtering
+  if ctx.mode == 'cmdline' then
+    local range_prefix = require('blink.cmp.sources.cmdline.utils').get_range_prefix(line)
+    if range_prefix and #line > #range_prefix then
+      line = line:sub(#range_prefix + 1)
+      col = math.max(0, col - #range_prefix)
+    end
+  end
+
+  local filtered_items = fuzzy.fuzzy(line, col, items_by_source, require('blink.cmp.config').completion.keyword.range)
 
   -- apply the per source max_items
   filtered_items = require('blink.cmp.sources.lib').apply_max_items_for_completions(ctx, filtered_items)

--- a/lua/blink/cmp/completion/list.lua
+++ b/lua/blink/cmp/completion/list.lua
@@ -143,12 +143,16 @@ function list.fuzzy(ctx, items_by_source)
   local line = ctx.get_line()
   local col = ctx.get_pos().col
 
-  -- Range prefixes in cmdline are not part of the keyword used for filtering
-  if ctx.mode == 'cmdline' then
-    local range_prefix = require('blink.cmp.sources.cmdline.utils').get_range_prefix(line)
-    if range_prefix and #line > #range_prefix then
-      line = line:sub(#range_prefix + 1)
-      col = math.max(0, col - #range_prefix)
+  -- Range prefixes in cmdline/cmdwin are not part of the keyword used for filtering
+  -- TODO: Remove when #657 is implemented
+  if ctx.mode == 'cmdline' or ctx.mode == 'cmdwin' then
+    local cmdline_utils = require('blink.cmp.sources.cmdline.utils')
+    if cmdline_utils.get_completion_type(ctx) == 'command' then
+      local range_prefix = cmdline_utils.get_range_prefix(line)
+      if range_prefix and #line > #range_prefix then
+        -- Preserve byte offsets while keeping the range out of the fuzzy matching keyword
+        line = string.rep(' ', #range_prefix) .. line:sub(#range_prefix + 1)
+      end
     end
   end
 


### PR DESCRIPTION
While working on making cmdline range prefix detection more robust (see https://github.com/saghen/blink.cmp/commit/61418c03ae0e7f93c8980f5a577999af32de9e72), I noticed a related issue with completion filtering (see video below).

For example, after entering a range such as `1,20y`, the completion list does not appear at the expected point because part of the range prefix is included when `fuzzy.fuzzy()` extracts the keyword:

```lua
-- get the keyword
local keyword_start_col, keyword_end_col = fuzzy.get_keyword_range(line, cursor_col, config.completion.keyword.range)
local keyword_length = keyword_end_col - keyword_start_col
local keyword = line:sub(keyword_start_col, keyword_end_col)
```

In this example, the keyword is something like `,20y` instead of just `y`, so it does not match the candidates as expected or the match can be delayed depending on the value of `fuzzy.max_typos`.

One possible solution is to strip a detected range prefix from the line and adjust the cursor position accordingly, before passing it to `fuzzy.fuzzy()`. This approach works fine but I am not sure whether `completion/list.lua` is the right place to handle this cmdline-specific special case.

Would it be preferable to handle the range prefix earlier or is adjusting the line before fuzzy keyword extraction the right abstraction?

---

BEFORE (main branch)

https://github.com/user-attachments/assets/7a867062-3d18-4255-b1e4-5fedeb10c7ec

AFTER (this PR)

https://github.com/user-attachments/assets/0165614b-4688-4096-90d1-2b53a75b79d9