### PR TITLE
fix(complete_func): nil check, handle errors better

### DIFF
--- a/lua/blink/cmp/sources/complete_func.lua
+++ b/lua/blink/cmp/sources/complete_func.lua
@@ -48,16 +48,18 @@ end
 local function invoke_complete_func(func, findstart, base)
   local prev_pos = utils.get_vim_pos_cursor(0)
 
-  local _, result = pcall(function()
-    local args = { findstart, base }
-    local match = func:match('^v:lua%.(.+)')
+  local result
+  local match = func:match('^v:lua%.(.+)')
 
-    if match then
-      return vim.fn.luaeval(string.format('%s(_A[1], _A[2], _A[3])', match), args)
-    else
-      return nvim.call_function(func, args)
-    end
-  end)
+  -- The call here used to be done in a pcall. However if the complete function errored, the 2nd return value of the
+  -- pcall would be a string and cause following code to error anyways. Letting the error propagate makes issues easier
+  -- to debug.
+  if match then
+    local fn = assert(loadstring('return ' .. match))()
+    result = fn(findstart, base)
+  else
+    result = nvim.call_function(func, { findstart, base })
+  end
 
   local next_pos = utils.get_vim_pos_cursor(0)
   if next_pos ~= prev_pos then nvim.win_set_cursor(0, utils.vim_pos_to_cursor(prev_pos)) end
@@ -102,6 +104,10 @@ function Source:get_completions(context, resolve)
   -- for info on complete-func results see `:h complete-items`
   -- get the actual complete-func completion results
   local cmp_results = invoke_complete_func(complete_func, 0, string.sub(context.line, start_col + 1, pos.col))
+  if type(cmp_results) ~= 'table' then
+    resolve()
+    return nil
+  end
   cmp_results = cmp_results['words'] or cmp_results
   ---@cast cmp_results blink.cmp.CompleteFuncWords
 

--- a/lua/blink/cmp/sources/complete_func.lua
+++ b/lua/blink/cmp/sources/complete_func.lua
@@ -37,7 +37,8 @@ function Source.new(_, config)
 end
 
 function Source:enabled()
-  return not vim.tbl_contains({ nil, '' }, self.opts.complete_func()) and nvim.get_mode().mode == 'i'
+  local complete_func = self.opts.complete_func()
+  return complete_func ~= nil and complete_func ~= '' and nvim.get_mode().mode == 'i'
 end
 
 ---Invoke an complete_func handling `v:lua.*`


### PR DESCRIPTION
first commit: the original nil check doesn't work - nil values don't really exist in lua tables. pairs() will never return a nil value in its iteration, thus vim.tbl_contains can't work for checking if a value is nil

second commit:

- switches from `:h luaeval()` to native lua using loadstring() as recommended in luaeval help
- see the comment for why i removed the pcall (but please feel free to suggest alternative error-handling methods)
- silently handle completefuncs that dont error but return the wrong type of value (not sure on silently doing this, maybe just throw a more descriptive error instead of letting later code fail)