### PR TITLE
fix(build): read CARGO_TARGET_DIR in fast event

### DIFF
--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -104,7 +104,7 @@ function cmp.library_available() return native:library_available() end
 --- @return blink.lib.Task
 function cmp.build(opts)
   return native:build({ 'cargo', 'build', '--release' }, function(repo_root, platform)
-    local target_dir = vim.env.CARGO_TARGET_DIR or repo_root .. '/target'
+    local target_dir = vim.uv.os_getenv('CARGO_TARGET_DIR') or repo_root .. '/target'
     return {
       target_dir .. '/release/libblink_cmp_fuzzy' .. platform.lib_extension,
       target_dir .. '/release/blink_cmp_fuzzy' .. platform.lib_extension,


### PR DESCRIPTION
## Description

The build task resolves from a `vim.system()` completion callback, so
`get_artifact_paths` can run in a fast-event context.

Reading `CARGO_TARGET_DIR` through `vim.env` delegates to
`vim.fn.getenv()`, which fails there with:

    E5560: Vimscript function "getenv" must not be called in a fast event context

Use `vim.uv.os_getenv()` instead, which is safe in a libuv callback.

This fixes a regression introduced by #2596.

## Testing

- Reproduced the `E5560` failure on current `main`.
- Forced a native build with a custom `CARGO_TARGET_DIR`.
- Verified that the native library built successfully and was available afterward.