### PR TITLE
ci: update OpenBSD version for Release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,7 +129,7 @@ jobs:
         with:
           operating_system: openbsd
           architecture: ${{ matrix.arch }}
-          version: '7.8'
+          version: '7.9'
           memory: 4G
           sync_files: true  # Sync files between runner/VM in both directions
 


### PR DESCRIPTION
Following PR #2538, update OpenBSD version in "Release" workflow 7.8 => 7.9 (release in May 2026).