### PR TITLE
fix(completion): stale cursor position in within_query_bounds

### DIFF
--- a/lua/blink/cmp/completion/trigger/context.lua
+++ b/lua/blink/cmp/completion/trigger/context.lua
@@ -95,7 +95,7 @@ end
 --- @param include_start_bound? boolean Whether to include the start boundary as inside of the query. E.g. start_col = 1 (one indexed), cursor[2] = 0 (zero indexed) would be considered within the query bounds with this flag enabled.
 --- @return boolean
 function context:within_query_bounds(include_start_bound)
-  local pos, bounds = self.pos, self.bounds
+  local pos, bounds = context.get_pos(), self.bounds
   if pos.row + 1 ~= bounds.line_number then return false end
 
   local cursor_col = pos.col + 1

--- a/lua/blink/cmp/completion/trigger/context.lua
+++ b/lua/blink/cmp/completion/trigger/context.lua
@@ -25,7 +25,7 @@ local utils = require('blink.cmp.lib.utils')
 ---
 --- @field new fun(opts: blink.cmp.ContextOpts): blink.cmp.Context
 --- @field get_keyword fun(): string
---- @field within_query_bounds fun(self: blink.cmp.Context, include_start_bound?: boolean): boolean
+--- @field within_query_bounds fun(self: blink.cmp.Context, pos: vim.Pos, include_start_bound?: boolean): boolean
 ---
 --- @field get_mode fun(): blink.cmp.Mode
 --- @field get_pos fun(): vim.Pos
@@ -92,10 +92,11 @@ function context.get_keyword()
   return string.sub(context.get_line(), range.start_col, range.start_col + range.length - 1)
 end
 
+--- @param pos vim.Pos
 --- @param include_start_bound? boolean Whether to include the start boundary as inside of the query. E.g. start_col = 1 (one indexed), cursor[2] = 0 (zero indexed) would be considered within the query bounds with this flag enabled.
 --- @return boolean
-function context:within_query_bounds(include_start_bound)
-  local pos, bounds = context.get_pos(), self.bounds
+function context:within_query_bounds(pos, include_start_bound)
+  local bounds = self.bounds
   if pos.row + 1 ~= bounds.line_number then return false end
 
   local cursor_col = pos.col + 1

--- a/lua/blink/cmp/completion/trigger/init.lua
+++ b/lua/blink/cmp/completion/trigger/init.lua
@@ -97,7 +97,7 @@ local function on_cursor_moved(event, is_ignored, is_backspace, last_event)
   if
     trigger.context ~= nil
     and trigger.context.trigger.kind ~= 'prefetch'
-    and trigger.context:within_query_bounds(trigger.is_trigger_character(char_under_cursor))
+    and trigger.context:within_query_bounds(pos, trigger.is_trigger_character(char_under_cursor))
   then
     trigger.show({ trigger_kind = 'keyword' })
 


### PR DESCRIPTION
`trigger.context.pos` does not represent the updated cursor position
after CursorMoved.

Closes #2601
