### PR TITLE
fix(keymap): handle fallback keys in typeahead correctly

### DIFF
--- a/lua/blink/cmp/keymap/apply.lua
+++ b/lua/blink/cmp/keymap/apply.lua
@@ -26,7 +26,7 @@ local function apply_callback(mode, key, commands, callback)
     local keys = do_fallback(mapping_only)
     for i = #keys, 1, -1 do
       local k = keys[i]
-      -- Feed before the typeahead so the re-fed key keeps its original position
+      -- Feed before the typeahead so fallback keys keep their original order
       utils.feedkeys(k.key, k.mode .. 'i')
     end
   end

--- a/lua/blink/cmp/keymap/apply.lua
+++ b/lua/blink/cmp/keymap/apply.lua
@@ -24,8 +24,10 @@ local function apply_callback(mode, key, commands, callback)
   local consume_fallback_keys = function(mapping_only)
     mapping_only = mapping_only or false
     local keys = do_fallback(mapping_only)
-    for _, k in ipairs(keys) do
-      utils.feedkeys(k.key, k.mode)
+    for i = #keys, 1, -1 do
+      local k = keys[i]
+      -- Feed before the typeahead so the re-fed key keeps its original position
+      utils.feedkeys(k.key, k.mode .. 'i')
     end
   end
 
@@ -48,8 +50,8 @@ local function apply_callback(mode, key, commands, callback)
         local result = command(cmp)
         if type(result) == 'string' then
           if result ~= '' then
-            -- Allow key composition using mode 't', e.g. '<C-n>'
-            utils.feedkeys(vim.keycode(result), 't')
+            -- Allow key composition using mode 't', e.g. '<C-n>' and insert before typeahead.
+            utils.feedkeys(vim.keycode(result), 'ti')
             return
           end
         elseif result then

--- a/lua/blink/cmp/keymap/fallback.lua
+++ b/lua/blink/cmp/keymap/fallback.lua
@@ -37,13 +37,17 @@ function fallback.wrap(mode, key)
     -- <Esc> (or <C-[>) can be either a key or a sequence prefix. When treated as a prefix,
     -- the following bytes must be fed together, otherwise they're read as literal chars.
     if normalized_raw == '\27' then
-      local pending = {}
-      while true do
-        local char = vim.fn.getcharstr(0)
-        if char == '' then break end
-        pending[#pending + 1] = char
+      local prefix = vim.fn.getcharstr(0)
+      if prefix == '[' or prefix == 'O' then
+        local pending = {}
+        while true do
+          local char = vim.fn.getcharstr(0)
+          if char == '' or char == normalized_raw then break end
+          pending[#pending + 1] = char
+        end
+        return single_key(normalized_raw .. prefix .. table.concat(pending))
       end
-      if #pending > 0 then return single_key(normalized_raw .. table.concat(pending)) end
+      if prefix ~= '' then return { { key = normalized_raw, mode = 'n' }, { key = prefix, mode = 'n' } } end
     end
 
     local mapping = buffer_index[normalized_key] or global_index[normalized_key]


### PR DESCRIPTION
Context:
This is related to https://github.com/Saghen/blink.cmp/issues/2448 and an amendment to its fix 612f4bd2bc29d9e7dc7be1dde960908951bedad1.

If a mapping for `<Esc>` is defined and calls `fallback`, issuing a command that feeds `<Esc>` to typeahead, will loop indefinitely.

Consider my config section:

```lua
require("blink.cmp").setup({
		keymap = {
			['<Esc>'] = {
				function(cmp)
					if cmp.is_visible() then
						cmp.cancel() -- Don't return; always fallback (cancel + exit insert mode).
					end
				end,
				'fallback'
			}
		}
})
```

My environment:
Blink: cba53eff1948109ec0f47cbead4f07494d1e25c9
Nvim: neovim/neovim@387bd0fbe78756b030884805e61754cee1be4bb4
OS: Windows 29639

---

Issue:

if we enter some text in a buffer or do something that would trigger blink's completions to be populated, then issue a command like `:normal i<Esc>` where `<Esc>` is a literal escape control-character entered either via: <kbd>Ctrl</kbd>-<kbd>v</kbd>, <kbd>Esc</kbd> or <kbd>Ctrl</kbd>-<kbd>q</kbd>, <kbd>Esc</kbd>, then the mapping code loops forever processing the control-character.

---

Patch:

The condition can be changed to break if we get the control-code while scanning the buffer.
Current behavior should still work and the check prevents the mapping from getting stuck in this case and likely other cases that might deal with invoking the mapping and using the typeahead buffer at the same time.
("Works on my machine™" but admittedly this is a little confusing for me to consider every case this could get called from / every implication related to feeding and draining `typeahead`.)

---

<details><summary>Extra (full blink config as of today)</summary>
<p>

```lua
-- Local type spec that I use for vim.pack:

---@class Spec
---@field pkg string|table|nil
---@field disabled? boolean
---@field dependencies? string[]
---@field setup? fun()
---@field events? { event: string, callback: fun() }[]

-- blink's pkg spec:

---@type Spec
local M = {}

M.pkg = 'https://github.com/saghen/blink.cmp'

M.dependencies = {
	'plugins.completion.blink-lib',
	'plugins.completion.friendly-snippets',
}

M.setup = function()
	require("blink.cmp").setup({
		keymap = {
			['<Tab>'] = { 'select_next', 'snippet_forward', 'fallback' },
			['<Down>'] = { 'select_next', 'snippet_forward', 'fallback' },
			['<C-space>'] = { 'show', 'show_documentation', 'hide_documentation' },
			['<Esc>'] = {
				function(cmp)
					if cmp.is_visible() then
						cmp.cancel() -- Don't return; always fallback (cancel + exit insert mode).
					end
				end,
				'fallback'
			},
			['<C-e>'] = { 'hide' },
			['<C-y>'] = { 'select_and_accept' },
			['<CR>'] = { 'accept', 'fallback' },
			['<Space>'] = { 'accept', 'fallback' },
			['<Right>'] = { 'accept', 'fallback' },
			['<S-Tab>'] = { 'select_prev', 'snippet_backward', 'fallback' },
			['<Up>'] = { 'select_prev', 'snippet_backward', 'fallback' },
			['<C-p>'] = { 'select_prev', 'fallback' },
			['<C-n>'] = { 'select_next', 'fallback' },
			['<C-b>'] = { 'scroll_documentation_up', 'fallback' },
			['<C-f>'] = { 'scroll_documentation_down', 'fallback' },
		},
		cmdline = {
			keymap = {
				["<CR>"] = { "accept_and_enter", "fallback" },
				['<Up>'] = { 'select_prev', 'fallback' },
				['<Down>'] = { 'select_next', 'fallback' },
				['<Right>'] = { 'accept', 'fallback' }
			},
			-- NOTE: [sxT79VW-]
			-- This worked in v1; needs to be hoisted to global for v2 otherwise the
			-- type check for config.auto_show reads the default for normal mode (a bool) on the first command or search invocation,
			-- but will call our function on subsequent invocations.
			-- Not clear if this is a bug and hoisting it is a workaround
			-- or if this is a genuine misconfiguration in v2 / undefined behavior.
			-- completion = {
			-- 	menu = {
			-- 		auto_show = function(ctx, _)
			-- 			return ctx.mode ~= 'cmdline'
			-- 			--return vim.fn.getcmdtype() ~= ':'
			-- 		end,
			-- 	}
			-- }
		},
		completion = {
			list = {
				selection = {
					auto_insert = true,
					preselect = false,
				},
				cycle = {
					from_bottom = true,
					from_top = true,
				},
			},
			accept = {
				auto_brackets = { enabled = false },
			},
			menu = {
				auto_show = function(ctx, _) -- NOTE: See: [sxT79VW-].
					return ctx.mode ~= 'cmdline'
					--return vim.fn.getcmdtype() ~= ':'
				end,
				border = 'double',
				draw = {
					columns = { { "kind_icon" }, { "label", gap = 1 } },
					components = {
						label = {
							text = function(ctx)
								return require("colorful-menu").blink_components_text(ctx)
							end,
							highlight = function(ctx)
								return require("colorful-menu").blink_components_highlight(ctx)
							end,
						},
					},
				},
			},
			documentation = {
				auto_show = true,
				window = { border = 'double' }
			},
			ghost_text = { enabled = true },
		},
		signature = {
			enabled = true,
			window = { border = 'double' },
		},
		appearance = { use_nvim_cmp_as_default = true },
		fuzzy = {
			sorts = { 'exact', 'score', 'sort_text' }
		}
	})
end

return M
```

</p>
</details> 