### PR TITLE
fix(lsp): respect snippet insert text mode

### DIFF
--- a/lua/blink/cmp/completion/accept/init.lua
+++ b/lua/blink/cmp/completion/accept/init.lua
@@ -60,7 +60,9 @@ local function apply_item(ctx, item)
     text_edits_lib.apply(temp_text_edit, all_text_edits)
 
     -- Expand the snippet
-    require('blink.cmp.config').snippets.expand(item.textEdit.newText)
+    require('blink.cmp.config').snippets.expand(item.textEdit.newText, {
+      adjust_indentation = item.insertTextMode ~= vim.lsp.protocol.InsertTextMode.asIs,
+    })
 
     -- OR Normal: Apply the text edit and move the cursor
   else

--- a/lua/blink/cmp/config/snippets.lua
+++ b/lua/blink/cmp/config/snippets.lua
@@ -1,6 +1,6 @@
 --- @class (exact) blink.cmp.SnippetsConfig
 --- @field preset 'default' | 'luasnip' | 'mini_snippets' | 'vsnip'
---- @field expand fun(snippet: string) Function to use when expanding LSP provided snippets
+--- @field expand fun(snippet: string, opts?: { adjust_indentation?: boolean }) Function to use when expanding LSP provided snippets
 --- @field active fun(filter?: { direction?: integer }): boolean Function to use when checking if a snippet is active
 --- @field jump fun(direction: integer): boolean Function to use when jumping between tab stops in a snippet, where direction can be negative or positive
 --- @field score_offset integer Offset to the score of all snippet items
@@ -30,7 +30,7 @@ return {
   -- NOTE: we wrap `vim.snippet` calls to reduce startup by 1-2ms
   expand = {
     by_preset({
-      default = function(snippet) vim.snippet.expand(snippet) end,
+      default = function(snippet, opts) vim.snippet.expand(snippet, opts) end,
       luasnip = function(snippet) require('luasnip').lsp_expand(snippet) end,
       mini_snippets = function(snippet)
         if not _G.MiniSnippets then error('mini.snippets has not been setup') end


### PR DESCRIPTION
Fixes #2610.

blink.cmp advertises `InsertTextMode.asIs`, but its default snippet expansion path previously called `vim.snippet.expand()` without forwarding the insertion mode. That caused Neovim to add the current line indentation to multiline snippets whose server-provided indentation was already absolute.

This passes an optional `adjust_indentation` expansion option through the snippet boundary. The default `vim.snippet` preset honors it, while the existing LuaSnip, mini.snippets, vsnip, and custom expand functions remain compatible because Lua ignores extra function arguments.

Verification:

- `stylua --check` on both changed Lua files
- `nix flake check --no-build`
- End-to-end Neovim test with a real LSP `textEdit` snippet using `insertTextMode = asIs`; nested output retains 1/2/1-space indentation and produces no diagnostics