### PR TITLE
ci: update cross-platform-actions/action for version 1.4.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,7 +125,7 @@ jobs:
           persist-credentials: false
 
       - name: Build on OpenBSD/${{ matrix.arch }}
-        uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee # v1.3.0
+        uses: cross-platform-actions/action@24ef01df165c76df1ed2b9f9e9212e78dc2fc963 # v1.4.0
         with:
           operating_system: openbsd
           architecture: ${{ matrix.arch }}


### PR DESCRIPTION
Update [cross-platform-actions/action](https://github.com/cross-platform-actions/action) for OpenBSD build in "Release" workflow 

Release v1.4.0: https://github.com/cross-platform-actions/action/releases/tag/v1.4.0