### PR TITLE
docs: add blink-cmp-deps community source for Maven

### DIFF
--- a/doc/configuration/sources.md
+++ b/doc/configuration/sources.md
@@ -104,6 +104,7 @@ Here is a non-exhaustive list of third-party plugins providing additional comple
 - [blink-cmp-ctags](https://github.com/netmute/blink-cmp-ctags) by `netmute`: Ctags
 - [blink-cmp-dap](https://github.com/mayromr/blink-cmp-dap) by `mayromr`: DAP repl
 - [blink-cmp-dat-word](https://github.com/xieyonn/blink-cmp-dat-word) by `xieyonn`: Word
+- [blink-cmp-deps](https://github.com/Mestane/blink-cmp-deps) by `Mestane`: Maven dependency coordinates and versions
 - [blink-cmp-dictionary](https://github.com/Kaiser-Yang/blink-cmp-dictionary) by `Kaiser-Yang`: Word
 - [blink-cmp-env](https://github.com/bydlw98/blink-cmp-env) by `bydlw98`: Environment variables
 - [blink-cmp-emoji](https://github.com/timrydefalk/blink-cmp-emoji) by `timrydefalk`: Unicode Emoji v17.0 glyphs sans Zero Width Joiner


### PR DESCRIPTION
## Description

Adds blink-cmp-deps to the community sources list.

blink-cmp-deps provides Maven dependency completion for `pom.xml`, including `groupId`, `artifactId`, and versions, backed by Maven Central.

## Status

- v0.1.0 released
- CI passing
- Tested with blink.cmp