### PR TITLE
ci: update cross-platform-actions/action for version 1.5.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,7 +125,7 @@ jobs:
           persist-credentials: false
 
       - name: Build on OpenBSD/${{ matrix.arch }}
-        uses: cross-platform-actions/action@24ef01df165c76df1ed2b9f9e9212e78dc2fc963 # v1.4.0
+        uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 # v1.5.0
         with:
           operating_system: openbsd
           architecture: ${{ matrix.arch }}


### PR DESCRIPTION
Update [cross-platform-actions/action](https://github.com/cross-platform-actions/action) for OpenBSD build in "Release" workflow 

Release v1.5.0: https://github.com/cross-platform-actions/action/releases/tag/v1.5.0