### PR TITLE
refactor!: get `config` on demand via function

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780479614,
-        "narHash": "sha256-YlvnmeKny7pGL5+tAqtZK84WxJ/vKwCMG5CP9xJEnUg=",
+        "lastModified": 1788552953,
+        "narHash": "sha256-Juv/bLgkj4OrmILy3n01ymFSJlAbUreb9oXOMhGELRg=",
         "owner": "saghen",
         "repo": "blink.lib",
-        "rev": "b127d48bf8e9ac9cf41f6e0fbead317503f76558",
+        "rev": "7126c87f2c2fc1287145d66dd952956e7e90aff7",
         "type": "github"
       },
       "original": {

--- a/lua/blink/cmp/completion/accept/init.lua
+++ b/lua/blink/cmp/completion/accept/init.lua
@@ -1,4 +1,3 @@
-local config = require('blink.cmp.config').completion.accept
 local logger = require('blink.cmp.logger')
 local text_edits_lib = require('blink.cmp.lib.text_edits')
 local brackets_lib = require('blink.cmp.completion.brackets')
@@ -98,7 +97,9 @@ local function accept(ctx, item, callback)
   sources
     .resolve(ctx, item)
     -- Some LSPs may take a long time to resolve the item, so we timeout
-    :timeout(config.resolve_timeout_ms)
+    :timeout(
+      require('blink.cmp.config').completion.accept.resolve_timeout_ms
+    )
     -- and use the item as-is
     :catch(function() return item end)
     :map(function(resolved_item)

--- a/lua/blink/cmp/completion/brackets/semantic.lua
+++ b/lua/blink/cmp/completion/brackets/semantic.lua
@@ -1,6 +1,6 @@
 local nvim = require('blink.lib.nvim')
 local task = require('blink.lib.task')
-local config = require('blink.cmp.config').completion.accept.auto_brackets
+local function config() return require('blink.cmp.config').completion.accept.auto_brackets end
 local lib_utils = require('blink.cmp.lib.utils')
 local utils = require('blink.cmp.completion.brackets.utils')
 
@@ -117,7 +117,7 @@ function semantic.add_brackets_via_semantic_token(ctx, filetype, item)
     end
 
     -- listen for LspTokenUpdate events until timeout
-    semantic.timer:start(config.semantic_token_resolution.timeout_ms, 0, semantic.finish_request)
+    semantic.timer:start(config().semantic_token_resolution.timeout_ms, 0, semantic.finish_request)
   end) --[[@as blink.lib.Task<boolean>]]
 end
 

--- a/lua/blink/cmp/completion/brackets/utils.lua
+++ b/lua/blink/cmp/completion/brackets/utils.lua
@@ -1,4 +1,4 @@
-local config = require('blink.cmp.config').completion.accept.auto_brackets
+local function config() return require('blink.cmp.config').completion.accept.auto_brackets end
 local CompletionItemKind = require('blink.cmp.types').CompletionItemKind
 local brackets = require('blink.cmp.completion.brackets.config')
 local utils = {}
@@ -19,8 +19,8 @@ end
 --- @param item blink.cmp.CompletionItem
 --- @return string[]
 function utils.get_for_filetype(filetype, item)
-  local default = config.default_brackets
-  local per_filetype = config.override_brackets_for_filetypes[filetype] or brackets.per_filetype[filetype]
+  local default = config().default_brackets
+  local per_filetype = config().override_brackets_for_filetypes[filetype] or brackets.per_filetype[filetype]
 
   if type(per_filetype) == 'function' then return per_filetype(item) or default end
   return per_filetype or default
@@ -32,9 +32,9 @@ end
 --- @return boolean
 function utils.should_run_resolution(ctx, filetype, resolution_method)
   -- resolution method specific
-  if not config[resolution_method .. '_resolution'].enabled then return false end
+  if not config()[resolution_method .. '_resolution'].enabled then return false end
   ---@type string[]
-  local resolution_blocked_filetypes = config[resolution_method .. '_resolution'].blocked_filetypes
+  local resolution_blocked_filetypes = config()[resolution_method .. '_resolution'].blocked_filetypes
   if vim.tbl_contains(resolution_blocked_filetypes, filetype) then return false end
 
   -- filetype specific exceptions
@@ -44,10 +44,10 @@ function utils.should_run_resolution(ctx, filetype, resolution_method)
   end
 
   -- global
-  if not config.enabled then return false end
+  if not config().enabled then return false end
 
-  if vim.tbl_contains(config.force_allow_filetypes, filetype) then return true end
-  return not vim.tbl_contains(config.blocked_filetypes, filetype)
+  if vim.tbl_contains(config().force_allow_filetypes, filetype) then return true end
+  return not vim.tbl_contains(config().blocked_filetypes, filetype)
     and not vim.tbl_contains(brackets.blocked_filetypes, filetype)
 end
 

--- a/lua/blink/cmp/completion/list.lua
+++ b/lua/blink/cmp/completion/list.lua
@@ -1,6 +1,5 @@
 --- Manages most of the state for the completion list such that downstream consumers can be mostly stateless
 --- @class (exact) blink.cmp.CompletionList
---- @field config blink.cmp.CompletionListConfig
 --- @field show_emitter blink.cmp.EventEmitter<blink.cmp.CompletionListShowEvent>
 --- @field hide_emitter blink.cmp.EventEmitter<blink.cmp.CompletionListHideEvent>
 --- @field select_emitter blink.cmp.EventEmitter<blink.cmp.CompletionListSelectEvent>
@@ -74,10 +73,12 @@ local lib = require('blink.lib')
 local context = require('blink.cmp.completion.trigger.context')
 local event_emitter = require('blink.cmp.lib.event_emitter')
 
+--- @return blink.cmp.CompletionListConfig
+local function config() return require('blink.cmp.config').completion.list end
+
 --- @type blink.cmp.CompletionList
 --- @diagnostic disable-next-line: missing-fields
 local list = {
-  config = require('blink.cmp.config').completion.list,
   context = nil,
   items = {},
   is_explicitly_selected = false,
@@ -163,7 +164,7 @@ function list.fuzzy(ctx, items_by_source)
   filtered_items = require('blink.cmp.sources.lib').apply_max_items_for_completions(ctx, filtered_items)
 
   -- apply the global max_items
-  return lib.list.slice(filtered_items, 1, list.config.max_items)
+  return lib.list.slice(filtered_items, 1, config().max_items)
 end
 
 function list.hide()
@@ -181,11 +182,11 @@ function list.get_selected_item() return list.selected_item_idx and list.items[l
 function list.get_selection_mode(ctx)
   assert(ctx ~= nil, 'Context must be set before getting selection mode')
 
-  local preselect = list.config.selection.preselect
+  local preselect = config().selection.preselect
   if type(preselect) == 'function' then preselect = preselect(ctx) end
   --- @cast preselect boolean
 
-  local auto_insert = list.config.selection.auto_insert
+  local auto_insert = config().selection.auto_insert
   if type(auto_insert) == 'function' then auto_insert = auto_insert(ctx) end
   --- @cast auto_insert boolean
 
@@ -232,7 +233,7 @@ function list.select_next(opts)
     if not select_mode.preselect or select_mode.auto_insert then return list.select(nil, opts) end
 
     -- cycling around has been disabled, ignore
-    if not list.config.cycle.from_bottom then return false end
+    if not config().cycle.from_bottom then return false end
 
     -- otherwise, we cycle around
     return list.select(1, opts)
@@ -251,7 +252,7 @@ function list.select_prev(opts)
 
   -- haven't selected anything yet, select the last item, if cycling enabled
   if list.selected_item_idx == nil then
-    if not list.config.cycle.from_top then return false end
+    if not config().cycle.from_top then return false end
 
     return list.select(#list.items, opts)
   end
@@ -263,7 +264,7 @@ function list.select_prev(opts)
     if not select_mode.preselect or select_mode.auto_insert then return list.select(nil, opts) end
 
     -- cycling around has been disabled, ignore
-    if not list.config.cycle.from_top then return false end
+    if not config().cycle.from_top then return false end
 
     -- otherwise, we cycle around
     return list.select(#list.items, opts)
@@ -316,14 +317,10 @@ function list.jump_by(dir, opts)
 
   if dir == 1 then
     if try_jump(list.selected_item_idx + 1, #list.items, 1) then return true end
-    if list.config and list.config.cycle and list.config.cycle.from_bottom then
-      return try_jump(1, list.selected_item_idx - 1, 1)
-    end
+    if config().cycle.from_bottom then return try_jump(1, list.selected_item_idx - 1, 1) end
   elseif dir == -1 then
     if try_jump(list.selected_item_idx - 1, 1, -1) then return true end
-    if list.config and list.config.cycle and list.config.cycle.from_top then
-      return try_jump(#list.items, list.selected_item_idx + 1, -1)
-    end
+    if config().cycle.from_top then return try_jump(#list.items, list.selected_item_idx + 1, -1) end
   end
 
   return false

--- a/lua/blink/cmp/completion/trigger/init.lua
+++ b/lua/blink/cmp/completion/trigger/init.lua
@@ -29,7 +29,7 @@
 --- @field initial_selected_item_idx? integer
 
 local root_config = require('blink.cmp.config')
-local config = root_config.completion.trigger
+local function config() return root_config.completion.trigger end
 local context = require('blink.cmp.completion.trigger.context')
 local utils = require('blink.cmp.lib.utils')
 local fuzzy = require('blink.cmp.fuzzy')
@@ -49,12 +49,12 @@ local function on_char_added(char, is_ignored)
     if trigger.context ~= nil then trigger.show({ send_upstream = false, trigger_kind = 'keyword' }) end
 
   -- character forces a trigger according to the sources, create a fresh context
-  elseif trigger.is_trigger_character(char) and (config.show_on_trigger_character or trigger.context ~= nil) then
+  elseif trigger.is_trigger_character(char) and (config().show_on_trigger_character or trigger.context ~= nil) then
     trigger.context = nil
     trigger.show({ trigger_kind = 'trigger_character', trigger_character = char })
 
   -- character is part of a keyword
-  elseif fuzzy.is_keyword_character(char) and (config.show_on_keyword or trigger.context ~= nil) then
+  elseif fuzzy.is_keyword_character(char) and (config().show_on_keyword or trigger.context ~= nil) then
     -- typed after auto insertion, refresh the menu
     if require('blink.cmp.completion.list').preview_undo ~= nil then trigger.context = nil end
 
@@ -88,8 +88,8 @@ local function on_cursor_moved(event, is_ignored, is_backspace, last_event)
 
   -- TODO: doesn't handle `a` where the cursor moves immediately after
   -- Reproducible with `example.|a` and pressing `a`, should not show the menu
-  local insert_enter_on_trigger_character = config.show_on_trigger_character
-    and config.show_on_insert_on_trigger_character
+  local insert_enter_on_trigger_character = config().show_on_trigger_character
+    and config().show_on_insert_on_trigger_character
     and is_enter_event
     and trigger.is_trigger_character(char_under_cursor, true)
 
@@ -112,27 +112,27 @@ local function on_cursor_moved(event, is_ignored, is_backspace, last_event)
     trigger.show({ trigger_kind = 'keyword' })
 
   -- show after entering insert mode
-  elseif is_enter_event and config.show_on_insert then
+  elseif is_enter_event and config().show_on_insert then
     trigger.show({ trigger_kind = 'keyword' })
 
   -- prefetch completions without opening window after entering insert mode
-  elseif is_enter_event and config.prefetch_on_insert then
+  elseif is_enter_event and config().prefetch_on_insert then
     trigger.show({ trigger_kind = 'prefetch' })
 
   -- show after backspacing
-  elseif config.show_on_backspace and is_backspace then
+  elseif config().show_on_backspace and is_backspace then
     trigger.show({ trigger_kind = 'keyword' })
 
   -- show after backspacing into a keyword
-  elseif config.show_on_backspace_in_keyword and is_backspace and is_keyword then
+  elseif config().show_on_backspace_in_keyword and is_backspace and is_keyword then
     trigger.show({ trigger_kind = 'keyword' })
 
   -- show after entering insert or term mode and backspacing into a keyword
-  elseif config.show_on_backspace_after_insert_enter and is_backspace and last_event == 'enter' and is_keyword then
+  elseif config().show_on_backspace_after_insert_enter and is_backspace and last_event == 'enter' and is_keyword then
     trigger.show({ trigger_kind = 'keyword' })
 
   -- show after accepting a completion and then backspacing into a keyword
-  elseif config.show_on_backspace_after_accept and is_backspace and last_event == 'accept' and is_keyword then
+  elseif config().show_on_backspace_after_accept and is_backspace and last_event == 'accept' and is_keyword then
     trigger.show({ trigger_kind = 'keyword' })
 
   -- otherwise hide
@@ -145,7 +145,7 @@ function trigger.activate()
   trigger.buffer_events = require('blink.cmp.lib.buffer_events').new({
     -- TODO: should this ignore trigger.kind == 'prefetch'?
     has_context = function() return trigger.context ~= nil end,
-    show_in_snippet = config.show_in_snippet,
+    show_in_snippet = function() return config().show_in_snippet end,
   })
 
   trigger.buffer_events:listen({
@@ -186,13 +186,13 @@ function trigger.is_trigger_character(char, is_show_on_x)
   -- ignore a-z and A-Z characters
   if char:match('%a') then return false end
 
-  local show_on_blocked_trigger_characters = type(config.show_on_blocked_trigger_characters) == 'function'
-      and config.show_on_blocked_trigger_characters()
-    or config.show_on_blocked_trigger_characters
+  local show_on_blocked_trigger_characters = type(config().show_on_blocked_trigger_characters) == 'function'
+      and config().show_on_blocked_trigger_characters()
+    or config().show_on_blocked_trigger_characters
   --- @cast show_on_blocked_trigger_characters string[]
-  local show_on_x_blocked_trigger_characters = type(config.show_on_x_blocked_trigger_characters) == 'function'
-      and config.show_on_x_blocked_trigger_characters()
-    or config.show_on_x_blocked_trigger_characters
+  local show_on_x_blocked_trigger_characters = type(config().show_on_x_blocked_trigger_characters) == 'function'
+      and config().show_on_x_blocked_trigger_characters()
+    or config().show_on_x_blocked_trigger_characters
   --- @cast show_on_x_blocked_trigger_characters string[]
 
   local is_blocked = vim.tbl_contains(show_on_blocked_trigger_characters, char)
@@ -218,7 +218,7 @@ end
 function trigger.show_if_on_trigger_character(opts)
   if
     (opts and opts.is_accept)
-    and (not config.show_on_trigger_character or not config.show_on_accept_on_trigger_character)
+    and (not config().show_on_trigger_character or not config().show_on_accept_on_trigger_character)
   then
     return
   end

--- a/lua/blink/cmp/completion/windows/documentation.lua
+++ b/lua/blink/cmp/completion/windows/documentation.lua
@@ -12,8 +12,7 @@
 
 local lib = require('blink.lib')
 local nvim = require('blink.lib.nvim')
-local config = require('blink.cmp.config').completion.documentation
-local win_config = config.window
+local function config() return require('blink.cmp.config').completion.documentation end
 
 local logger = require('blink.cmp.logger')
 local sources = require('blink.cmp.sources.lib')
@@ -23,14 +22,14 @@ local menu = require('blink.cmp.completion.windows.menu')
 --- @diagnostic disable-next-line: missing-fields
 local docs = {
   win = require('blink.cmp.lib.window').new('documentation', {
-    min_width = win_config.min_width,
-    max_width = win_config.max_width,
-    max_height = win_config.max_height,
+    min_width = config().window.min_width,
+    max_width = config().window.max_width,
+    max_height = config().window.max_height,
     default_border = 'padded',
-    border = win_config.border,
-    winblend = win_config.winblend,
-    winhighlight = win_config.winhighlight,
-    scrollbar = win_config.scrollbar,
+    border = config().window.border,
+    winblend = config().window.winblend,
+    winhighlight = config().window.winhighlight,
+    scrollbar = config().window.scrollbar,
     wrap = true,
     linebreak = true,
     filetype = 'blink-cmp-documentation',
@@ -45,11 +44,11 @@ menu.close_emitter:on(function() docs.close() end)
 function docs.auto_show_item(context, item)
   docs.auto_show_timer:stop()
   if docs.win:is_open() then
-    docs.auto_show_timer:start(config.update_delay_ms, 0, function()
+    docs.auto_show_timer:start(config().update_delay_ms, 0, function()
       vim.schedule(function() docs.show_item(context, item) end)
     end)
-  elseif config.auto_show then
-    docs.auto_show_timer:start(config.auto_show_delay_ms, 0, function()
+  elseif config().auto_show then
+    docs.auto_show_timer:start(config().auto_show_delay_ms, 0, function()
       vim.schedule(function() docs.show_item(context, item) end)
     end)
   end
@@ -82,17 +81,17 @@ function docs.show_item(context, item)
           detail = resolved_item.detail,
           documentation = resolved_item.documentation,
           max_width = docs.win.config.max_width or docs.win:get_content_width(),
-          use_treesitter_highlighting = config and config.treesitter_highlighting,
+          use_treesitter_highlighting = config().treesitter_highlighting,
         }
         -- allow the provider to override the drawing optionally
         -- TODO: should the default_implementation be the configured draw function instead of the built-in?
-        local draw = type(resolved_item.documentation) == 'table' and resolved_item.documentation.draw or config.draw
+        local draw = type(resolved_item.documentation) == 'table' and resolved_item.documentation.draw or config().draw
 
         nvim.set_option_value('modifiable', true, { buf = docs_buf })
         draw({
           item = resolved_item,
           window = docs.win,
-          config = config,
+          config = config(),
           default_implementation = function(opts)
             opts = opts or {}
             ---@type blink.cmp.RenderDetailAndDocumentationOpts
@@ -159,8 +158,8 @@ function docs.update_position()
 
   -- decide direction priority based on the menu window's position
   local menu_win_is_up = menu_win_config.row - cursor_win_row < 0
-  local direction_priority = menu_win_is_up and win_config.direction_priority.menu_north
-    or win_config.direction_priority.menu_south
+  local direction_priority = menu_win_is_up and config().window.direction_priority.menu_north
+    or config().window.direction_priority.menu_south
 
   -- remove the direction priority of the signature window if it's open
   local signature = require('blink.cmp.signature.window')
@@ -173,8 +172,8 @@ function docs.update_position()
 
   -- decide direction, width and height of window
   local pos = docs.win:get_direction_with_window_constraints(menu.win, direction_priority, {
-    width = win_config.desired_min_width,
-    height = win_config.desired_min_height,
+    width = config().window.desired_min_width,
+    height = config().window.desired_min_height,
   })
 
   -- couldn't find anywhere to place the window

--- a/lua/blink/cmp/completion/windows/ghost_text/init.lua
+++ b/lua/blink/cmp/completion/windows/ghost_text/init.lua
@@ -1,5 +1,5 @@
 local nvim = require('blink.lib.nvim')
-local config = require('blink.cmp.config').completion.ghost_text
+local function config() return require('blink.cmp.config').completion.ghost_text end
 local highlight_ns = require('blink.cmp.config').appearance.highlight_ns
 
 local text_edits_lib = require('blink.cmp.lib.text_edits')
@@ -24,8 +24,8 @@ nvim.create_autocmd({ 'CursorMovedI' }, {
 })
 
 function ghost_text.enabled()
-  if type(config.enabled) == 'function' then return config.enabled() end
-  return config.enabled
+  if type(config().enabled) == 'function' then return config().enabled() end
+  return config().enabled
 end
 
 function ghost_text.is_open() return ghost_text.extmark_id ~= nil end
@@ -39,7 +39,7 @@ function ghost_text.show_preview(context, items, selection_idx)
   -- check if we're supposed to show
   local has_selection = selection_idx ~= nil
   if
-    (has_selection and not config.show_with_selection) or (not has_selection and not config.show_without_selection)
+    (has_selection and not config().show_with_selection) or (not has_selection and not config().show_without_selection)
   then
     ghost_text.clear_preview()
     return
@@ -69,7 +69,7 @@ function ghost_text.draw_preview()
   -- check if we should be showing
   local menu_open = menu.win:is_open()
   local should_show_preview = ghost_text.enabled()
-    and ((menu_open and config.show_with_menu) or (not menu_open and config.show_without_menu))
+    and ((menu_open and config().show_with_menu) or (not menu_open and config().show_without_menu))
 
   if not should_show_preview then
     ghost_text.clear_preview()
@@ -101,7 +101,7 @@ function ghost_text.draw_preview()
   local typed_length = math.max(0, math.min(vim.fn.strchars(typed_text), vim.fn.strchars(text_edit.newText)))
   local untyped_text = vim.fn.strcharpart(text_edit.newText, typed_length)
   local display_lines = vim.split(untyped_text, '\n', { plain = true })
-  if config.show_first_line_only and #display_lines > 1 then
+  if config().show_first_line_only and #display_lines > 1 then
     display_lines = { display_lines[1] .. ' [+' .. #display_lines - 1 .. ']' }
   end
 

--- a/lua/blink/cmp/completion/windows/menu/init.lua
+++ b/lua/blink/cmp/completion/windows/menu/init.lua
@@ -30,24 +30,36 @@
 
 local lib = require('blink.lib')
 local nvim = require('blink.lib.nvim')
-local config = require('blink.cmp.config').completion.menu
+local function config() return require('blink.cmp.config').completion.menu end
 local event_emitter = require('blink.cmp.lib.event_emitter')
 local auto_wrap = require('blink.cmp.completion.windows.menu.auto_wrap')
+
+local function default_auto_show_enabled(context, items)
+  local auto_show = config().auto_show
+  if type(auto_show) == 'function' then return auto_show(context, items) end
+  return auto_show
+end
+
+local function default_auto_show_delay_ms(context, items)
+  local delay_ms = config().auto_show_delay_ms
+  if type(delay_ms) == 'function' then return delay_ms(context, items) end
+  return delay_ms
+end
 
 --- @type blink.cmp.CompletionMenu
 --- @diagnostic disable-next-line: missing-fields
 local menu = {
   win = require('blink.cmp.lib.window').new('menu', {
-    min_width = config.min_width,
-    max_height = config.max_height,
+    min_width = config().min_width,
+    max_height = config().max_height,
     default_border = 'none',
-    border = config.border,
-    winblend = config.winblend,
-    winhighlight = config.winhighlight,
+    border = config().border,
+    winblend = config().winblend,
+    winhighlight = config().winhighlight,
     cursorline = false,
-    cursorline_priority = config.draw.cursorline_priority,
-    scrolloff = config.scrolloff,
-    scrollbar = config.scrollbar,
+    cursorline_priority = config().draw.cursorline_priority,
+    scrolloff = config().scrolloff,
+    scrollbar = config().scrollbar,
     filetype = 'blink-cmp-menu',
   }),
 
@@ -55,9 +67,8 @@ local menu = {
   items = {},
 
   auto_show = {
-    enabled = type(config.auto_show) == 'function' and config.auto_show or function() return config.auto_show end,
-    delay_ms = type(config.auto_show_delay_ms) == 'function' and config.auto_show_delay_ms
-      or function() return config.auto_show_delay_ms end,
+    enabled = default_auto_show_enabled,
+    delay_ms = default_auto_show_delay_ms,
     timer = lib.timer.new(),
     timer_key = '',
   },
@@ -80,8 +91,8 @@ function menu.open_with_items(context, items)
   menu.items = items
   menu.set_selected_item_idx(menu.selected_item_idx ~= nil and math.min(menu.selected_item_idx, #items) or nil)
 
-  if not menu.renderer then menu.renderer = require('blink.cmp.completion.windows.render').new(config.draw) end
-  menu.renderer:draw(context, menu.win:get_buf(), items, {})
+  if not menu.renderer then menu.renderer = require('blink.cmp.completion.windows.render').new(config().draw) end
+  menu.renderer:draw(context, menu.win:get_buf(), items, config().draw)
 
   menu.queue_auto_show(context, items)
 end
@@ -91,7 +102,7 @@ function menu.open_loading(context)
   menu.items = {}
   menu.set_selected_item_idx(nil)
 
-  if not menu.renderer then menu.renderer = require('blink.cmp.completion.windows.render').new(config.draw) end
+  if not menu.renderer then menu.renderer = require('blink.cmp.completion.windows.render').new(config().draw) end
   menu.renderer:draw(context, menu.win:get_buf(), {
     {
       label = 'Loading...',
@@ -111,7 +122,7 @@ function menu.open_loading(context)
       client_id = 0,
       client_name = '',
     },
-  }, {})
+  }, config().draw)
 
   menu.queue_auto_show(context, {})
 end
@@ -149,7 +160,7 @@ function menu.set_selected_item_idx(idx)
   -- user may want to reposition on the menu based on the selected item
   -- https://github.com/Saghen/blink.cmp/issues/2000
   -- https://github.com/Saghen/blink.cmp/issues/1801
-  if type(config.direction_priority) == 'function' then menu.update_position() end
+  if type(config().direction_priority) == 'function' then menu.update_position() end
 end
 
 ---------------
@@ -204,10 +215,8 @@ function menu.force_auto_show()
 end
 
 function menu.reset_auto_show()
-  menu.auto_show.enabled = type(config.auto_show) == 'function' and config.auto_show
-    or function() return config.auto_show end
-  menu.auto_show.delay_ms = type(config.auto_show_delay_ms) == 'function' and config.auto_show_delay_ms
-    or function() return config.auto_show_delay_ms end
+  menu.auto_show.enabled = default_auto_show_enabled
+  menu.auto_show.delay_ms = default_auto_show_delay_ms
   menu.auto_show.timer:stop()
   menu.auto_show.timer_key = ''
 end
@@ -227,7 +236,7 @@ function menu.update_position()
   win:update_size()
 
   local border_size = win:get_border_size()
-  local pos = win:get_vertical_direction_and_height(config.direction_priority, config.max_height)
+  local pos = win:get_vertical_direction_and_height(config().direction_priority, config().max_height)
 
   -- couldn't find anywhere to place the window
   if not pos then
@@ -243,7 +252,7 @@ function menu.update_position()
 
   -- in cmdline mode, we get the position from a function to support UI plugins like noice
   if nvim.get_mode().mode == 'c' then
-    local cmdline_position = config.cmdline_position()
+    local cmdline_position = config().cmdline_position()
     win:set_win_config({
       relative = 'editor',
       row = cmdline_position[1] + row,
@@ -265,7 +274,7 @@ function menu.update_position()
     local prefix = vim.fn.strpart(context.line, 0, context.bounds.start_col - 1)
     local offset_from_cursor = vim.fn.strdisplaywidth(prefix) - curswant
     local col = offset_from_cursor - alignment_start_col - border_size.left
-    if config.draw.align_to == 'cursor' then col = 0 end
+    if config().draw.align_to == 'cursor' then col = 0 end
     if off ~= 0 then col = col + off end
 
     win:set_win_config({ relative = 'cursor', row = row, col = col })

--- a/lua/blink/cmp/completion/windows/render/context.lua
+++ b/lua/blink/cmp/completion/windows/render/context.lua
@@ -15,6 +15,8 @@
 --- @field source_name string
 
 local lib = require('blink.lib')
+local kinds = require('blink.cmp.types').CompletionItemKind
+local function config() return require('blink.cmp.config').appearance end
 
 local draw_context = {}
 
@@ -30,29 +32,29 @@ function draw_context.get_from_items(context, draw, items)
     require('blink.cmp.config').completion.keyword.range
   )
 
+  local appearance = config()
   local ctxs = {}
   for idx, item in ipairs(items) do
     local matched_idx = matched_indices[idx]
     assert(matched_idx, 'No index ' .. idx .. ' found in fuzzy_matched_indices')
-    ctxs[idx] = draw_context.new(draw, idx, item, matched_idx)
+    ctxs[idx] = draw_context.new(draw, idx, item, matched_idx, appearance)
   end
   return ctxs
 end
-
-local config = require('blink.cmp.config').appearance
-local kinds = require('blink.cmp.types').CompletionItemKind
 
 --- @param draw blink.cmp.Draw
 --- @param item_idx integer
 --- @param item blink.cmp.CompletionItem
 --- @param matched_indices integer[]
+--- @param appearance? blink.cmp.AppearanceConfig
 --- @return blink.cmp.DrawItemContext
-function draw_context.new(draw, item_idx, item, matched_indices)
+function draw_context.new(draw, item_idx, item, matched_indices, appearance)
+  appearance = appearance or config()
   local kind = item.kind_name or kinds[item.kind] or 'Unknown'
-  local kind_icon = item.kind_icon or config.kind_icons[kind] or config.kind_icons.Field
+  local kind_icon = item.kind_icon or appearance.kind_icons[kind] or appearance.kind_icons.Field
   local kind_hl = item.kind_hl or ('BlinkCmpKind' .. (kinds[item.kind] or 'Unknown'))
 
-  local icon_spacing = config.nerd_font_variant == 'mono' and '' or ' '
+  local icon_spacing = appearance.nerd_font_variant == 'mono' and '' or ' '
 
   -- Some LSPs can return labels with newlines
   -- Escape them to avoid errors in nvim_buf_set_lines when rendering the completion menu
@@ -83,7 +85,7 @@ function draw_context.new(draw, item_idx, item, matched_indices)
     kind = kind,
     kind_icon = kind_icon,
     kind_hl = kind_hl,
-    icon_gap = config.nerd_font_variant == 'mono' and '' or ' ',
+    icon_gap = icon_spacing,
     deprecated = (lib.is_not_nil(item.deprecated) and item.deprecated)
       or (lib.is_not_nil(item.tags) and vim.tbl_contains(item.tags or {}, 1))
       or false,

--- a/lua/blink/cmp/completion/windows/render/init.lua
+++ b/lua/blink/cmp/completion/windows/render/init.lua
@@ -8,7 +8,7 @@ local nvim = require('blink.lib.nvim')
 --- @field bufnr? integer
 ---
 --- @field new fun(draw: blink.cmp.Draw): blink.cmp.Renderer
---- @field draw fun(self: blink.cmp.Renderer, context: blink.cmp.Context, bufnr: integer, items: blink.cmp.CompletionItem[], draw: blink.cmp.Draw)
+--- @field draw fun(self: blink.cmp.Renderer, context: blink.cmp.Context, bufnr: integer, items: blink.cmp.CompletionItem[], draw?: blink.cmp.Draw)
 --- @field get_columns fun(self: blink.cmp.Renderer, context: blink.cmp.Context, draw: blink.cmp.Draw): blink.cmp.DrawColumn[]
 --- @field get_component_column_location fun(self: blink.cmp.Renderer, columns: blink.cmp.DrawColumn[], component_name: string): { [1]: integer, [2]: integer }
 --- @field get_component_start_col fun(self: blink.cmp.Renderer, columns: blink.cmp.DrawColumn[], component_name: string): integer
@@ -21,7 +21,8 @@ local ns = nvim.create_namespace('blink_cmp_renderer')
 local renderer = {}
 
 function renderer.new(draw)
-  local padding = type(draw.padding) == 'number' and { draw.padding, draw.padding } or draw.padding
+  local padding = type(draw.padding) == 'number' and { draw.padding, draw.padding }
+    or { draw.padding[1] or 0, draw.padding[2] or draw.padding[1] or 0 }
 
   local self = setmetatable({}, { __index = renderer })
   self.padding = padding
@@ -90,9 +91,16 @@ function renderer:get_columns(context, draw)
   )
 end
 
-function renderer:draw(context, bufnr, items)
-  local columns = self:get_columns(context, self.def)
-  local draw_contexts = require('blink.cmp.completion.windows.render.context').get_from_items(context, self.def, items)
+function renderer:draw(context, bufnr, items, draw)
+  -- the draw config may change at runtime (per buffer/mode), so prefer the one passed by the caller
+  draw = draw or self.def
+  self.def = draw
+  self.padding = type(draw.padding) == 'number' and { draw.padding, draw.padding }
+    or { draw.padding[1] or 0, draw.padding[2] or draw.padding[1] or 0 }
+  self.gap = draw.gap or 0
+
+  local columns = self:get_columns(context, draw)
+  local draw_contexts = require('blink.cmp.completion.windows.render.context').get_from_items(context, draw, items)
 
   -- render the columns
   for _, column in ipairs(columns) do

--- a/lua/blink/cmp/config/completion/menu.lua
+++ b/lua/blink/cmp/config/completion/menu.lua
@@ -54,7 +54,7 @@ return {
     -- Aligns the keyword you've typed to a component in the menu
     align_to = { 'label', config.types.validator('known component', function() return true end) },
     -- Left and right padding, optionally { left, right } for different padding on each side
-    padding = { 1, { 'number', config.types.table({ 'number', 'number' }) } },
+    padding = { 1, { 'number', config.types.list('number') } },
     -- Gap between columns
     gap = { 1, 'number' },
     -- Priority of the cursorline highlight, setting this to 0 will render it below other highlights

--- a/lua/blink/cmp/config/init.lua
+++ b/lua/blink/cmp/config/init.lua
@@ -18,7 +18,7 @@
 --- @field enabled boolean
 --- @field keymap blink.cmp.KeymapConfig
 
---- @type blink.cmp.ConfigStrict
+--- @type blink.cmp.ConfigStrict | blink.lib.Config
 local config = require('blink.lib.config').new({
   enabled = { true, { 'boolean', 'function' } },
   keymap = require('blink.cmp.config.keymap').get('default'),
@@ -41,10 +41,10 @@ local config = require('blink.lib.config').new({
     enabled = { true, 'boolean' },
     keymap = require('blink.cmp.config.keymap').get('inherit'),
   },
-}, { global_key = 'blink_cmp', validate = false })
+}, { validate = false })
 
 -- cmdline override
-config({
+config.set({
   sources = { default = { 'buffer', 'cmdline' } },
   completion = {
     trigger = { show_on_blocked_trigger_characters = {}, show_on_x_blocked_trigger_characters = {} },
@@ -54,17 +54,8 @@ config({
   },
 }, { mode = 'cmdline', validate = false })
 
--- cmdwin override
-config({
-  sources = { default = { 'buffer', 'cmdline' } },
-  completion = {
-    menu = { auto_show = true },
-    ghost_text = { enabled = true },
-  },
-}, { mode = 'cmdwin', validate = false })
-
 -- term override
-config({
+config.set({
   sources = { default = {} },
   completion = {
     trigger = {

--- a/lua/blink/cmp/config/keymap.lua
+++ b/lua/blink/cmp/config/keymap.lua
@@ -194,19 +194,14 @@ local commands = {
   'snippet_backward',
 }
 
-local keycode = config.types.validator('keycode', function(val)
-  if type(val) ~= 'string' or val == '' then return false end
-  local rest = val:gsub('<[^<>]+>', '')
-  if rest:match('[<>]') then return false end
-  return true
-end)
-
-local actions =
-  config.types.union(config.types.enum({ false }), config.types.list({ config.types.enum(commands), 'function' }))
+local actions = { config.types.enum({ false }), config.types.list({ config.types.enum(commands), 'function' }) }
 
 ---@param default_preset blink.cmp.KeymapPreset
 function keymap.get(default_preset)
-  return config.types.catchall({ preset = { default_preset, config.types.enum(presets) } }, keycode, actions)
+  return {
+    { preset = default_preset },
+    config.types.table({ preset = config.types.enum(presets) }, config.types.keycode, actions),
+  }
 end
 
 return keymap

--- a/lua/blink/cmp/init.lua
+++ b/lua/blink/cmp/init.lua
@@ -55,14 +55,14 @@ function cmp.setup(opts)
   ---@type blink.cmp.Config
   opts = lib.tbl.copy(opts)
   if opts.cmdline then
-    config(lib.tbl.omit(opts.cmdline, { 'enabled', 'keymap' }), { mode = 'cmdline' })
+    config.set(lib.tbl.omit(opts.cmdline, { 'enabled', 'keymap' }), { mode = 'cmdline' })
     opts.cmdline = lib.tbl.pick(opts.cmdline, { 'enabled', 'keymap' })
   end
   if opts.term then
-    config(lib.tbl.omit(opts.term, { 'enabled', 'keymap' }), { mode = 'terminal' })
+    config.set(lib.tbl.omit(opts.term, { 'enabled', 'keymap' }), { mode = 'terminal' })
     opts.term = lib.tbl.pick(opts.term, { 'enabled', 'keymap' })
   end
-  config(opts)
+  config.set(opts)
 
   -- setup native library
   if config.fuzzy.implementation ~= 'lua' then

--- a/lua/blink/cmp/keymap/init.lua
+++ b/lua/blink/cmp/keymap/init.lua
@@ -82,12 +82,11 @@ function keymap.get_mappings(keymap_config, mode)
 
   -- Inherit preset from default, if needed
   if mappings.preset == 'inherit' and mode ~= 'default' then
-    ---@diagnostic disable-next-line: undefined-field
     ---@type blink.cmp.ConfigStrict
-    local snapshot = config.snapshot()
+    local root = config.get()
 
-    mappings = vim.tbl_deep_extend('force', snapshot.keymap, mappings)
-    mappings.preset = snapshot.keymap.preset
+    mappings = vim.tbl_deep_extend('force', root.keymap, mappings)
+    mappings.preset = root.keymap.preset
   end
 
   -- Remove unused keys, but keep keys set to false or empty tables (to disable them)
@@ -119,9 +118,8 @@ function keymap.get_mappings(keymap_config, mode)
 end
 
 function keymap.setup()
-  ---@diagnostic disable-next-line: undefined-field
   ---@type blink.cmp.ConfigStrict
-  local cfg = config.snapshot()
+  local cfg = config.get()
 
   -- Load keymaps per mode
   keymap.mappings = {

--- a/lua/blink/cmp/lib/buffer_events.lua
+++ b/lua/blink/cmp/lib/buffer_events.lua
@@ -3,12 +3,12 @@
 --- Unlike in regular neovim, ctrl + c and buffer switching will trigger "insert leave"
 
 local nvim = require('blink.lib.nvim')
-local snippet = require('blink.cmp.config').snippets
+local function snippet_config() return require('blink.cmp.config').snippets end
 local utils = require('blink.cmp.lib.utils')
 
 --- @class blink.cmp.BufferEvents
 --- @field has_context fun(): boolean
---- @field show_in_snippet boolean
+--- @field show_in_snippet fun(): boolean
 --- @field ignore_next_text_changed boolean
 --- @field ignore_next_cursor_moved boolean
 --- @field last_char string
@@ -23,7 +23,7 @@ local utils = require('blink.cmp.lib.utils')
 
 --- @class blink.cmp.BufferEventsOptions
 --- @field has_context fun(): boolean
---- @field show_in_snippet boolean
+--- @field show_in_snippet fun(): boolean
 
 --- @class blink.cmp.BufferEventsListener
 --- @field on_char_added? fun(char: string, is_ignored: boolean)
@@ -97,7 +97,7 @@ local function make_cursor_moved(self, on_cursor_moved)
     --- @cast ev vim.api.keyset.create_autocmd.callback_args
     --- @cast ev.event 'CursorMoved' | 'CursorMovedI' | 'InsertEnter'
 
-    local in_snippet_context = self.has_context() and snippet.active()
+    local in_snippet_context = self.has_context() and snippet_config().active()
 
     -- only fire a CursorMoved event (notable not CursorMovedI)
     -- when jumping between tab stops in a snippet while showing the menu
@@ -240,6 +240,8 @@ function buffer_events:suppress_events_for_callback(cb)
   if not cursor_moved then vim.defer_fn(function() self.ignore_next_cursor_moved = false end, 10) end
 end
 
-function buffer_events:hide_in_snippet() return not self.show_in_snippet and not self.has_context() and snippet.active() end
+function buffer_events:hide_in_snippet()
+  return not self.show_in_snippet() and not self.has_context() and snippet_config().active()
+end
 
 return buffer_events

--- a/lua/blink/cmp/signature/trigger.lua
+++ b/lua/blink/cmp/signature/trigger.lua
@@ -33,7 +33,7 @@
 
 local nvim = require('blink.lib.nvim')
 local root_config = require('blink.cmp.config')
-local config = require('blink.cmp.config').signature.trigger
+local function config() return root_config.signature.trigger end
 local utils = require('blink.cmp.lib.utils')
 local fuzzy = require('blink.cmp.fuzzy')
 
@@ -49,7 +49,7 @@ local trigger = {
 
 function trigger.activate()
   trigger.buffer_events = require('blink.cmp.lib.buffer_events').new({
-    show_in_snippet = true,
+    show_in_snippet = function() return true end,
     has_context = function() return trigger.context ~= nil end,
   })
   trigger.buffer_events:listen({
@@ -59,12 +59,12 @@ function trigger.activate()
       -- ignore if disabled
       if not require('blink.cmp').is_enabled() then
         return trigger.hide()
-      elseif not config.enabled and trigger.context == nil then
+      elseif not config().enabled and trigger.context == nil then
         return
-      elseif config.show_on_keyword and fuzzy.is_keyword_character(char_under_cursor) then
+      elseif config().show_on_keyword and fuzzy.is_keyword_character(char_under_cursor) then
         return trigger.show({ trigger_character = char_under_cursor })
       -- character forces a trigger according to the sources, refresh the existing context if it exists
-      elseif config.show_on_trigger_character and trigger.is_trigger_character(char_under_cursor) then
+      elseif config().show_on_trigger_character and trigger.is_trigger_character(char_under_cursor) then
         return trigger.show({ trigger_character = char_under_cursor })
       -- character forces a re-trigger according to the sources, show if we have a context
       elseif trigger.is_trigger_character(char_under_cursor, true) and trigger.context ~= nil then
@@ -75,13 +75,13 @@ function trigger.activate()
       local char_under_cursor = utils.get_char_at_cursor()
       local is_on_trigger = trigger.is_trigger_character(char_under_cursor)
 
-      if not config.enabled and trigger.context == nil then
+      if not config().enabled and trigger.context == nil then
         return
-      elseif config.show_on_insert_on_trigger_character and is_on_trigger and event == 'InsertEnter' then
+      elseif config().show_on_insert_on_trigger_character and is_on_trigger and event == 'InsertEnter' then
         trigger.show({ trigger_character = char_under_cursor })
       elseif event == 'CursorMoved' and trigger.context ~= nil then
         trigger.show()
-      elseif event == 'InsertEnter' and config.show_on_insert then
+      elseif event == 'InsertEnter' and config().show_on_insert then
         trigger.show()
       end
     end,
@@ -89,17 +89,17 @@ function trigger.activate()
     on_complete_changed = function() require('blink.cmp.signature.window').update_position() end,
   })
 
-  if config.show_on_accept then
-    require('blink.cmp.completion.list').accept_emitter:on(function(ev)
-      local cursor_col = ev.context.get_pos().col
-      local char_under_cursor = nvim.get_current_line():sub(cursor_col, cursor_col)
+  require('blink.cmp.completion.list').accept_emitter:on(function(ev)
+    if not config().show_on_accept then return end
 
-      local is_on_trigger = trigger.is_trigger_character(char_under_cursor)
-      local opts = is_on_trigger and { trigger_character = char_under_cursor } or nil
+    local cursor_col = ev.context.get_pos().col
+    local char_under_cursor = nvim.get_current_line():sub(cursor_col, cursor_col)
 
-      trigger.show(opts)
-    end)
-  end
+    local is_on_trigger = trigger.is_trigger_character(char_under_cursor)
+    local opts = is_on_trigger and { trigger_character = char_under_cursor } or nil
+
+    trigger.show(opts)
+  end)
 end
 
 function trigger.is_trigger_character(char, is_retrigger)
@@ -109,8 +109,8 @@ function trigger.is_trigger_character(char, is_retrigger)
   local trigger_characters = is_retrigger and res.retrigger_characters or res.trigger_characters
   local is_trigger = vim.tbl_contains(trigger_characters, char)
 
-  local blocked_trigger_characters = is_retrigger and config.blocked_retrigger_characters
-    or config.blocked_trigger_characters
+  local blocked_trigger_characters = is_retrigger and config().blocked_retrigger_characters
+    or config().blocked_trigger_characters
   local is_blocked = vim.tbl_contains(blocked_trigger_characters, char)
 
   return is_trigger and not is_blocked
@@ -118,7 +118,7 @@ end
 
 function trigger.show_if_on_trigger_character()
   if require('blink.cmp.completion.trigger.context').get_mode() ~= 'default' then return end
-  if not config.enabled or not trigger.context then return end
+  if not config().enabled or not trigger.context then return end
 
   local cursor_col = trigger.context.pos.col
   local char_under_cursor = nvim.get_current_line():sub(cursor_col, cursor_col)
@@ -128,7 +128,7 @@ end
 function trigger.show(opts)
   opts = opts or {}
 
-  if not opts.force and (not config.enabled or not root_config.signature.enabled) and trigger.context == nil then
+  if not opts.force and (not config().enabled or not root_config.signature.enabled) and trigger.context == nil then
     return
   end
 

--- a/lua/blink/cmp/signature/window.lua
+++ b/lua/blink/cmp/signature/window.lua
@@ -9,20 +9,20 @@
 --- @field update_position fun()
 
 local nvim = require('blink.lib.nvim')
-local config = require('blink.cmp.config').signature.window
+local function config() return require('blink.cmp.config').signature.window end
 local sources = require('blink.cmp.sources.lib')
 local menu = require('blink.cmp.completion.windows.menu')
 
 local signature = {
   win = require('blink.cmp.lib.window').new('signature', {
-    min_width = config.min_width,
-    max_width = config.max_width,
-    max_height = config.max_height,
+    min_width = config().min_width,
+    max_width = config().max_width,
+    max_height = config().max_height,
     default_border = 'padded',
-    border = config.border,
-    winblend = config.winblend,
-    winhighlight = config.winhighlight,
-    scrollbar = config.scrollbar,
+    border = config().border,
+    winblend = config().winblend,
+    winhighlight = config().winhighlight,
+    scrollbar = config().scrollbar,
     wrap = true,
     filetype = 'blink-cmp-signature',
   }),
@@ -59,9 +59,9 @@ function signature.open_with_signature_help(context, signature_help)
     require('blink.cmp.lib.window.docs').render_detail_and_documentation({
       bufnr = signature.win:get_buf(),
       detail = labels,
-      documentation = config.show_documentation and active_signature.documentation or nil,
-      max_width = config.max_width,
-      use_treesitter_highlighting = config.treesitter_highlighting,
+      documentation = config().show_documentation and active_signature.documentation or nil,
+      max_width = config().max_width,
+      use_treesitter_highlighting = config().treesitter_highlighting,
     })
   end
   signature.shown_signature = active_signature
@@ -131,7 +131,7 @@ function signature.update_position()
 
   local menu_winnr = menu.win:get_win()
   local menu_win_config = menu_winnr and nvim.win_get_config(menu_winnr)
-  local direction_priority = config.direction_priority
+  local direction_priority = config().direction_priority
 
   -- if the menu window is open, we want to place the signature window on the opposite side
   if menu.win:is_open() then
@@ -149,7 +149,7 @@ function signature.update_position()
     direction_priority = popupmenu_is_up and { 's' } or { 'n' }
   end
 
-  local pos = win:get_vertical_direction_and_height(direction_priority, config.max_height)
+  local pos = win:get_vertical_direction_and_height(direction_priority, config().max_height)
 
   -- couldn't find anywhere to place the window
   if not pos then


### PR DESCRIPTION
The `blink.lib.config` has been simplified down to a single metatable with accessors, `.get()` and `.set()` functions. It also drops support for `vim.g` and `vim.b` based configuration. See https://github.com/saghen/blink.lib/pull/29 

This PR also make some modules support dynamic configuration such as auto_show and drawing.

Need to finish the changes to blink.pairs before merging