### PR TITLE
fix: override lsp `dynamicRegistration` to be false

### DIFF
--- a/lua/blink/cmp/sources/lib/init.lua
+++ b/lua/blink/cmp/sources/lib/init.lua
@@ -292,6 +292,7 @@ function sources.get_lsp_capabilities(override, include_nvim_defaults)
   return vim.tbl_deep_extend('force', include_nvim_defaults and vim.lsp.protocol.make_client_capabilities() or {}, {
     textDocument = {
       completion = {
+        dynamicRegistration = false,
         completionItem = {
           snippetSupport = true,
           commitCharactersSupport = false, -- TODO:


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/41748 changes the neovim default for this capability. It breaks completions for some servers, like lua_ls