### PR TITLE
feat(ghost-text): support native nvim ui2 for cmdline

### DIFF
--- a/lua/blink/cmp/completion/windows/ghost_text/utils.lua
+++ b/lua/blink/cmp/completion/windows/ghost_text/utils.lua
@@ -4,42 +4,57 @@ local nvim = require('blink.lib.nvim')
 
 local utils = {}
 
-function utils.is_cmdline() return nvim.get_mode().mode == 'c' end
+local function is_cmdline() return nvim.get_mode().mode == 'c' end
 
-function utils.is_noice()
-  return utils.is_cmdline()
-    and package.loaded['noice']
-    and vim.g.ui_cmdline_pos ~= nil
-    and require('noice.ui.cmdline').position ~= nil
-    and require('noice.ui.cmdline').position.buf ~= nil
+--- Whether Neovim's ui2 cmdline is enabled.
+--- @return boolean
+local function has_ui2() return require('vim._core.ui2').cfg.enable or false end
+
+--- Whether Noice's cmdline is active.
+--- @return boolean
+local function has_noice()
+  return package.loaded['noice'] ~= nil and vim.g.ui_cmdline_pos ~= nil and require('noice.ui.cmdline').position ~= nil
 end
 
 function utils.redraw_if_needed()
-  if utils.is_cmdline() then
-    local bufnr = utils.get_buf() or 0
-    if nvim.buf_is_valid(bufnr) then nvim._redraw({ buf = bufnr, flush = true }) end
-  end
+  if not is_cmdline() then return end
+
+  local bufnr = utils.get_buf() or 0
+  if nvim.buf_is_valid(bufnr) then nvim._redraw({ buf = bufnr, flush = true }) end
 end
 
 --- Gets the buffer to use for ghost text
 --- @return integer?
 function utils.get_buf()
-  if utils.is_cmdline() then
-    if not utils.is_noice() then return end
-    return require('noice.ui.cmdline').position.buf
+  if not is_cmdline() then return nvim.get_current_buf() end
+
+  if has_noice() then
+    local buf = require('noice.ui.cmdline').position.buf --[[@as integer]]
+    if buf and nvim.buf_is_valid(buf) then return buf end
   end
-  return nvim.get_current_buf()
+
+  if has_ui2() then
+    local buf = require('vim._core.ui2').bufs.cmd
+    if buf and nvim.buf_is_valid(buf) then return buf end
+  end
 end
 
---- Gets the offset from the cursor, primarily used for noice cmdline
+--- Gets the offset from the cursor, primarily used for cmdline UIs
 --- @return integer
 function utils.get_offset()
-  if utils.is_cmdline() then
-    if not utils.is_noice() then return 0 end
-    ---@type integer
-    local cursor_pos = require('noice.ui.cmdline').position.cursor
+  if not is_cmdline() then return 0 end
+
+  if has_noice() then
+    local cursor_pos = require('noice.ui.cmdline').position.cursor --[[@as integer]]
     return cursor_pos - (vim.fn.getcmdpos() - 1)
   end
+
+  if has_ui2() then
+    local win = require('vim._core.ui2').wins.cmd
+    local cursor = require('blink.cmp.lib.utils').get_vim_pos_cursor(win)
+    return cursor.col - (vim.fn.getcmdpos() - 1)
+  end
+
   return 0
 end
 


### PR DESCRIPTION
Support ghost text when using nvim's ui2 cmdline.

Noice remains the preferred cmdline integration when both are enabled, avoiding this issue: https://github.com/folke/noice.nvim/issues/1201.

`vim._core.ui2` is still an internal API, but it's the direction the core team is moving toward. Since we're already supporting nvim-0.12 and nightly and the implementation is small, I think that's worth the cost.

Credits to @celeste3z for the original idea discussed in https://github.com/saghen/blink.cmp/discussions/2630.
